### PR TITLE
Add Node.js version requirements and build preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,16 @@ for details.
 ### Prerequisites
 
 - `curl` and `npm` need to be present on your system.
+- Node.js >= 22.9.0 and npm >= 11.6.0 (upgrade with `npm install -g npm@latest`)
 - The browser requires a graphical environment.
-
 
 ### Steps
 
 1. Clone this repository to your local machine.
 2. Enter the repository's directory.
 3. `npm install -g .`
+
+**nvm users**: Global packages are per node version. If you switch versions, reinstall with `npm install -g .`
 
 ## Integrations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1215,7 +1215,6 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1265,7 +1264,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -1596,7 +1594,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1897,7 +1894,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2530,7 +2526,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2874,7 +2869,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2930,7 +2924,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "latchkey": "./dist/src/cli.js"
   },
   "scripts": {
+    "prepare": "npm run build",
     "postinstall": "npx playwright install chromium",
     "build": "tsc",
     "dev": "tsc --watch",


### PR DESCRIPTION
## Summary
- Document minimum Node.js (22.9.0) and npm (11.6.0) versions as a reference for first time user.
- Add note for nvm users about global package reinstallation when switching Node versions
- Add `prepare` script to automatically run build before npm install

## Test plan
In my local setup, I found the prepare script is required to make `npm install -g .` succeed. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)