### PR TITLE
Don't crash the prepare flow when the browser closes during Google login detection

### DIFF
--- a/src/services/google/base.ts
+++ b/src/services/google/base.ts
@@ -270,11 +270,23 @@ function checkGoogleLoginResponse(
   const request = response.request();
   if (request.url().startsWith('https://console.cloud.google.com/')) {
     if (response.status() === 200) {
-      void response.text().then((text) => {
-        if (!text.includes('accounts.google.com/signin')) {
-          loginDetector.isLoggedIn = true;
-        }
-      });
+      void response
+        .text()
+        .then((text) => {
+          if (!text.includes('accounts.google.com/signin')) {
+            loginDetector.isLoggedIn = true;
+          }
+        })
+        .catch((error: unknown) => {
+          // The response body can become unreadable if the page/context
+          // closes while it's still being read (e.g. the automation
+          // navigates onward, or the user closes the browser). Treat that
+          // specific race as inconclusive; let any other error propagate.
+          if (error instanceof Error && isBrowserClosedError(error)) {
+            return;
+          }
+          throw error;
+        });
     }
   }
 }


### PR DESCRIPTION
## Why the change was needed

`auth browser-prepare google-*` listens for `console.cloud.google.com` responses to detect when the user is past the Google sign-in page. The handler asynchronously reads each response body via `response.text()`, but does not attach a `.catch()`. When the page or context closes while a body read is still in flight — either because the automation navigates onward (which the flow does many times during project creation, API enabling, and OAuth-client creation) or because the user closes the browser window — Node sees an unhandled rejection and terminates the entire prepare process.

In practice this kills `prepare()` mid-flight, which means any GCP project and OAuth client it has already created in the user's Google account get orphaned (latchkey only persists the credentials *after* `prepare()` returns successfully).

## How this change fixes it

Attach a narrowly-scoped `.catch()` to the fire-and-forget `response.text()` chain that swallows *only* closed-page rejections — i.e. the ones already classified by the existing `isBrowserClosedError` helper (matches `target closed`, `browser/context/page has been closed`, `net::ERR_ABORTED`). Any other rejection is rethrown, so genuinely unexpected errors still surface. The login detector already treats a response it can't classify as inconclusive (same as not seeing it at all), so this is behaviour-preserving on the happy path. The only thing that changes is the failure mode for the closed-page race: instead of crashing the process, the polling loop in `waitForGoogleLogin` keeps running until login is detected or the existing timeout fires.

## Caveats

The crash was observed on WSL2 (Ubuntu 22.04, Node 24, Playwright Chromium 145). It has not been reproduced on macOS, so the timing of the race may differ there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)