### PR TITLE
Version 2.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "latchkey",
-  "version": "2.12.2",
+  "version": "2.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "latchkey",
-      "version": "2.12.2",
+      "version": "2.13.0",
       "license": "MIT",
       "dependencies": {
         "@imbue-ai/detent": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "latchkey",
-  "version": "2.12.2",
+  "version": "2.13.0",
   "description": "A CLI tool that injects API credentials into curl requests to third-party services",
   "author": "Imbue <hynek@imbue.com>",
   "repository": {

--- a/src/curlInjection.ts
+++ b/src/curlInjection.ts
@@ -147,5 +147,9 @@ export async function prepareCurlInvocation(
     }
   }
 
+  if (service.adjustCredentials !== undefined) {
+    apiCredentials = service.adjustCredentials(apiCredentials, url);
+  }
+
   return await apiCredentials.injectIntoCurlCall(curlArguments);
 }

--- a/src/services/core/base.ts
+++ b/src/services/core/base.ts
@@ -73,6 +73,15 @@ export abstract class Service {
   abstract readonly credentialCheckCurlArguments: readonly string[];
 
   /**
+   * Optionally transform the stored credentials before they are injected into a
+   * curl call, based on the request URL. Services can override this to use a
+   * different credential form for different kinds of URLs (e.g. API access vs.
+   * repository access). Implementations should throw if the stored credentials
+   * are not of the expected type.
+   */
+  adjustCredentials?(apiCredentials: ApiCredentials, url: string): ApiCredentials;
+
+  /**
    * Check if the given API credentials are valid for this service.
    */
   async checkApiCredentials(apiCredentials: ApiCredentials): Promise<ApiCredentialStatus> {

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -12,6 +12,82 @@ const DEFAULT_TIMEOUT_MS = 8000;
 // URL for creating a new personal access token (also used as login URL to trigger sudo)
 const GITHUB_NEW_TOKEN_URL = 'https://github.com/settings/tokens/new';
 
+// First path segments under github.com that are website routes rather than
+// repository owners. Used to avoid treating those URLs as repository URLs.
+const GITHUB_RESERVED_PATH_SEGMENTS = [
+  'settings',
+  'login',
+  'logout',
+  'join',
+  'signup',
+  'sessions',
+  'notifications',
+  'organizations',
+  'orgs',
+  'users',
+  'user',
+  'apps',
+  'marketplace',
+  'explore',
+  'topics',
+  'collections',
+  'trending',
+  'events',
+  'sponsors',
+  'about',
+  'pricing',
+  'features',
+  'contact',
+  'search',
+  'new',
+  'dashboard',
+  'codespaces',
+  'copilot',
+] as const;
+
+/**
+ * Matches URLs that point at a GitHub repository (e.g. for git over HTTPS), as
+ * opposed to the REST API or a regular website page. A repository URL lives on
+ * github.com and has at least two path segments where the first segment (the
+ * owner) is not a reserved website route.
+ */
+const GITHUB_REPOSITORY_URL_PATTERN = new RegExp(
+  `^https://github\\.com/(?!(?:${GITHUB_RESERVED_PATH_SEGMENTS.join('|')})(?:/|$))[^/]+/[^/]+`,
+  'i'
+);
+
+export class UnexpectedGithubCredentialsError extends Error {
+  constructor() {
+    super(
+      'Expected GitHub credentials of the "Authorization: Bearer" form for repository access.'
+    );
+    this.name = 'UnexpectedGithubCredentialsError';
+  }
+}
+
+/**
+ * GitHub token credentials injected via curl's `-u` flag, suitable for git
+ * operations over HTTPS (the smart HTTP protocol uses HTTP basic auth). This
+ * credential form is produced on the fly from a stored bearer token and is
+ * never persisted.
+ */
+export class GithubTokenBasicAuth implements ApiCredentials {
+  readonly objectType = 'githubTokenBasicAuth' as const;
+  readonly token: string;
+
+  constructor(token: string) {
+    this.token = token;
+  }
+
+  injectIntoCurlCall(curlArguments: readonly string[]): Promise<readonly string[]> {
+    return Promise.resolve(['-u', `x-access-token:${this.token}`, ...curlArguments]);
+  }
+
+  isExpired(): boolean | undefined {
+    return undefined;
+  }
+}
+
 // GitHub personal access token scopes to enable
 const GITHUB_TOKEN_SCOPES = [
   'repo',
@@ -110,7 +186,11 @@ class GithubServiceSession extends BrowserFollowupServiceSession {
 export class Github extends Service {
   readonly name = 'github';
   readonly displayName = 'GitHub';
-  readonly baseApiUrls = ['https://api.github.com/', 'https://uploads.github.com/'] as const;
+  readonly baseApiUrls = [
+    'https://api.github.com/',
+    'https://uploads.github.com/',
+    GITHUB_REPOSITORY_URL_PATTERN,
+  ] as const;
   readonly loginUrl = GITHUB_NEW_TOKEN_URL;
   readonly info =
     'https://docs.github.com/en/rest. ' +
@@ -120,6 +200,16 @@ export class Github extends Service {
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  override adjustCredentials(apiCredentials: ApiCredentials, url: string): ApiCredentials {
+    if (!GITHUB_REPOSITORY_URL_PATTERN.test(url)) {
+      return apiCredentials;
+    }
+    if (!(apiCredentials instanceof AuthorizationBearer)) {
+      throw new UnexpectedGithubCredentialsError();
+    }
+    return new GithubTokenBasicAuth(apiCredentials.token);
   }
 
   override getSession(): GithubServiceSession {

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -12,49 +12,16 @@ const DEFAULT_TIMEOUT_MS = 8000;
 // URL for creating a new personal access token (also used as login URL to trigger sudo)
 const GITHUB_NEW_TOKEN_URL = 'https://github.com/settings/tokens/new';
 
-// First path segments under github.com that are website routes rather than
-// repository owners. Used to avoid treating those URLs as repository URLs.
-const GITHUB_RESERVED_PATH_SEGMENTS = [
-  'settings',
-  'login',
-  'logout',
-  'join',
-  'signup',
-  'sessions',
-  'notifications',
-  'organizations',
-  'orgs',
-  'users',
-  'user',
-  'apps',
-  'marketplace',
-  'explore',
-  'topics',
-  'collections',
-  'trending',
-  'events',
-  'sponsors',
-  'about',
-  'pricing',
-  'features',
-  'contact',
-  'search',
-  'new',
-  'dashboard',
-  'codespaces',
-  'copilot',
-] as const;
-
 /**
- * Matches URLs that point at a GitHub repository (e.g. for git over HTTPS), as
- * opposed to the REST API or a regular website page. A repository URL lives on
- * github.com and has at least two path segments where the first segment (the
- * owner) is not a reserved website route.
+ * Matches the GitHub smart-HTTP endpoints used by git over HTTPS, as opposed to
+ * the REST API or a regular website page. The git client only ever talks to
+ * `<owner>/<repo>[.git]/info/refs`, `.../git-upload-pack` and
+ * `.../git-receive-pack`, so matching those endpoints reliably distinguishes
+ * actual git operations from ordinary repository web pages (which should not be
+ * authenticated as git).
  */
-const GITHUB_REPOSITORY_URL_PATTERN = new RegExp(
-  `^https://github\\.com/(?!(?:${GITHUB_RESERVED_PATH_SEGMENTS.join('|')})(?:/|$))[^/]+/[^/]+`,
-  'i'
-);
+const GITHUB_GIT_OPERATION_URL_PATTERN =
+  /^https:\/\/github\.com\/[^/]+\/[^/]+\/(?:info\/refs|git-upload-pack|git-receive-pack)(?:[/?]|$)/;
 
 export class UnexpectedGithubCredentialsError extends Error {
   constructor() {
@@ -189,7 +156,7 @@ export class Github extends Service {
   readonly baseApiUrls = [
     'https://api.github.com/',
     'https://uploads.github.com/',
-    GITHUB_REPOSITORY_URL_PATTERN,
+    GITHUB_GIT_OPERATION_URL_PATTERN,
   ] as const;
   readonly loginUrl = GITHUB_NEW_TOKEN_URL;
   readonly info =
@@ -203,7 +170,7 @@ export class Github extends Service {
   }
 
   override adjustCredentials(apiCredentials: ApiCredentials, url: string): ApiCredentials {
-    if (!GITHUB_REPOSITORY_URL_PATTERN.test(url)) {
+    if (!GITHUB_GIT_OPERATION_URL_PATTERN.test(url)) {
       return apiCredentials;
     }
     if (!(apiCredentials instanceof AuthorizationBearer)) {

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -25,9 +25,7 @@ const GITHUB_GIT_OPERATION_URL_PATTERN =
 
 export class UnexpectedGithubCredentialsError extends Error {
   constructor() {
-    super(
-      'Expected GitHub credentials of the "Authorization: Bearer" form for repository access.'
-    );
+    super('Expected GitHub credentials of the "Authorization: Bearer" form for repository access.');
     this.name = 'UnexpectedGithubCredentialsError';
   }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // Auto-generated from package.json by scripts/generateVersion.js.
 // Do not edit by hand; run `node scripts/generateVersion.js` to refresh.
-export const VERSION = "2.12.2";
+export const VERSION = "2.13.0";

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GITHUB,
+  GithubTokenBasicAuth,
+  UnexpectedGithubCredentialsError,
+} from '../src/services/github.js';
+import { AuthorizationBearer, RawCurlCredentials } from '../src/apiCredentials/base.js';
+import { SERVICE_REGISTRY } from '../src/serviceRegistry.js';
+
+describe('Github URL matching', () => {
+  it('matches the REST API host', () => {
+    expect(SERVICE_REGISTRY.getByUrl('https://api.github.com/user')).toBe(GITHUB);
+    expect(SERVICE_REGISTRY.getByUrl('https://uploads.github.com/anything')).toBe(GITHUB);
+  });
+
+  it('matches repository URLs', () => {
+    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo')).toBe(GITHUB);
+    expect(
+      SERVICE_REGISTRY.getByUrl(
+        'https://github.com/owner/repo.git/info/refs?service=git-upload-pack'
+      )
+    ).toBe(GITHUB);
+  });
+
+  it('does not match website routes or single-segment paths', () => {
+    expect(SERVICE_REGISTRY.getByUrl('https://github.com/settings/tokens')).toBeNull();
+    expect(SERVICE_REGISTRY.getByUrl('https://github.com/orgs/some-org')).toBeNull();
+    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner')).toBeNull();
+    expect(SERVICE_REGISTRY.getByUrl('https://example.com/owner/repo')).toBeNull();
+  });
+});
+
+describe('Github.adjustCredentials', () => {
+  it('leaves API credentials untouched', () => {
+    const bearer = new AuthorizationBearer('token-123');
+    const adjusted = GITHUB.adjustCredentials(bearer, 'https://api.github.com/user');
+    expect(adjusted).toBe(bearer);
+  });
+
+  it('converts bearer credentials to basic auth for repository URLs', async () => {
+    const bearer = new AuthorizationBearer('token-123');
+    const adjusted = GITHUB.adjustCredentials(bearer, 'https://github.com/owner/repo.git/info/refs');
+    expect(adjusted).toBeInstanceOf(GithubTokenBasicAuth);
+
+    const args = await adjusted.injectIntoCurlCall(['https://github.com/owner/repo.git']);
+    expect(args).toEqual(['-u', 'x-access-token:token-123', 'https://github.com/owner/repo.git']);
+  });
+
+  it('throws when repository credentials are not bearer credentials', () => {
+    const raw = new RawCurlCredentials(['-H', 'X-Custom: 1']);
+    expect(() => GITHUB.adjustCredentials(raw, 'https://github.com/owner/repo')).toThrow(
+      UnexpectedGithubCredentialsError
+    );
+  });
+});

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -13,20 +13,29 @@ describe('Github URL matching', () => {
     expect(SERVICE_REGISTRY.getByUrl('https://uploads.github.com/anything')).toBe(GITHUB);
   });
 
-  it('matches repository URLs', () => {
-    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo')).toBe(GITHUB);
+  it('matches git smart-HTTP operation URLs', () => {
     expect(
       SERVICE_REGISTRY.getByUrl(
         'https://github.com/owner/repo.git/info/refs?service=git-upload-pack'
       )
     ).toBe(GITHUB);
+    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo/info/refs')).toBe(GITHUB);
+    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo.git/git-upload-pack')).toBe(
+      GITHUB
+    );
+    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo/git-receive-pack')).toBe(
+      GITHUB
+    );
   });
 
-  it('does not match website routes or single-segment paths', () => {
+  it('does not match repository web pages or website routes', () => {
+    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo')).toBeNull();
+    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo/issues/1')).toBeNull();
     expect(SERVICE_REGISTRY.getByUrl('https://github.com/settings/tokens')).toBeNull();
-    expect(SERVICE_REGISTRY.getByUrl('https://github.com/orgs/some-org')).toBeNull();
     expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner')).toBeNull();
-    expect(SERVICE_REGISTRY.getByUrl('https://example.com/owner/repo')).toBeNull();
+    expect(
+      SERVICE_REGISTRY.getByUrl('https://example.com/owner/repo.git/info/refs')
+    ).toBeNull();
   });
 });
 
@@ -37,7 +46,13 @@ describe('Github.adjustCredentials', () => {
     expect(adjusted).toBe(bearer);
   });
 
-  it('converts bearer credentials to basic auth for repository URLs', async () => {
+  it('leaves credentials untouched for repository web pages', () => {
+    const bearer = new AuthorizationBearer('token-123');
+    const adjusted = GITHUB.adjustCredentials(bearer, 'https://github.com/owner/repo');
+    expect(adjusted).toBe(bearer);
+  });
+
+  it('converts bearer credentials to basic auth for git operation URLs', async () => {
     const bearer = new AuthorizationBearer('token-123');
     const adjusted = GITHUB.adjustCredentials(bearer, 'https://github.com/owner/repo.git/info/refs');
     expect(adjusted).toBeInstanceOf(GithubTokenBasicAuth);
@@ -46,10 +61,10 @@ describe('Github.adjustCredentials', () => {
     expect(args).toEqual(['-u', 'x-access-token:token-123', 'https://github.com/owner/repo.git']);
   });
 
-  it('throws when repository credentials are not bearer credentials', () => {
+  it('throws when git operation credentials are not bearer credentials', () => {
     const raw = new RawCurlCredentials(['-H', 'X-Custom: 1']);
-    expect(() => GITHUB.adjustCredentials(raw, 'https://github.com/owner/repo')).toThrow(
-      UnexpectedGithubCredentialsError
-    );
+    expect(() =>
+      GITHUB.adjustCredentials(raw, 'https://github.com/owner/repo.git/git-upload-pack')
+    ).toThrow(UnexpectedGithubCredentialsError);
   });
 });

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -33,9 +33,7 @@ describe('Github URL matching', () => {
     expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo/issues/1')).toBeNull();
     expect(SERVICE_REGISTRY.getByUrl('https://github.com/settings/tokens')).toBeNull();
     expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner')).toBeNull();
-    expect(
-      SERVICE_REGISTRY.getByUrl('https://example.com/owner/repo.git/info/refs')
-    ).toBeNull();
+    expect(SERVICE_REGISTRY.getByUrl('https://example.com/owner/repo.git/info/refs')).toBeNull();
   });
 });
 
@@ -54,7 +52,10 @@ describe('Github.adjustCredentials', () => {
 
   it('converts bearer credentials to basic auth for git operation URLs', async () => {
     const bearer = new AuthorizationBearer('token-123');
-    const adjusted = GITHUB.adjustCredentials(bearer, 'https://github.com/owner/repo.git/info/refs');
+    const adjusted = GITHUB.adjustCredentials(
+      bearer,
+      'https://github.com/owner/repo.git/info/refs'
+    );
     expect(adjusted).toBeInstanceOf(GithubTokenBasicAuth);
 
     const args = await adjusted.injectIntoCurlCall(['https://github.com/owner/repo.git']);

--- a/tests/serviceRegistry.test.ts
+++ b/tests/serviceRegistry.test.ts
@@ -94,6 +94,21 @@ describe('ServiceRegistry', () => {
     it('should not match partial URLs', () => {
       expect(SERVICE_REGISTRY.getByUrl('https://slack.com/')).toBeNull();
     });
+
+    it('should match GitHub repository URLs', () => {
+      expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo')).toBe(GITHUB);
+      expect(
+        SERVICE_REGISTRY.getByUrl(
+          'https://github.com/owner/repo.git/info/refs?service=git-upload-pack'
+        )
+      ).toBe(GITHUB);
+    });
+
+    it('should not match GitHub website routes as repositories', () => {
+      expect(SERVICE_REGISTRY.getByUrl('https://github.com/settings/tokens')).toBeNull();
+      expect(SERVICE_REGISTRY.getByUrl('https://github.com/orgs/some-org')).toBeNull();
+      expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner')).toBeNull();
+    });
   });
 
   describe('services', () => {

--- a/tests/serviceRegistry.test.ts
+++ b/tests/serviceRegistry.test.ts
@@ -95,19 +95,20 @@ describe('ServiceRegistry', () => {
       expect(SERVICE_REGISTRY.getByUrl('https://slack.com/')).toBeNull();
     });
 
-    it('should match GitHub repository URLs', () => {
-      expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo')).toBe(GITHUB);
+    it('should match GitHub git smart-HTTP operation URLs', () => {
       expect(
         SERVICE_REGISTRY.getByUrl(
           'https://github.com/owner/repo.git/info/refs?service=git-upload-pack'
         )
       ).toBe(GITHUB);
+      expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo/git-upload-pack')).toBe(
+        GITHUB
+      );
     });
 
-    it('should not match GitHub website routes as repositories', () => {
+    it('should not match GitHub web pages as git operations', () => {
+      expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo')).toBeNull();
       expect(SERVICE_REGISTRY.getByUrl('https://github.com/settings/tokens')).toBeNull();
-      expect(SERVICE_REGISTRY.getByUrl('https://github.com/orgs/some-org')).toBeNull();
-      expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner')).toBeNull();
     });
   });
 


### PR DESCRIPTION
- Make GitHub credentials work with git operation over http, too.