### PR TITLE
Fix Notion integration URL and workspace selector

### DIFF
--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -14,7 +14,7 @@ import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core
 
 const DEFAULT_TIMEOUT_MS = 8000;
 
-const NOTION_INTEGRATIONS_URL = 'https://www.notion.so/profile/integrations/form/new-integration';
+const NOTION_INTEGRATIONS_URL = 'https://www.notion.so/profile/integrations/internal/form/new-integration';
 
 class NotionServiceSession extends BrowserFollowupServiceSession {
   private isLoggedIn = false;
@@ -47,7 +47,7 @@ class NotionServiceSession extends BrowserFollowupServiceSession {
     await page.getByRole('textbox').click();
     await page.getByRole('textbox').fill(generateLatchkeyAppName());
     // Workspace - initially empty
-    await page.getByRole('button').filter({ hasText: /^$/ }).click();
+    await page.locator('form').getByRole('button').filter({ hasText: /^$/ }).click();
     // Just pick the first workspace
     await page.getByRole('menuitem').click();
     // Create integration

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -14,7 +14,8 @@ import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core
 
 const DEFAULT_TIMEOUT_MS = 8000;
 
-const NOTION_INTEGRATIONS_URL = 'https://www.notion.so/profile/integrations/internal/form/new-integration';
+const NOTION_INTEGRATIONS_URL =
+  'https://www.notion.so/profile/integrations/internal/form/new-integration';
 
 class NotionServiceSession extends BrowserFollowupServiceSession {
   private isLoggedIn = false;


### PR DESCRIPTION
## 1. Integration URL change

Notion changed their integration creation page URL from:

```
https://www.notion.so/profile/integrations/form/new-integration
```

to:

```
https://www.notion.so/profile/integrations/internal/form/new-integration
```

The old URL was broken (no longer routed to the integration creation form), causing the entire login flow to fail.

**File:** `src/services/notion.ts`, line 17 (`NOTION_INTEGRATIONS_URL`)

## 2. Workspace selector ambiguity

After the URL fix, the workspace dropdown selector broke:

```typescript
await page.getByRole('button').filter({ hasText: /^$/ })
```

This matched multiple empty-text buttons on the new page (sidebar buttons, account button, etc.). On the old page it resolved to one element; on the new page it resolved to 2+ elements, triggering Playwright's strict mode violation.

**Fix:** Scoped the selector to the form element:

```typescript
await page.locator('form').getByRole('button').filter({ hasText: /^$/ })
```

This narrows the match to only the workspace dropdown inside the integration creation form, avoiding collisions with unrelated buttons on the page.

**File:** `src/services/notion.ts`, line 50