### PR TITLE
Introduce Gateway extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ request automatically (analogous to `LATCHKEY_GATEWAY_PASSWORD`).
 #### Extensions
 
 You can extend the gateway with your own HTTP endpoints. For
-details, see the [./docs/extensions.md](extensions docs).
+details, see the [extensions docs](./docs/extensions.md).
 
 
 ### Other configuration

--- a/README.md
+++ b/README.md
@@ -360,6 +360,12 @@ to the JWT and the CLI will attach it to every outgoing gateway
 request automatically (analogous to `LATCHKEY_GATEWAY_PASSWORD`).
 
 
+#### Extensions
+
+You can extend the gateway with your own HTTP endpoints. For
+details, see the [./docs/extensions.md](extensions docs).
+
+
 ### Other configuration
 
 You can set these environment variables to override certain

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -2,9 +2,9 @@
 
 You can extend the gateway with your own HTTP endpoints.
 At startup, `latchkey gateway` scans `~/.latchkey/extensions/` (or the corresponding alternative if you override `LATCHKEY_DIRECTORY`) for
-files ending in `.js` or `.mjs` (in alphabetical order) and
-dynamically imports each one. Every module's default export
-must be a function with the signature
+files ending in `.mjs` (in alphabetical order) and dynamically
+imports each one. Every module's default export must be a
+function with the signature
 `(request, response) => boolean | Promise<boolean>`:
 
 - Return `true` (or a promise resolving to `true`) when the

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,111 @@
+# Gateway extensions
+
+You can extend the gateway with your own HTTP endpoints.
+At startup, `latchkey gateway` scans `~/.latchkey/extensions/` (or the corresponding alternative if you override `LATCHKEY_DIRECTORY`) for
+files ending in `.js` or `.mjs` (in alphabetical order) and
+dynamically imports each one. Every module's default export
+must be a function with the signature
+`(request, response) => boolean | Promise<boolean>`:
+
+- Return `true` (or a promise resolving to `true`) when the
+  extension has handled the request — i.e. it has written, or
+  will write, the full response. The gateway will not consult
+  any further extensions.
+- Return `false` to defer to the next extension. In that case
+  the handler must not touch the response.
+
+If no extension claims the request, the gateway responds with
+`404`.
+
+```js
+// ~/.latchkey/extensions/hello.mjs
+export default (request, response) => {
+  if (request.method === 'GET' && request.url === '/extensions/myorg/hello') {
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify({ greeting: 'hello' }));
+    return true;
+  }
+  return false;
+};
+```
+
+- The handler receives Node's raw `http.IncomingMessage` and
+  `http.ServerResponse`. Extensions cannot read stored
+  credentials, the curl-injection pipeline, or the service
+  registry.
+
+Extension requests are gated by `permissions.json` like every
+other gateway request. The check happens before any extension
+is offered the request: Latchkey synthesises a request using the
+inbound method, path, query string, and headers, but with
+a fixed placeholder URL host (`https://latchkey-self.invalid:1`)
+representing "this gateway".
+
+The placeholder host uses RFC 2606's reserved `.invalid` TLD, so
+it can never collide with a real outbound rule. To write rules
+that target extension endpoints, [define Detent
+schemas](https://github.com/imbue-ai/detent#request-schemas)
+that match on `domain: "latchkey-self.invalid"`. Detent
+normalizes `domain` and `method` field values before matching,
+so the schema must use lowercase domains and uppercase methods.
+
+Here's an example `permissions.json` that allows only
+`GET /extensions/myorg/hello` on the gateway and rejects every
+other extension call:
+
+```json
+{
+  "schemas": {
+    "latchkey-self": {
+      "properties": {
+        "domain": { "const": "latchkey-self.invalid" }
+      },
+      "required": ["domain"]
+    },
+    "myorg-hello": {
+      "properties": {
+        "method": { "const": "GET" },
+        "path": { "const": "/extensions/myorg/hello" }
+      },
+      "required": ["method", "path"]
+    }
+  },
+  "rules": [
+    { "latchkey-self": ["myorg-hello"] }
+  ]
+}
+```
+
+How this works (see [Detent's rule resolution docs](https://github.com/imbue-ai/detent#rule-resolution-default-outcomes)
+for the full picture):
+
+- The `latchkey-self` schema is the scope - it picks out
+  any inbound request to the gateway itself (i.e. anything that
+  is run through the extension chain).
+- The `myorg-hello` schema is the permission - it describes
+  one specific allowed call.
+- The single rule says: "when the request is addressed to the
+  gateway itself, the only allowed permission is `myorg-hello`".
+  Anything else - a different path, a `POST` to the same path,
+  etc. - fails the rule and the gateway returns `403`.
+
+In a real config you would normally combine this with rules for
+the outbound services your agents call, e.g.:
+
+```json
+{
+  "schemas": {
+    "latchkey-self": { "properties": { "domain": { "const": "latchkey-self.invalid" } }, "required": ["domain"] },
+    "myorg-hello":   { "properties": { "method": { "const": "GET" }, "path": { "const": "/extensions/myorg/hello" } }, "required": ["method", "path"] }
+  },
+  "rules": [
+    { "latchkey-self":   ["myorg-hello"] },
+    { "github-rest-api": ["github-read-all"] },
+    { "slack-api":       ["slack-read-all"] }
+  ]
+}
+```
+
+Rules are evaluated top-to-bottom; the first whose scope matches
+the request decides the outcome, so the extension rule and the
+third-party-service rules don't interfere with each other.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "latchkey",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "latchkey",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "@imbue-ai/detent": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "latchkey",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "A CLI tool that injects API credentials into curl requests to third-party services",
   "author": "Imbue <hynek@imbue.com>",
   "repository": {

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -98,7 +98,7 @@ export interface CliDependencies {
   readonly runCurl: (args: readonly string[]) => CurlResult;
   readonly runCurlAsync: typeof curlRunAsync;
   readonly checkPermission: (
-    curlArguments: readonly string[],
+    request: Request,
     configPath: string,
     doNotUseBuiltinSchemas: boolean
   ) => Promise<boolean>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,7 @@ const CREDENTIAL_STORE_FILENAME = 'credentials.json.enc';
 const BROWSER_STATE_FILENAME = 'browser_state.json.enc';
 const CONFIG_FILENAME = 'config.json';
 const PERMISSIONS_CONFIG_FILENAME = 'permissions.json';
+const EXTENSIONS_DIRECTORY_NAME = 'extensions';
 
 function resolvePathWithTildeExpansion(path: string): string {
   if (path.startsWith('~')) {
@@ -332,6 +333,14 @@ export class Config {
 
   get permissionsConfigPath(): string {
     return this.permissionsConfigOverride ?? join(this.directory, PERMISSIONS_CONFIG_FILENAME);
+  }
+
+  /**
+   * Directory the gateway scans for extension modules at startup.
+   * See `src/gateway/extensions.ts`.
+   */
+  get extensionsDirectoryPath(): string {
+    return join(this.directory, EXTENSIONS_DIRECTORY_NAME);
   }
 
   /**

--- a/src/curlInjection.ts
+++ b/src/curlInjection.ts
@@ -14,6 +14,7 @@ import type { ApiCredentials } from './apiCredentials/base.js';
 import type { ApiCredentialStore } from './apiCredentials/store.js';
 import { maybeRefreshCredentials } from './apiCredentials/utils.js';
 import { CurlParseError, extractUrlFromCurlArguments } from './curl.js';
+import { parseCurlArgs } from '@imbue-ai/detent';
 import { ErrorMessages } from './errorMessages.js';
 import type { ServiceRegistry } from './serviceRegistry.js';
 
@@ -68,7 +69,7 @@ export class CredentialsExpiredError extends Error {
 export interface CurlInjectionDependencies {
   readonly registry: ServiceRegistry;
   readonly checkPermission: (
-    curlArguments: readonly string[],
+    request: Request,
     configPath: string,
     doNotUseBuiltinSchemas: boolean
   ) => Promise<boolean>;
@@ -88,8 +89,21 @@ export async function prepareCurlInvocation(
   apiCredentialStore: ApiCredentialStore,
   dependencies: CurlInjectionDependencies
 ): Promise<readonly string[]> {
+  // Parse the curl arguments once for the permission check. A parse failure
+  // here means the user's curl invocation is malformed, which is treated as
+  // a URL-extraction failure (the same category as the second parse below),
+  // not a permission-check failure.
+  let parsedRequest: Request;
+  try {
+    parsedRequest = parseCurlArgs(curlArguments);
+  } catch (error) {
+    if (error instanceof CurlParseError) {
+      throw new UrlExtractionFailedError(error.message);
+    }
+    throw error;
+  }
   const allowed = await dependencies.checkPermission(
-    curlArguments,
+    parsedRequest,
     dependencies.permissionsConfigPath,
     dependencies.permissionsDoNotUseBuiltinSchemas
   );

--- a/src/gateway/extensions.ts
+++ b/src/gateway/extensions.ts
@@ -1,0 +1,218 @@
+/**
+ * Extensions: user-supplied HTTP handlers mounted on the gateway.
+ *
+ * The gateway scans `extensionsDirectory` for `*.js` / `*.mjs` files at
+ * startup and dynamically imports each one. Each module's default export
+ * must be a function `(request, response) => boolean | Promise<boolean>`:
+ *
+ *   - return `true` when the extension has handled the request (i.e. it
+ *     has written / will write the response). The gateway will not consult
+ *     any further extensions.
+ *   - return `false` to defer to the next extension. The handler must not
+ *     touch the response in this case.
+ *
+ * Extensions only see Node's raw HTTP request / response. They do NOT have
+ * access to credential storage, the curl-injection pipeline, or the service
+ * registry. Each extension request is run through the same
+ * `permissions.json` machinery as `/gateway/...` proxy requests, by
+ * synthesising a request whose URL uses fixed placeholder values
+ * (representing "this gateway") while preserving the inbound method, path,
+ * and headers.
+ */
+
+import * as http from 'node:http';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { CliDependencies } from '../cliCommands.js';
+import { PermissionCheckError } from '../permissions.js';
+import { RequestNotPermittedError } from '../curlInjection.js';
+import { GATEWAY_INTERNAL_HEADERS, HOP_BY_HOP_HEADERS } from './gatewayEndpoint.js';
+
+/**
+ * Placeholder URL parts that stand in for "this gateway" when extension
+ * requests are run through the permission check. They use RFC 2606's
+ * reserved `.invalid` TLD so the synthetic URL is guaranteed never to
+ * resolve to a real host. Detent schemas matching extension routes should
+ * key on these exact values.
+ */
+export const EXTENSION_PLACEHOLDER_SCHEME = 'https';
+export const EXTENSION_PLACEHOLDER_HOST = 'latchkey-self.invalid';
+export const EXTENSION_PLACEHOLDER_PORT = 1;
+
+const SUPPORTED_EXTENSION_FILE_SUFFIXES: readonly string[] = ['.js', '.mjs'];
+
+export type ExtensionHandler = (
+  request: http.IncomingMessage,
+  response: http.ServerResponse
+) => boolean | Promise<boolean>;
+
+export interface LoadedExtension {
+  readonly handler: ExtensionHandler;
+  /** Absolute path of the file the handler was loaded from. */
+  readonly sourceFile: string;
+}
+
+interface ExtensionModuleShape {
+  readonly default: ExtensionHandler;
+}
+
+export class ExtensionLoadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ExtensionLoadError';
+  }
+}
+
+function isExtensionModuleShape(value: unknown): value is ExtensionModuleShape {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'default' in value &&
+    typeof (value as { default: unknown }).default === 'function'
+  );
+}
+
+/**
+ * Load every extension module in `directory` and return the resulting
+ * ordered list. Extensions are tried in alphabetical order of filename, so
+ * the loader returns them in that order. Returns an empty list if the
+ * directory does not exist. Throws `ExtensionLoadError` on the first file
+ * that fails to import or has the wrong shape.
+ */
+export async function loadExtensions(directory: string): Promise<readonly LoadedExtension[]> {
+  if (!existsSync(directory)) {
+    return [];
+  }
+  if (!statSync(directory).isDirectory()) {
+    return [];
+  }
+
+  const fileNames = readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .filter((entry) =>
+      SUPPORTED_EXTENSION_FILE_SUFFIXES.some((suffix) => entry.name.endsWith(suffix))
+    )
+    .map((entry) => entry.name)
+    .sort();
+
+  const extensions: LoadedExtension[] = [];
+  for (const fileName of fileNames) {
+    const filePath = join(directory, fileName);
+    let importedModule: unknown;
+    try {
+      importedModule = (await import(pathToFileURL(filePath).href)) as unknown;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ExtensionLoadError(`Failed to load extension '${filePath}': ${message}`);
+    }
+    if (!isExtensionModuleShape(importedModule)) {
+      throw new ExtensionLoadError(
+        `Extension '${filePath}' must export a default function ` +
+          `(request, response) => boolean | Promise<boolean>.`
+      );
+    }
+    extensions.push({ handler: importedModule.default, sourceFile: filePath });
+  }
+  return extensions;
+}
+
+/**
+ * Build the synthetic `Request` fed to the permission check. The URL uses
+ * fixed placeholder values for protocol/host/port (representing "this
+ * gateway") with the inbound path and query string preserved verbatim. The
+ * inbound method and headers are forwarded, minus hop-by-hop and
+ * gateway-internal headers (so the password and permissions-override
+ * headers cannot influence schema matching). The body is intentionally
+ * omitted: the permission check operates on URL/method/headers only.
+ */
+function buildExtensionPermissionCheckRequest(request: http.IncomingMessage): Request {
+  const url =
+    `${EXTENSION_PLACEHOLDER_SCHEME}://${EXTENSION_PLACEHOLDER_HOST}` +
+    `:${String(EXTENSION_PLACEHOLDER_PORT)}${request.url ?? ''}`;
+  const headers = new Headers();
+  const rawHeaders = request.rawHeaders;
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    const name = rawHeaders[index]!;
+    const value = rawHeaders[index + 1]!;
+    const lowerName = name.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lowerName) || GATEWAY_INTERNAL_HEADERS.has(lowerName)) {
+      continue;
+    }
+    headers.append(name, value);
+  }
+  return new Request(url, {
+    method: (request.method ?? 'GET').toUpperCase(),
+    headers,
+  });
+}
+
+function sendErrorResponse(
+  response: http.ServerResponse,
+  statusCode: number,
+  message: string
+): void {
+  if (response.headersSent) return;
+  response.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  response.end(JSON.stringify({ error: message }));
+}
+
+/**
+ * Run the permission check for an inbound extension request and offer it to
+ * each loaded extension in order. Returns true when an extension claimed
+ * the request (i.e. responded or threw). When false, no extension touched
+ * the response and the caller is responsible for sending a fallback
+ * (typically `404`).
+ */
+export async function dispatchExtensionRequest(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  extensions: readonly LoadedExtension[],
+  deps: CliDependencies,
+  permissionsConfigPath: string
+): Promise<boolean> {
+  const method = (request.method ?? 'GET').toUpperCase();
+  const pathAndQuery = request.url ?? '';
+
+  let allowed: boolean;
+  try {
+    allowed = await deps.checkPermission(
+      buildExtensionPermissionCheckRequest(request),
+      permissionsConfigPath,
+      deps.config.permissionsDoNotUseBuiltinSchemas
+    );
+  } catch (error) {
+    if (error instanceof PermissionCheckError) {
+      deps.log(`${method} ${pathAndQuery} -> 403 (extension)`);
+      sendErrorResponse(response, 403, `Error: ${error.message}`);
+      return true;
+    }
+    throw error;
+  }
+  if (!allowed) {
+    const notPermitted = new RequestNotPermittedError();
+    deps.log(`${method} ${pathAndQuery} -> 403 (extension)`);
+    sendErrorResponse(response, 403, notPermitted.message);
+    return true;
+  }
+
+  for (const extension of extensions) {
+    let handled: boolean;
+    try {
+      handled = await extension.handler(request, response);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      deps.errorLog(
+        `Unexpected error in extension '${extension.sourceFile}' ` +
+          `(${method} ${pathAndQuery}): ${message}`
+      );
+      sendErrorResponse(response, 500, 'Internal error');
+      return true;
+    }
+    if (handled) {
+      deps.log(`${method} ${pathAndQuery} -> ${String(response.statusCode)} (extension)`);
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/gateway/extensions.ts
+++ b/src/gateway/extensions.ts
@@ -1,9 +1,9 @@
 /**
  * Extensions: user-supplied HTTP handlers mounted on the gateway.
  *
- * The gateway scans `extensionsDirectory` for `*.js` / `*.mjs` files at
- * startup and dynamically imports each one. Each module's default export
- * must be a function `(request, response) => boolean | Promise<boolean>`:
+ * The gateway scans `extensionsDirectory` for `*.mjs` files at startup
+ * and dynamically imports each one. Each module's default export must be
+ * a function `(request, response) => boolean | Promise<boolean>`:
  *
  *   - return `true` when the extension has handled the request (i.e. it
  *     has written / will write the response). The gateway will not consult
@@ -40,7 +40,7 @@ export const EXTENSION_PLACEHOLDER_SCHEME = 'https';
 export const EXTENSION_PLACEHOLDER_HOST = 'latchkey-self.invalid';
 export const EXTENSION_PLACEHOLDER_PORT = 1;
 
-const SUPPORTED_EXTENSION_FILE_SUFFIXES: readonly string[] = ['.js', '.mjs'];
+const EXTENSION_FILE_SUFFIX = '.mjs';
 
 export type ExtensionHandler = (
   request: http.IncomingMessage,
@@ -90,9 +90,7 @@ export async function loadExtensions(directory: string): Promise<readonly Loaded
 
   const fileNames = readdirSync(directory, { withFileTypes: true })
     .filter((entry) => entry.isFile())
-    .filter((entry) =>
-      SUPPORTED_EXTENSION_FILE_SUFFIXES.some((suffix) => entry.name.endsWith(suffix))
-    )
+    .filter((entry) => entry.name.endsWith(EXTENSION_FILE_SUFFIX))
     .map((entry) => entry.name)
     .sort();
 

--- a/src/gateway/gatewayEndpoint.ts
+++ b/src/gateway/gatewayEndpoint.ts
@@ -28,13 +28,13 @@ import {
   InvalidPermissionsOverrideError,
   PERMISSIONS_OVERRIDE_HEADER,
   PermissionsOverrideFileMissingError,
-  resolvePermissionsOverride,
+  resolveRequestPermissionsConfig,
 } from './permissionsOverride.js';
 
 /**
  * Headers that should not be forwarded between client and upstream (hop-by-hop).
  */
-const HOP_BY_HOP_HEADERS = new Set([
+export const HOP_BY_HOP_HEADERS: ReadonlySet<string> = new Set([
   'connection',
   'keep-alive',
   'proxy-authenticate',
@@ -50,7 +50,10 @@ const HOP_BY_HOP_HEADERS = new Set([
  * Headers that the gateway consumes itself and must not forward to upstream
  * (in addition to hop-by-hop headers).
  */
-const GATEWAY_INTERNAL_HEADERS = new Set([GATEWAY_PASSWORD_HEADER, PERMISSIONS_OVERRIDE_HEADER]);
+export const GATEWAY_INTERNAL_HEADERS: ReadonlySet<string> = new Set([
+  GATEWAY_PASSWORD_HEADER,
+  PERMISSIONS_OVERRIDE_HEADER,
+]);
 
 export const GATEWAY_PATH_PREFIX = '/gateway/';
 
@@ -119,7 +122,8 @@ export function extractTargetUrl(rawUrl: string): string | null {
 
 /**
  * Build curl arguments from an HTTP request's components.
- * Strips hop-by-hop headers and constructs a curl-compatible argument array.
+ *
+ * Hop-by-hop headers and gateway-internal headers are stripped.
  */
 export function buildCurlArguments(
   method: string,
@@ -134,7 +138,8 @@ export function buildCurlArguments(
   }
 
   for (const [name, value] of headers) {
-    if (HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
+    const lowerName = name.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lowerName) || GATEWAY_INTERNAL_HEADERS.has(lowerName)) {
       continue;
     }
     args.push('-H', `${name}: ${value}`);
@@ -147,6 +152,18 @@ export function buildCurlArguments(
   args.push(targetUrl);
 
   return args;
+}
+
+/**
+ * Build a `Map<string, string>` view of an `IncomingMessage`'s `rawHeaders`,
+ * preserving original case.
+ */
+function rawHeadersToMap(rawHeaders: readonly string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    map.set(rawHeaders[index]!, rawHeaders[index + 1]!);
+  }
+  return map;
 }
 
 /**
@@ -269,29 +286,26 @@ export async function handleGatewayRequest(
   // Resolve the permissions config for this request. When the client
   // supplied a permissions-override JWT, validate it and use the referenced
   // file; otherwise fall back to the gateway's default config path.
-  const pointerHeader = request.headers[PERMISSIONS_OVERRIDE_HEADER];
-  const pointerToken = typeof pointerHeader === 'string' ? pointerHeader : undefined;
-  let permissionsConfigPath = deps.config.permissionsConfigPath;
-  if (pointerToken !== undefined) {
-    try {
-      permissionsConfigPath = resolvePermissionsOverride(
-        pointerToken,
-        options.permissionsOverrideSigningKey
-      );
-    } catch (error) {
-      const method = request.method ?? 'UNKNOWN';
-      if (error instanceof InvalidPermissionsOverrideError) {
-        deps.log(`${method} ${targetUrl} -> 401 (permissions override)`);
-        sendErrorResponse(response, 401, error.message);
-        return;
-      }
-      if (error instanceof PermissionsOverrideFileMissingError) {
-        deps.log(`${method} ${targetUrl} -> 400 (permissions override)`);
-        sendErrorResponse(response, 400, error.message);
-        return;
-      }
-      throw error;
+  let permissionsConfigPath: string;
+  try {
+    permissionsConfigPath = resolveRequestPermissionsConfig(
+      request.headers,
+      deps.config.permissionsConfigPath,
+      options.permissionsOverrideSigningKey
+    );
+  } catch (error) {
+    const method = request.method ?? 'UNKNOWN';
+    if (error instanceof InvalidPermissionsOverrideError) {
+      deps.log(`${method} ${targetUrl} -> 401 (permissions override)`);
+      sendErrorResponse(response, 401, error.message);
+      return;
     }
+    if (error instanceof PermissionsOverrideFileMissingError) {
+      deps.log(`${method} ${targetUrl} -> 400 (permissions override)`);
+      sendErrorResponse(response, 400, error.message);
+      return;
+    }
+    throw error;
   }
 
   // Read body
@@ -308,23 +322,16 @@ export async function handleGatewayRequest(
     throw error;
   }
 
-  // Build curl arguments from the incoming request, dropping headers that
-  // must not be forwarded upstream: HTTP hop-by-hop headers and headers
-  // the gateway itself consumes (password, permissions override).
+  // Build curl arguments from the incoming request. `buildCurlArguments`
+  // strips hop-by-hop and gateway-internal headers itself, so we just hand
+  // it the raw header map.
   const method = request.method ?? 'GET';
-  const headerMap = new Map<string, string>();
-  const rawHeaders = request.rawHeaders;
-  for (let i = 0; i < rawHeaders.length; i += 2) {
-    const name = rawHeaders[i]!;
-    const value = rawHeaders[i + 1]!;
-    const lowerName = name.toLowerCase();
-    if (HOP_BY_HOP_HEADERS.has(lowerName) || GATEWAY_INTERNAL_HEADERS.has(lowerName)) {
-      continue;
-    }
-    headerMap.set(name, value);
-  }
-
-  const curlArguments = buildCurlArguments(method, headerMap, targetUrl, body !== null);
+  const curlArguments = buildCurlArguments(
+    method,
+    rawHeadersToMap(request.rawHeaders),
+    targetUrl,
+    body !== null
+  );
 
   let allArguments: readonly string[];
   try {

--- a/src/gateway/permissionsOverride.ts
+++ b/src/gateway/permissionsOverride.ts
@@ -14,6 +14,7 @@
 
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { existsSync, statSync } from 'node:fs';
+import type * as http from 'node:http';
 import { isAbsolute } from 'node:path';
 
 /**
@@ -200,4 +201,22 @@ export function resolvePermissionsOverride(token: string, signingKey: Buffer): s
     throw new PermissionsOverrideFileMissingError(permissionsConfig);
   }
   return permissionsConfig;
+}
+
+/**
+ * Apply the optional `X-Latchkey-Gateway-Permissions-Override` header to a
+ * request: when absent, return the default config path; when present,
+ * validate the JWT and return the referenced path. Throws
+ * `InvalidPermissionsOverrideError` (=> 401) or
+ * `PermissionsOverrideFileMissingError` (=> 400) on invalid input.
+ */
+export function resolveRequestPermissionsConfig(
+  headers: http.IncomingHttpHeaders,
+  defaultConfigPath: string,
+  signingKey: Buffer
+): string {
+  const headerValue = headers[PERMISSIONS_OVERRIDE_HEADER];
+  const token = typeof headerValue === 'string' ? headerValue : undefined;
+  if (token === undefined) return defaultConfigPath;
+  return resolvePermissionsOverride(token, signingKey);
 }

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -117,13 +117,7 @@ function runExtensions(
     return Promise.resolve(true);
   }
 
-  return dispatchExtensionRequest(
-    request,
-    response,
-    extensions,
-    deps,
-    permissionsConfigPath
-  );
+  return dispatchExtensionRequest(request, response, extensions, deps, permissionsConfigPath);
 }
 
 /**

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -18,6 +18,12 @@ import {
 } from './gatewayEndpoint.js';
 import { handleLatchkeyRequest } from './latchkeyEndpoint.js';
 import { GATEWAY_PASSWORD_HEADER, passwordsMatch } from './password.js';
+import { dispatchExtensionRequest, loadExtensions, type LoadedExtension } from './extensions.js';
+import {
+  InvalidPermissionsOverrideError,
+  PermissionsOverrideFileMissingError,
+  resolveRequestPermissionsConfig,
+} from './permissionsOverride.js';
 
 function sendErrorResponse(
   response: http.ServerResponse,
@@ -67,9 +73,63 @@ export interface GatewayServer {
 }
 
 /**
+ * Run an inbound request through the loaded extensions. Resolves to true when
+ * the request has been handled in some way and false if not.
+ */
+function runExtensions(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  extensions: readonly LoadedExtension[],
+  deps: CliDependencies,
+  options: GatewayOptions
+): Promise<boolean> {
+  if (extensions.length === 0) return Promise.resolve(false);
+
+  const rawUrl = request.url ?? '';
+  const method = (request.method ?? 'GET').toUpperCase();
+
+  let permissionsConfigPath: string;
+  try {
+    permissionsConfigPath = resolveRequestPermissionsConfig(
+      request.headers,
+      deps.config.permissionsConfigPath,
+      options.permissionsOverrideSigningKey
+    );
+  } catch (error) {
+    if (error instanceof InvalidPermissionsOverrideError) {
+      deps.log(`${method} ${rawUrl} -> 401 (extension)`);
+      sendErrorResponse(response, 401, error.message);
+      return Promise.resolve(true);
+    }
+    if (error instanceof PermissionsOverrideFileMissingError) {
+      deps.log(`${method} ${rawUrl} -> 400 (extension)`);
+      sendErrorResponse(response, 400, error.message);
+      return Promise.resolve(true);
+    }
+    // resolveRequestPermissionsConfig only throws the two known error
+    // types, so this branch is just defensive: an http.Server request
+    // listener is sync, and rethrowing here would crash the process.
+    deps.errorLog(
+      `Unexpected error resolving permissions override for ${method} ${rawUrl}: ` +
+        (error instanceof Error ? error.message : String(error))
+    );
+    sendErrorResponse(response, 500, 'Internal error');
+    return Promise.resolve(true);
+  }
+
+  return dispatchExtensionRequest(
+    request,
+    response,
+    extensions,
+    deps,
+    permissionsConfigPath
+  );
+}
+
+/**
  * Start the gateway HTTP server.
  */
-export function startGateway(
+export async function startGateway(
   deps: CliDependencies,
   apiCredentialStore: ApiCredentialStore,
   encryptedStorage: EncryptedStorage,
@@ -77,15 +137,18 @@ export function startGateway(
 ): Promise<GatewayServer> {
   const inFlightRequests = new Set<Promise<void>>();
 
+  const extensions = await loadExtensions(deps.config.extensionsDirectoryPath);
+
   const server = http.createServer((request, response) => {
     const rawUrl = request.url ?? '';
+    const method = request.method ?? 'UNKNOWN';
 
     if (!enforcePassword(request, response, options.password, deps)) {
       return;
     }
 
     // Health endpoint
-    if (rawUrl === '/' && request.method === 'GET') {
+    if (rawUrl === '/' && method === 'GET') {
       response.writeHead(200, { 'Content-Type': 'application/json' });
       response.end(JSON.stringify({ status: 'ok', version: deps.version }));
       return;
@@ -115,37 +178,55 @@ export function startGateway(
       return;
     }
 
-    // Extract target URL
-    const targetUrl = extractTargetUrl(rawUrl);
-    if (targetUrl === null) {
-      if (rawUrl.startsWith(GATEWAY_PATH_PREFIX)) {
-        const method = request.method ?? 'UNKNOWN';
+    // Gateway proxy endpoint
+    if (rawUrl.startsWith(GATEWAY_PATH_PREFIX)) {
+      const targetUrl = extractTargetUrl(rawUrl);
+      if (targetUrl === null) {
         deps.log(`${method} ${rawUrl.slice(GATEWAY_PATH_PREFIX.length)} -> 400`);
         sendErrorResponse(response, 400, ErrorMessages.couldNotExtractUrl);
-      } else {
-        response.writeHead(404);
-        response.end();
+        return;
       }
+
+      const requestPromise = handleGatewayRequest(
+        request,
+        response,
+        targetUrl,
+        deps,
+        apiCredentialStore,
+        options
+      ).catch((error: unknown) => {
+        deps.errorLog(
+          `Unexpected error handling ${method} ${targetUrl}: ${error instanceof Error ? error.message : String(error)}`
+        );
+        if (!response.headersSent) {
+          sendErrorResponse(response, 502, ErrorMessages.upstreamRequestFailed);
+        }
+      });
+
+      inFlightRequests.add(requestPromise);
+      void requestPromise.finally(() => {
+        inFlightRequests.delete(requestPromise);
+      });
       return;
     }
 
-    const requestPromise = handleGatewayRequest(
-      request,
-      response,
-      targetUrl,
-      deps,
-      apiCredentialStore,
-      options
-    ).catch((error: unknown) => {
-      const method = request.method ?? 'UNKNOWN';
-      deps.errorLog(
-        `Unexpected error handling ${method} ${targetUrl}: ${error instanceof Error ? error.message : String(error)}`
-      );
-      if (!response.headersSent) {
-        sendErrorResponse(response, 502, ErrorMessages.upstreamRequestFailed);
-      }
-    });
-
+    // Finally, try extensions (if any).
+    const requestPromise = runExtensions(request, response, extensions, deps, options)
+      .then((handled) => {
+        if (!handled && !response.headersSent) {
+          response.writeHead(404);
+          response.end();
+        }
+      })
+      .catch((error: unknown) => {
+        deps.errorLog(
+          `Unexpected error handling extension request ${method} ${rawUrl}: ` +
+            (error instanceof Error ? error.message : String(error))
+        );
+        if (!response.headersSent) {
+          sendErrorResponse(response, 500, 'Internal error');
+        }
+      });
     inFlightRequests.add(requestPromise);
     void requestPromise.finally(() => {
       inFlightRequests.delete(requestPromise);

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,19 +1,10 @@
 /**
  * Permission checking for outgoing HTTP requests based on the
  * Detent library.
- *
- * When a permissions config file exists, outgoing curl requests are checked
- * against the user's permission rules before being sent.
  */
 
 import { existsSync } from 'node:fs';
-import {
-  check,
-  parseCurlArgs,
-  CurlParseError,
-  ConfigError,
-  RequestSchemaError,
-} from '@imbue-ai/detent';
+import { check, ConfigError, RequestSchemaError } from '@imbue-ai/detent';
 
 export class PermissionCheckError extends Error {
   constructor(message: string) {
@@ -23,20 +14,20 @@ export class PermissionCheckError extends Error {
 }
 
 /**
- * Check whether a curl request is allowed by permission rules.
+ * Check whether a request is allowed by permission rules.
  *
  * When no permissions config file is present at the given path, the check is
  * skipped (returns true). When a config exists, the request is validated
  * against its rules.
  *
- * @param curlArguments - The raw curl arguments (before credential injection).
+ * @param request - The request to check.
  * @param configPath - Path to the permissions config file.
  * @param doNotUseBuiltinSchemas - When true, detent's built-in schemas are not used.
  * @returns true if the request is allowed (or no config exists), false if denied.
  * @throws PermissionCheckError if parsing or checking fails unexpectedly.
  */
 export async function checkPermission(
-  curlArguments: readonly string[],
+  request: Request,
   configPath: string,
   doNotUseBuiltinSchemas = false
 ): Promise<boolean> {
@@ -45,15 +36,9 @@ export async function checkPermission(
   }
 
   try {
-    const request = parseCurlArgs(curlArguments);
-    const useBuiltinSchemas = !doNotUseBuiltinSchemas;
-    return await check(request, configPath, useBuiltinSchemas);
+    return await check(request, configPath, !doNotUseBuiltinSchemas);
   } catch (error) {
-    if (
-      error instanceof CurlParseError ||
-      error instanceof ConfigError ||
-      error instanceof RequestSchemaError
-    ) {
+    if (error instanceof ConfigError || error instanceof RequestSchemaError) {
       throw new PermissionCheckError(`Permission check failed: ${error.message}`);
     }
     throw error;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // Auto-generated from package.json by scripts/generateVersion.js.
 // Do not edit by hand; run `node scripts/generateVersion.js` to refresh.
-export const VERSION = "2.8.0";
+export const VERSION = "2.9.0";

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -353,6 +353,9 @@ describe('CLI commands with dependency injection', () => {
       get permissionsConfigPath() {
         return overrides.permissionsConfigOverride ?? join(directory, 'permissions.json');
       },
+      get extensionsDirectoryPath() {
+        return join(directory, 'extensions');
+      },
       curlCommand: overrides.curlCommand ?? defaultConfig.curlCommand,
       encryptionKeyOverride: overrides.encryptionKeyOverride ?? TEST_ENCRYPTION_KEY,
       serviceName: overrides.serviceName ?? defaultConfig.serviceName,

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -106,6 +106,21 @@ describe('buildCurlArguments', () => {
     expect(args.join(' ')).not.toContain('Keep-Alive');
   });
 
+  it('should strip gateway-internal headers so they cannot leak upstream', () => {
+    const headers = new Map([
+      ['Content-Type', 'application/json'],
+      ['X-Latchkey-Gateway-Password', 'sekret'],
+      ['X-Latchkey-Gateway-Permissions-Override', 'jwt-payload'],
+    ]);
+    const args = buildCurlArguments('GET', headers, 'https://api.example.com/test', false);
+    expect(args).toContain('Content-Type: application/json');
+    const joined = args.join('\n').toLowerCase();
+    expect(joined).not.toContain('x-latchkey-gateway-password');
+    expect(joined).not.toContain('x-latchkey-gateway-permissions-override');
+    expect(joined).not.toContain('sekret');
+    expect(joined).not.toContain('jwt-payload');
+  });
+
   it('should add --data-binary @- when body is present', () => {
     const args = buildCurlArguments(
       'POST',

--- a/tests/gatewayExtensions.test.ts
+++ b/tests/gatewayExtensions.test.ts
@@ -1,0 +1,535 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { CliDependencies } from '../src/cliCommands.js';
+import { ApiCredentialStore } from '../src/apiCredentials/store.js';
+import { Config } from '../src/config.js';
+import { EncryptedStorage } from '../src/encryptedStorage.js';
+import { ServiceRegistry } from '../src/serviceRegistry.js';
+import { startGateway, type GatewayServer } from '../src/gateway/server.js';
+import {
+  derivePermissionsOverrideSigningKey,
+  createPermissionsOverrideJwt,
+  PERMISSIONS_OVERRIDE_HEADER,
+} from '../src/gateway/permissionsOverride.js';
+import type { GatewayOptions } from '../src/gateway/gatewayEndpoint.js';
+import {
+  EXTENSION_PLACEHOLDER_HOST,
+  ExtensionLoadError,
+  loadExtensions,
+} from '../src/gateway/extensions.js';
+import type { CurlResult, AsyncCurlResult } from '../src/curl.js';
+import { GATEWAY_PASSWORD_HEADER } from '../src/gateway/password.js';
+
+const TEST_ENCRYPTION_KEY = 'dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleXRlc3Q=';
+
+function writeExtension(directory: string, fileName: string, source: string): string {
+  const filePath = join(directory, fileName);
+  writeFileSync(filePath, source, 'utf-8');
+  return filePath;
+}
+
+// ─── Unit tests: loadExtensions ───────────────────────────────────────────────
+
+describe('loadExtensions', () => {
+  let tempDir: string;
+  let extensionsDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'latchkey-ext-test-'));
+    extensionsDir = join(tempDir, 'extensions');
+    mkdirSync(extensionsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns an empty list when the directory does not exist', async () => {
+    const extensions = await loadExtensions(join(tempDir, 'nonexistent'));
+    expect(extensions).toEqual([]);
+  });
+
+  it('returns an empty list when the path is a file, not a directory', async () => {
+    const filePath = join(tempDir, 'not-a-dir');
+    writeFileSync(filePath, 'noop', 'utf-8');
+    const extensions = await loadExtensions(filePath);
+    expect(extensions).toEqual([]);
+  });
+
+  it('skips files with unsupported suffixes', async () => {
+    writeExtension(extensionsDir, 'README.txt', 'not an extension');
+    writeExtension(extensionsDir, 'config.json', '{}');
+    const extensions = await loadExtensions(extensionsDir);
+    expect(extensions).toEqual([]);
+  });
+
+  it('loads a single .mjs extension', async () => {
+    writeExtension(
+      extensionsDir,
+      'hello.mjs',
+      `export default async (req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('hi');
+        return true;
+      };`
+    );
+    const extensions = await loadExtensions(extensionsDir);
+    expect(extensions).toHaveLength(1);
+    expect(extensions[0]!.sourceFile).toContain('hello.mjs');
+    expect(typeof extensions[0]!.handler).toBe('function');
+  });
+
+  it('loads multiple files in deterministic alphabetical order', async () => {
+    writeExtension(extensionsDir, 'b-second.mjs', `export default () => false;`);
+    writeExtension(extensionsDir, 'a-first.mjs', `export default () => false;`);
+    const extensions = await loadExtensions(extensionsDir);
+    expect(extensions.map((extension) => extension.sourceFile.endsWith('a-first.mjs'))).toEqual([
+      true,
+      false,
+    ]);
+    expect(extensions.map((extension) => extension.sourceFile.endsWith('b-second.mjs'))).toEqual([
+      false,
+      true,
+    ]);
+  });
+
+  it('throws ExtensionLoadError when a file has a syntax error', async () => {
+    writeExtension(extensionsDir, 'broken.mjs', 'this is not valid javascript ((((');
+    await expect(loadExtensions(extensionsDir)).rejects.toThrow(ExtensionLoadError);
+  });
+
+  it('throws ExtensionLoadError when there is no default export', async () => {
+    writeExtension(extensionsDir, 'no-default.mjs', `export const handler = () => {};`);
+    await expect(loadExtensions(extensionsDir)).rejects.toThrow(/must export a default function/);
+  });
+
+  it('throws ExtensionLoadError when the default export is not a function', async () => {
+    writeExtension(extensionsDir, 'object-default.mjs', `export default { handler: () => {} };`);
+    await expect(loadExtensions(extensionsDir)).rejects.toThrow(/must export a default function/);
+  });
+});
+
+// ─── Integration tests via startGateway ───────────────────────────────────────
+
+describe('gateway extensions integration', () => {
+  let tempDir: string;
+  let extensionsDir: string;
+  let gateway: GatewayServer | undefined;
+  let logs: string[];
+  let errorLogs: string[];
+  let mockPermissionResult: boolean;
+  let lastPermissionCheckRequest: Request | undefined;
+  let lastPermissionCheckPath: string | undefined;
+
+  function createMockConfig(): Config {
+    return new Config((name) => {
+      if (name === 'LATCHKEY_DIRECTORY') return tempDir;
+      if (name === 'LATCHKEY_ENCRYPTION_KEY') return TEST_ENCRYPTION_KEY;
+      return undefined;
+    });
+  }
+
+  async function createTestGateway(
+    optionOverrides: Partial<GatewayOptions> = {}
+  ): Promise<GatewayServer> {
+    const credentialsPath = join(tempDir, 'credentials.json.enc');
+    const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
+    encryptedStorage.writeFile(credentialsPath, '{}');
+    const apiCredentialStore = new ApiCredentialStore(credentialsPath, encryptedStorage);
+
+    const config = createMockConfig();
+    const deps: CliDependencies = {
+      registry: new ServiceRegistry([]),
+      config,
+      runCurl: (): CurlResult => ({ returncode: 0, stdout: '', stderr: '' }),
+      runCurlAsync: (): Promise<AsyncCurlResult> =>
+        Promise.resolve({ returncode: 0, stdout: Buffer.alloc(0), stderr: '' }),
+      checkPermission: (
+        request: Request,
+        configPath: string,
+        _builtin: boolean
+      ): Promise<boolean> => {
+        lastPermissionCheckRequest = request;
+        lastPermissionCheckPath = configPath;
+        return Promise.resolve(mockPermissionResult);
+      },
+      confirm: () => Promise.resolve(true),
+      exit: (code: number): never => {
+        throw new Error(`process.exit(${String(code)})`);
+      },
+      log: (message: string) => {
+        logs.push(message);
+      },
+      errorLog: (message: string) => {
+        errorLogs.push(message);
+      },
+      version: '0.0.0-test',
+    };
+
+    const options: GatewayOptions = {
+      port: 0,
+      host: 'localhost',
+      maxBodySize: 10 * 1024 * 1024,
+      password: null,
+      permissionsOverrideSigningKey: derivePermissionsOverrideSigningKey(TEST_ENCRYPTION_KEY),
+      ...optionOverrides,
+    };
+
+    return startGateway(deps, apiCredentialStore, encryptedStorage, options);
+  }
+
+  function getHost(): string {
+    if (gateway === undefined) throw new Error('Gateway not started');
+    const address = gateway.server.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('Failed to get server address');
+    }
+    const host = address.family === 'IPv6' ? `[${address.address}]` : address.address;
+    return `http://${host}:${String(address.port)}`;
+  }
+
+  function fetch(path: string, options: RequestInit = {}): Promise<Response> {
+    return globalThis.fetch(`${getHost()}${path}`, options);
+  }
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'latchkey-ext-int-'));
+    extensionsDir = join(tempDir, 'extensions');
+    mkdirSync(extensionsDir, { recursive: true });
+    logs = [];
+    errorLogs = [];
+    mockPermissionResult = true;
+    lastPermissionCheckRequest = undefined;
+    lastPermissionCheckPath = undefined;
+  });
+
+  afterEach(async () => {
+    if (gateway) {
+      await gateway.close();
+      gateway = undefined;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('serves an extension that claims a request', async () => {
+    writeExtension(
+      extensionsDir,
+      'echo.mjs',
+      `export default (req, res) => {
+        if (req.url === '/extensions/echo') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ url: req.url }));
+          return true;
+        }
+        return false;
+      };`
+    );
+
+    gateway = await createTestGateway();
+    const response = await fetch('/extensions/echo');
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { url: string };
+    expect(body.url).toBe('/extensions/echo');
+  });
+
+  it('falls through to 404 when no extension claims the request', async () => {
+    writeExtension(
+      extensionsDir,
+      'narrow.mjs',
+      `export default (req, res) => {
+        if (req.url === '/extensions/specific') {
+          res.writeHead(200);
+          res.end();
+          return true;
+        }
+        return false;
+      };`
+    );
+    gateway = await createTestGateway();
+    const response = await fetch('/extensions/different');
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when no extensions are installed', async () => {
+    rmSync(extensionsDir, { recursive: true, force: true });
+    gateway = await createTestGateway();
+    const response = await fetch('/extensions/anything');
+    expect(response.status).toBe(404);
+  });
+
+  it('tries extensions in alphabetical order; first to return true wins', async () => {
+    writeExtension(
+      extensionsDir,
+      'a-claim.mjs',
+      `export default (req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('a');
+        return true;
+      };`
+    );
+    writeExtension(
+      extensionsDir,
+      'b-also-claim.mjs',
+      `export default (req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('b');
+        return true;
+      };`
+    );
+    gateway = await createTestGateway();
+    const response = await fetch('/anything');
+    expect(await response.text()).toBe('a');
+  });
+
+  it('continues to the next extension when one returns false', async () => {
+    writeExtension(extensionsDir, 'a-defer.mjs', `export default (req, res) => false;`);
+    writeExtension(
+      extensionsDir,
+      'b-claim.mjs',
+      `export default (req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('handled-by-b');
+        return true;
+      };`
+    );
+    gateway = await createTestGateway();
+    const response = await fetch('/whatever');
+    expect(await response.text()).toBe('handled-by-b');
+  });
+
+  it('preserves query string for the handler and in the permission check', async () => {
+    writeExtension(
+      extensionsDir,
+      'q.mjs',
+      `export default (req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end(req.url);
+        return true;
+      };`
+    );
+
+    gateway = await createTestGateway();
+    const response = await fetch('/extensions/q?x=1&y=2');
+    expect(await response.text()).toBe('/extensions/q?x=1&y=2');
+
+    const synthesizedUrl = lastPermissionCheckRequest?.url ?? '';
+    expect(synthesizedUrl).toContain('?x=1&y=2');
+    expect(synthesizedUrl).toContain(EXTENSION_PLACEHOLDER_HOST);
+  });
+
+  it('returns 403 when the permission check denies the request, before any extension is invoked', async () => {
+    writeExtension(
+      extensionsDir,
+      'should-not-run.mjs',
+      `export default (req, res) => {
+        res.writeHead(200);
+        res.end('should not happen');
+        return true;
+      };`
+    );
+
+    mockPermissionResult = false;
+    gateway = await createTestGateway();
+    const response = await fetch('/anything');
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: string };
+    expect(body.error.toLowerCase()).toContain('not permitted');
+  });
+
+  it('returns 500 and logs when an extension throws', async () => {
+    writeExtension(
+      extensionsDir,
+      'boom.mjs',
+      `export default () => {
+        throw new Error('boom!');
+      };`
+    );
+
+    gateway = await createTestGateway();
+    const response = await fetch('/extensions/boom');
+    expect(response.status).toBe(500);
+    expect(errorLogs.some((message) => message.includes('boom!'))).toBe(true);
+  });
+
+  it('does not call later extensions after one throws', async () => {
+    writeExtension(
+      extensionsDir,
+      'a-throws.mjs',
+      `export default () => {
+        throw new Error('first failed');
+      };`
+    );
+    writeExtension(
+      extensionsDir,
+      'b-claim.mjs',
+      `export default (req, res) => {
+        res.writeHead(200);
+        res.end('b');
+        return true;
+      };`
+    );
+    gateway = await createTestGateway();
+    const response = await fetch('/path');
+    expect(response.status).toBe(500);
+  });
+
+  it('does not let extensions intercept the health endpoint', async () => {
+    writeExtension(
+      extensionsDir,
+      'broad.mjs',
+      `export default (req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('hijacked');
+        return true;
+      };`
+    );
+    gateway = await createTestGateway();
+    const response = await fetch('/');
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { status: string };
+    expect(body.status).toBe('ok');
+  });
+
+  it('does not offer /gateway/<malformed-url> requests to extensions', async () => {
+    writeExtension(
+      extensionsDir,
+      'broad.mjs',
+      `export default (req, res) => {
+        res.writeHead(200);
+        res.end('hijacked');
+        return true;
+      };`
+    );
+    gateway = await createTestGateway();
+    const response = await fetch('/gateway/not-a-url');
+    expect(response.status).toBe(400);
+  });
+
+  it('does not offer /latchkey/ requests to extensions', async () => {
+    writeExtension(
+      extensionsDir,
+      'broad.mjs',
+      `export default (req, res) => {
+        res.writeHead(200);
+        res.end('hijacked');
+        return true;
+      };`
+    );
+    gateway = await createTestGateway();
+    const response = await fetch('/latchkey/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'auth list' }),
+    });
+    // Should be handled by the latchkey RPC endpoint, not the extension.
+    expect(response.status).toBe(200);
+  });
+
+  it('fails startup when an extension is malformed', async () => {
+    writeExtension(extensionsDir, 'broken.mjs', 'syntax error (((');
+    await expect(createTestGateway()).rejects.toThrow(ExtensionLoadError);
+  });
+
+  it('still requires the gateway password for extension routes', async () => {
+    writeExtension(
+      extensionsDir,
+      'pw.mjs',
+      `export default (req, res) => {
+        res.writeHead(200);
+        res.end('ok');
+        return true;
+      };`
+    );
+    gateway = await createTestGateway({ password: 'sekret' });
+
+    const denied = await fetch('/extensions/pw');
+    expect(denied.status).toBe(401);
+
+    const allowed = await fetch('/extensions/pw', {
+      headers: { [GATEWAY_PASSWORD_HEADER]: 'sekret' },
+    });
+    expect(allowed.status).toBe(200);
+  });
+
+  it('honors the permissions-override JWT for extension routes', async () => {
+    writeExtension(
+      extensionsDir,
+      'perm.mjs',
+      `export default (req, res) => {
+        res.writeHead(200);
+        res.end('ok');
+        return true;
+      };`
+    );
+    const overridePath = join(tempDir, 'override-permissions.json');
+    writeFileSync(overridePath, '{"rules":[]}', 'utf-8');
+    const signingKey = derivePermissionsOverrideSigningKey(TEST_ENCRYPTION_KEY);
+    const jwt = createPermissionsOverrideJwt(overridePath, signingKey);
+
+    gateway = await createTestGateway();
+    const response = await fetch('/extensions/perm', {
+      headers: { [PERMISSIONS_OVERRIDE_HEADER]: jwt },
+    });
+    expect(response.status).toBe(200);
+    expect(lastPermissionCheckPath).toBe(overridePath);
+  });
+
+  it('returns 401 for an invalid permissions-override JWT', async () => {
+    writeExtension(
+      extensionsDir,
+      'p.mjs',
+      `export default (req, res) => {
+        res.writeHead(200);
+        res.end('ok');
+        return true;
+      };`
+    );
+    gateway = await createTestGateway();
+    const response = await fetch('/extensions/p', {
+      headers: { [PERMISSIONS_OVERRIDE_HEADER]: 'not.a.jwt' },
+    });
+    expect(response.status).toBe(401);
+  });
+
+  it('supports handlers that complete asynchronously after reading the request body', async () => {
+    writeExtension(
+      extensionsDir,
+      'echo-body.mjs',
+      `export default (req, res) =>
+        new Promise((resolve) => {
+          let body = '';
+          req.on('data', (chunk) => { body += chunk; });
+          req.on('end', () => {
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end(body.toUpperCase());
+            resolve(true);
+          });
+        });`
+    );
+    gateway = await createTestGateway();
+    const response = await fetch('/extensions/echo-body', {
+      method: 'POST',
+      body: 'hello',
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('HELLO');
+  });
+
+  it('logs the extension request line with the actual response status', async () => {
+    writeExtension(
+      extensionsDir,
+      'log.mjs',
+      `export default (req, res) => {
+        res.writeHead(202);
+        res.end();
+        return true;
+      };`
+    );
+    gateway = await createTestGateway();
+    const response = await fetch('/extensions/log');
+    await response.text();
+    expect(logs).toContain('GET /extensions/log -> 202 (extension)');
+  });
+});

--- a/tests/gatewayExtensions.test.ts
+++ b/tests/gatewayExtensions.test.ts
@@ -64,11 +64,7 @@ describe('loadExtensions', () => {
     // .js is intentionally not supported: extensions must be `.mjs` so Node
     // never has to fall back to the CommonJS-then-ESM reparse, which emits
     // a MODULE_TYPELESS_PACKAGE_JSON warning.
-    writeExtension(
-      extensionsDir,
-      'looks-like-an-extension.js',
-      `export default () => false;`
-    );
+    writeExtension(extensionsDir, 'looks-like-an-extension.js', `export default () => false;`);
     const extensions = await loadExtensions(extensionsDir);
     expect(extensions).toEqual([]);
   });

--- a/tests/gatewayExtensions.test.ts
+++ b/tests/gatewayExtensions.test.ts
@@ -58,9 +58,17 @@ describe('loadExtensions', () => {
     expect(extensions).toEqual([]);
   });
 
-  it('skips files with unsupported suffixes', async () => {
+  it('skips files with unsupported suffixes (including .js)', async () => {
     writeExtension(extensionsDir, 'README.txt', 'not an extension');
     writeExtension(extensionsDir, 'config.json', '{}');
+    // .js is intentionally not supported: extensions must be `.mjs` so Node
+    // never has to fall back to the CommonJS-then-ESM reparse, which emits
+    // a MODULE_TYPELESS_PACKAGE_JSON warning.
+    writeExtension(
+      extensionsDir,
+      'looks-like-an-extension.js',
+      `export default () => false;`
+    );
     const extensions = await loadExtensions(extensionsDir);
     expect(extensions).toEqual([]);
   });

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { parseCurlArgs } from '@imbue-ai/detent';
 import { checkPermission, PermissionCheckError } from '../src/permissions.js';
+
+function requestFromCurl(args: readonly string[]): Request {
+  return parseCurlArgs(args);
+}
 
 describe('checkPermission', () => {
   let tempDir: string;
@@ -19,7 +24,7 @@ describe('checkPermission', () => {
     const configPath = join(tempDir, 'nonexistent', 'permissions.json');
 
     const result = await checkPermission(
-      ['-X', 'GET', 'https://api.example.com/anything'],
+      requestFromCurl(['-X', 'GET', 'https://api.example.com/anything']),
       configPath
     );
 
@@ -49,7 +54,10 @@ describe('checkPermission', () => {
       })
     );
 
-    const result = await checkPermission(['https://api.example.com/users'], configPath);
+    const result = await checkPermission(
+      requestFromCurl(['https://api.example.com/users']),
+      configPath
+    );
 
     expect(result).toBe(true);
   });
@@ -78,7 +86,7 @@ describe('checkPermission', () => {
     );
 
     const result = await checkPermission(
-      ['-X', 'POST', 'https://api.example.com/users'],
+      requestFromCurl(['-X', 'POST', 'https://api.example.com/users']),
       configPath
     );
 
@@ -108,7 +116,10 @@ describe('checkPermission', () => {
       })
     );
 
-    const result = await checkPermission(['https://api.other.com/something'], configPath);
+    const result = await checkPermission(
+      requestFromCurl(['https://api.other.com/something']),
+      configPath
+    );
 
     expect(result).toBe(false);
   });
@@ -117,9 +128,9 @@ describe('checkPermission', () => {
     const configPath = join(tempDir, 'permissions.json');
     writeFileSync(configPath, 'not valid json');
 
-    await expect(checkPermission(['https://api.example.com/anything'], configPath)).rejects.toThrow(
-      PermissionCheckError
-    );
+    await expect(
+      checkPermission(requestFromCurl(['https://api.example.com/anything']), configPath)
+    ).rejects.toThrow(PermissionCheckError);
   });
 
   it('should accept URLs without a scheme (defaulting to http://) when rules allow them', async () => {
@@ -131,7 +142,7 @@ describe('checkPermission', () => {
       })
     );
 
-    const result = await checkPermission(['www.seznam.cz'], configPath);
+    const result = await checkPermission(requestFromCurl(['www.seznam.cz']), configPath);
     expect(result).toBe(true);
   });
 
@@ -145,7 +156,7 @@ describe('checkPermission', () => {
     );
 
     await expect(
-      checkPermission(['https://api.example.com/anything'], configPath, true)
+      checkPermission(requestFromCurl(['https://api.example.com/anything']), configPath, true)
     ).rejects.toThrow(PermissionCheckError);
   });
 
@@ -158,9 +169,12 @@ describe('checkPermission', () => {
       })
     );
 
-    const resultGet = await checkPermission(['https://api.example.com/anything'], configPath);
+    const resultGet = await checkPermission(
+      requestFromCurl(['https://api.example.com/anything']),
+      configPath
+    );
     const resultPost = await checkPermission(
-      ['-X', 'POST', '-d', '{"key":"value"}', 'https://api.other.com/resource'],
+      requestFromCurl(['-X', 'POST', '-d', '{"key":"value"}', 'https://api.other.com/resource']),
       configPath
     );
 
@@ -177,7 +191,10 @@ describe('checkPermission', () => {
       })
     );
 
-    const result = await checkPermission(['https://api.example.com/anything'], configPath);
+    const result = await checkPermission(
+      requestFromCurl(['https://api.example.com/anything']),
+      configPath
+    );
 
     expect(result).toBe(false);
   });


### PR DESCRIPTION
- Developers can drop .mjs files in `~/.latchkey/extensions` to implement additional gateway endpoints without touching core Latchkey.