### PR TITLE
playwrightLoader: adapt to playwright-core 1.60 restructure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@imbue-ai/detent": "^1.4.0",
         "@napi-rs/keyring": "^1.2.0",
         "commander": "^12.0.0",
-        "playwright": "^1.60.0",
+        "playwright": "~1.60.0",
         "zod": "^3.22.0"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@imbue-ai/detent": "^1.4.0",
         "@napi-rs/keyring": "^1.2.0",
         "commander": "^12.0.0",
-        "playwright": "^1.58.2",
+        "playwright": "^1.60.0",
         "zod": "^3.22.0"
       },
       "bin": {
@@ -1321,7 +1321,6 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1371,7 +1370,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -1700,7 +1698,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1967,7 +1964,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2594,7 +2590,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2603,12 +2598,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2621,9 +2616,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -2921,7 +2916,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2977,7 +2971,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@imbue-ai/detent": "^1.4.0",
     "@napi-rs/keyring": "^1.2.0",
     "commander": "^12.0.0",
-    "playwright": "^1.60.0",
+    "playwright": "~1.60.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@imbue-ai/detent": "^1.4.0",
     "@napi-rs/keyring": "^1.2.0",
     "commander": "^12.0.0",
-    "playwright": "^1.58.2",
+    "playwright": "^1.60.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {

--- a/src/playwright-core.d.ts
+++ b/src/playwright-core.d.ts
@@ -1,7 +1,7 @@
 /**
  * Type declarations for internal playwright-core modules.
  */
-declare module 'playwright-core/lib/server/registry/index' {
+declare module 'playwright-core/lib/coreBundle' {
   export interface Executable {
     name: string;
     directory: string | undefined;
@@ -13,11 +13,15 @@ declare module 'playwright-core/lib/server/registry/index' {
     findExecutable(name: string): Executable | undefined;
   }
 
-  export const registry: Registry;
+  export interface CoreBundle {
+    registry: {
+      registry: Registry;
+    };
+    utils: {
+      extractZip: (zipPath: string, options: { dir: string }) => Promise<void>;
+    };
+  }
 
-  export function installBrowsersForNpmInstall(browsers: string[]): Promise<void>;
-}
-
-declare module 'playwright-core/lib/zipBundle' {
-  export function extract(zipPath: string, options: { dir: string }): Promise<void>;
+  const coreBundle: CoreBundle;
+  export default coreBundle;
 }

--- a/src/playwrightLoader.ts
+++ b/src/playwrightLoader.ts
@@ -77,5 +77,3 @@ export async function loadPlaywrightZipBundle(): Promise<{
   const cb = await loadPlaywrightCoreBundle();
   return { extract: cb.default.utils.extractZip };
 }
-</content>
-</invoke>

--- a/src/playwrightLoader.ts
+++ b/src/playwrightLoader.ts
@@ -8,10 +8,9 @@
  * resolved at runtime (i.e. when a user is running the standalone binary
  * instead of the `npm install -g latchkey` distribution).
  *
- * The registry instance and zip `extract` function live inside
- * `lib/coreBundle`; the more specific subpaths that expose them
- * directly are absent from playwright-core's `package.json#exports`
- * map, so importing them throws `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+ * The registry instance and zip `extract` function are read from
+ * `lib/coreBundle`, the only subpath in playwright-core's
+ * `package.json#exports` that still reaches them.
  */
 
 export class BrowserFeaturesUnavailableError extends Error {

--- a/src/playwrightLoader.ts
+++ b/src/playwrightLoader.ts
@@ -8,10 +8,10 @@
  * resolved at runtime (i.e. when a user is running the standalone binary
  * instead of the `npm install -g latchkey` distribution).
  *
- * The registry instance and zip ``extract`` function live inside
- * ``lib/coreBundle``; the more specific subpaths that expose them
- * directly are absent from playwright-core's ``package.json#exports``
- * map, so importing them throws ``ERR_PACKAGE_PATH_NOT_EXPORTED``.
+ * The registry instance and zip `extract` function live inside
+ * `lib/coreBundle`; the more specific subpaths that expose them
+ * directly are absent from playwright-core's `package.json#exports`
+ * map, so importing them throws `ERR_PACKAGE_PATH_NOT_EXPORTED`.
  */
 
 export class BrowserFeaturesUnavailableError extends Error {

--- a/src/playwrightLoader.ts
+++ b/src/playwrightLoader.ts
@@ -47,10 +47,21 @@ export async function loadPlaywright(): Promise<typeof import('playwright')> {
   }
 }
 
+interface PlaywrightExecutable {
+  name: string;
+  directory?: string;
+  executablePath(sdkLanguage: string): string | undefined;
+  downloadURLs?: string[];
+}
+
+interface PlaywrightRegistry {
+  findExecutable(name: string): PlaywrightExecutable | undefined;
+}
+
 interface PlaywrightCoreBundle {
   default: {
     registry: {
-      registry: unknown;
+      registry: PlaywrightRegistry;
     };
     utils: {
       extractZip: (zipPath: string, options: { dir: string }) => Promise<void>;
@@ -66,7 +77,7 @@ async function loadPlaywrightCoreBundle(): Promise<PlaywrightCoreBundle> {
   }
 }
 
-export async function loadPlaywrightRegistry(): Promise<{ registry: unknown }> {
+export async function loadPlaywrightRegistry(): Promise<{ registry: PlaywrightRegistry }> {
   const cb = await loadPlaywrightCoreBundle();
   return { registry: cb.default.registry.registry };
 }

--- a/src/playwrightLoader.ts
+++ b/src/playwrightLoader.ts
@@ -71,6 +71,7 @@ interface PlaywrightCoreBundle {
 
 async function loadPlaywrightCoreBundle(): Promise<PlaywrightCoreBundle> {
   try {
+    // @ts-expect-error - playwright-core ships no type declarations for this internal subpath
     return (await import('playwright-core/lib/coreBundle')) as unknown as PlaywrightCoreBundle;
   } catch (error) {
     throw new BrowserFeaturesUnavailableError(error);

--- a/src/playwrightLoader.ts
+++ b/src/playwrightLoader.ts
@@ -8,20 +8,10 @@
  * resolved at runtime (i.e. when a user is running the standalone binary
  * instead of the `npm install -g latchkey` distribution).
  *
- * Playwright-core 1.60 restructured its internals: the symbols we used
- * to import from ``lib/server/registry/index`` (the ``registry``
- * instance) and ``lib/zipBundle`` (the ``extract`` function) now live
- * inside ``lib/coreBundle`` as ``coreBundle.default.registry.registry``
- * and ``coreBundle.default.utils.extractZip``. The old subpaths are no
- * longer in playwright-core's ``package.json#exports`` map, so any
- * import that names them throws ``ERR_PACKAGE_PATH_NOT_EXPORTED`` —
- * which our caller surfaces as ``BrowserFeaturesUnavailableError`` and
- * the user sees as "Browser-based features are not available in the
- * standalone latchkey binary" even though both ``playwright`` and
- * ``playwright-core`` resolve fine. Loading via ``lib/coreBundle``
- * (which IS in the exports map) and adapting the returned namespace
- * keeps the original ``{ registry }`` / ``{ extract }`` shape that
- * playwrightDownload.ts destructures.
+ * The registry instance and zip ``extract`` function live inside
+ * ``lib/coreBundle``; the more specific subpaths that expose them
+ * directly are absent from playwright-core's ``package.json#exports``
+ * map, so importing them throws ``ERR_PACKAGE_PATH_NOT_EXPORTED``.
  */
 
 export class BrowserFeaturesUnavailableError extends Error {
@@ -47,45 +37,22 @@ export async function loadPlaywright(): Promise<typeof import('playwright')> {
   }
 }
 
-export interface PlaywrightExecutable {
-  name: string;
-  directory?: string;
-  executablePath(sdkLanguage: string): string | undefined;
-  downloadURLs?: string[];
-}
-
-export interface PlaywrightRegistry {
-  findExecutable(name: string): PlaywrightExecutable | undefined;
-}
-
-interface PlaywrightCoreBundle {
-  default: {
-    registry: {
-      registry: PlaywrightRegistry;
-    };
-    utils: {
-      extractZip: (zipPath: string, options: { dir: string }) => Promise<void>;
-    };
-  };
-}
-
-async function loadPlaywrightCoreBundle(): Promise<PlaywrightCoreBundle> {
+async function loadPlaywrightCoreBundle(): Promise<
+  typeof import('playwright-core/lib/coreBundle').default
+> {
   try {
-    // @ts-expect-error - playwright-core ships no type declarations for this internal subpath
-    return (await import('playwright-core/lib/coreBundle')) as unknown as PlaywrightCoreBundle;
+    return (await import('playwright-core/lib/coreBundle')).default;
   } catch (error) {
     throw new BrowserFeaturesUnavailableError(error);
   }
 }
 
-export async function loadPlaywrightRegistry(): Promise<{ registry: PlaywrightRegistry }> {
-  const cb = await loadPlaywrightCoreBundle();
-  return { registry: cb.default.registry.registry };
+export async function loadPlaywrightRegistry() {
+  const coreBundle = await loadPlaywrightCoreBundle();
+  return { registry: coreBundle.registry.registry };
 }
 
-export async function loadPlaywrightZipBundle(): Promise<{
-  extract: (zipPath: string, options: { dir: string }) => Promise<void>;
-}> {
-  const cb = await loadPlaywrightCoreBundle();
-  return { extract: cb.default.utils.extractZip };
+export async function loadPlaywrightZipBundle() {
+  const coreBundle = await loadPlaywrightCoreBundle();
+  return { extract: coreBundle.utils.extractZip };
 }

--- a/src/playwrightLoader.ts
+++ b/src/playwrightLoader.ts
@@ -7,6 +7,21 @@
  * which surface a clear, actionable error when the modules cannot be
  * resolved at runtime (i.e. when a user is running the standalone binary
  * instead of the `npm install -g latchkey` distribution).
+ *
+ * Playwright-core 1.60 restructured its internals: the symbols we used
+ * to import from ``lib/server/registry/index`` (the ``registry``
+ * instance) and ``lib/zipBundle`` (the ``extract`` function) now live
+ * inside ``lib/coreBundle`` as ``coreBundle.default.registry.registry``
+ * and ``coreBundle.default.utils.extractZip``. The old subpaths are no
+ * longer in playwright-core's ``package.json#exports`` map, so any
+ * import that names them throws ``ERR_PACKAGE_PATH_NOT_EXPORTED`` —
+ * which our caller surfaces as ``BrowserFeaturesUnavailableError`` and
+ * the user sees as "Browser-based features are not available in the
+ * standalone latchkey binary" even though both ``playwright`` and
+ * ``playwright-core`` resolve fine. Loading via ``lib/coreBundle``
+ * (which IS in the exports map) and adapting the returned namespace
+ * keeps the original ``{ registry }`` / ``{ extract }`` shape that
+ * playwrightDownload.ts destructures.
  */
 
 export class BrowserFeaturesUnavailableError extends Error {
@@ -32,22 +47,35 @@ export async function loadPlaywright(): Promise<typeof import('playwright')> {
   }
 }
 
-export async function loadPlaywrightRegistry(): Promise<
-  typeof import('playwright-core/lib/server/registry/index')
-> {
+interface PlaywrightCoreBundle {
+  default: {
+    registry: {
+      registry: unknown;
+    };
+    utils: {
+      extractZip: (zipPath: string, options: { dir: string }) => Promise<void>;
+    };
+  };
+}
+
+async function loadPlaywrightCoreBundle(): Promise<PlaywrightCoreBundle> {
   try {
-    return await import('playwright-core/lib/server/registry/index');
+    return (await import('playwright-core/lib/coreBundle')) as unknown as PlaywrightCoreBundle;
   } catch (error) {
     throw new BrowserFeaturesUnavailableError(error);
   }
 }
 
-export async function loadPlaywrightZipBundle(): Promise<
-  typeof import('playwright-core/lib/zipBundle')
-> {
-  try {
-    return await import('playwright-core/lib/zipBundle');
-  } catch (error) {
-    throw new BrowserFeaturesUnavailableError(error);
-  }
+export async function loadPlaywrightRegistry(): Promise<{ registry: unknown }> {
+  const cb = await loadPlaywrightCoreBundle();
+  return { registry: cb.default.registry.registry };
 }
+
+export async function loadPlaywrightZipBundle(): Promise<{
+  extract: (zipPath: string, options: { dir: string }) => Promise<void>;
+}> {
+  const cb = await loadPlaywrightCoreBundle();
+  return { extract: cb.default.utils.extractZip };
+}
+</content>
+</invoke>

--- a/src/playwrightLoader.ts
+++ b/src/playwrightLoader.ts
@@ -47,14 +47,14 @@ export async function loadPlaywright(): Promise<typeof import('playwright')> {
   }
 }
 
-interface PlaywrightExecutable {
+export interface PlaywrightExecutable {
   name: string;
   directory?: string;
   executablePath(sdkLanguage: string): string | undefined;
   downloadURLs?: string[];
 }
 
-interface PlaywrightRegistry {
+export interface PlaywrightRegistry {
   findExecutable(name: string): PlaywrightExecutable | undefined;
 }
 


### PR DESCRIPTION
playwright-core 1.60 dropped the internal subpaths we were importing in playwrightLoader.ts:

- `./lib/server/registry/index` (Registry instance)
- `./lib/zipBundle` (extract function)

Both files were removed AND not added to `package.json#exports`. Imports throw `ERR_PACKAGE_PATH_NOT_EXPORTED`, which our caller wraps as `BrowserFeaturesUnavailableError` — "Browser-based features are not available in the standalone latchkey binary". Misleading: latchkey isn't standalone, just incompatible with the new playwright-core.

This PR loads `lib/coreBundle` (which IS in the exports map) once and pulls the same symbols from the new locations:
- `coreBundle.default.registry.registry` → Registry instance
- `coreBundle.default.utils.extractZip` → extract function

The returned shape is unchanged so `playwrightDownload.ts` keeps working without changes.

Empirically verified locally that the new `registry` exposes `findExecutable('chromium')` and returns a real Executable. Diagnosed against the bundled `playwright-core@1.60.0` shipping inside the minds.app, which is the version most users encounter.

## Dependency bump (required)

`lib/coreBundle` only exists in playwright-core ≥ 1.60.0; 1.58.x/1.59.x still ship the old `lib/zipBundle` + `lib/server/registry/index` layout. latchkey declared `playwright ^1.58.2` (lockfile pinned 1.58.2), so the new imports would throw `ERR_PACKAGE_PATH_NOT_EXPORTED` on the `npm install -g latchkey` path even though they resolve fine against the minds.app-bundled 1.60. This PR therefore bumps `playwright` and regenerates the lockfile so latchkey's own declared dependency matches the layout the code now requires.

The range is pinned with a tilde (`~1.60.0`), not a caret. We import playwright-core *private internals*, which carry no semver guarantee and were restructured in the 1.59→1.60 minor bump. A caret would let a fresh `npm install -g latchkey` resolve a future minor that moves them again, silently reintroducing this exact failure. Tilde allows only 1.60.x patches; minor playwright upgrades become deliberate, re-verified changes.

## Typing

`playwright-core` ships no `.d.ts` for these internal subpaths, so `src/playwright-core.d.ts` carries an ambient declaration for `lib/coreBundle` (`Executable`, `Registry`, and the `default` export shape). `playwrightLoader.ts` derives its return types from that declaration — no inline casts or `@ts-expect-error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
