### PR TITLE
Add Todoist service

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,4 +440,4 @@ override `config.json` values.
 Latchkey currently offers varying levels of support for the
 following services: AWS, Calendly, Discord, Dropbox, Figma, GitHub, GitLab,
 Gmail, Google Analytics, Google Calendar, Google Docs, Google Drive, Google Sheets,
-Linear, Mailchimp, Notion, Sentry, Slack, Stripe, Telegram, Yelp, Zoom, and more.
+Linear, Mailchimp, Notion, Sentry, Slack, Stripe, Telegram, Todoist, Yelp, Zoom, and more.

--- a/src/serviceRegistry.ts
+++ b/src/serviceRegistry.ts
@@ -33,6 +33,7 @@ import {
   GOOGLE_DIRECTIONS,
   COOLIFY,
   UMAMI,
+  TODOIST,
 } from './services/index.js';
 
 export class DuplicateServiceNameError extends Error {
@@ -160,4 +161,5 @@ export const SERVICE_REGISTRY = new ServiceRegistry([
   GOOGLE_DIRECTIONS,
   COOLIFY,
   UMAMI,
+  TODOIST,
 ]);

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -43,3 +43,4 @@ export { GoogleDirections, GOOGLE_DIRECTIONS } from './google/directions.js';
 export { Yelp, YELP } from './yelp.js';
 export { Coolify, COOLIFY } from './coolify.js';
 export { Umami, UMAMI } from './umami.js';
+export { Todoist, TODOIST } from './todoist.js';

--- a/src/services/todoist.ts
+++ b/src/services/todoist.ts
@@ -1,0 +1,95 @@
+/**
+ * Todoist service implementation.
+ */
+
+import type { Response, BrowserContext } from 'playwright';
+import { ApiCredentials, AuthorizationBearer } from '../apiCredentials/base.js';
+import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
+
+const DEFAULT_TIMEOUT_MS = 8000;
+
+// The Developer settings page exposes the user's personal API token. It also
+// doubles as the login URL: when visited while logged out, Todoist redirects to
+// the sign-in page; once the user authenticates, they land back here with the
+// token visible.
+const TODOIST_DEVELOPER_SETTINGS_URL =
+  'https://app.todoist.com/app/settings/integrations/developer';
+
+class TodoistServiceSession extends BrowserFollowupServiceSession {
+  private isLoggedIn = false;
+
+  onResponse(response: Response): void {
+    if (this.isLoggedIn) {
+      return;
+    }
+
+    // Todoist's web app is a SPA that continuously syncs once the user is signed
+    // in. Detect login by observing a successful, authenticated API call (mirrors
+    // the Dropbox session, which watches for an authenticated request).
+    const url = response.request().url();
+    if (
+      !url.startsWith('https://app.todoist.com/api/') &&
+      !url.startsWith('https://api.todoist.com/')
+    ) {
+      return;
+    }
+    if (response.status() !== 200) {
+      return;
+    }
+
+    this.isLoggedIn = true;
+  }
+
+  protected isLoginComplete(): boolean {
+    return this.isLoggedIn;
+  }
+
+  protected async performBrowserFollowup(
+    context: BrowserContext,
+    _oldCredentials?: ApiCredentials
+  ): Promise<ApiCredentials | null> {
+    const page = context.pages()[0];
+    if (!page) {
+      throw new LoginFailedError('No page available in browser context.');
+    }
+
+    await page.goto(TODOIST_DEVELOPER_SETTINGS_URL);
+
+    // The personal API token is shown in a read-only input on the Developer
+    // settings page. Read it directly from the element value (never the
+    // clipboard), the same way other services scrape generated tokens.
+    const tokenInput = page.locator('input[readonly]').first();
+    await tokenInput.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+
+    const token = (await tokenInput.inputValue()).trim();
+    if (token === '') {
+      throw new LoginFailedError('Failed to extract token from Todoist.');
+    }
+
+    await page.close();
+
+    return new AuthorizationBearer(token);
+  }
+}
+
+export class Todoist extends Service {
+  readonly name = 'todoist';
+  readonly displayName = 'Todoist';
+  readonly baseApiUrls = ['https://api.todoist.com/'] as const;
+  readonly loginUrl = TODOIST_DEVELOPER_SETTINGS_URL;
+  readonly info =
+    'https://developer.todoist.com/api/v1. ' +
+    'The personal API token is read from Settings → Integrations → Developer during login.';
+
+  readonly credentialCheckCurlArguments = ['https://api.todoist.com/api/v1/projects'] as const;
+
+  setCredentialsExample(serviceName: string): string {
+    return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  override getSession(appNamePrefix: string): TodoistServiceSession {
+    return new TodoistServiceSession(this, appNamePrefix);
+  }
+}
+
+export const TODOIST = new Todoist();

--- a/tests/serviceRegistry.test.ts
+++ b/tests/serviceRegistry.test.ts
@@ -24,6 +24,7 @@ import {
   GITLAB,
   AWS,
   TELEGRAM,
+  TODOIST,
 } from '../src/services/index.js';
 
 describe('ServiceRegistry', () => {
@@ -44,6 +45,7 @@ describe('ServiceRegistry', () => {
       ['mailchimp', MAILCHIMP],
       ['aws', AWS],
       ['telegram', TELEGRAM],
+      ['todoist', TODOIST],
     ] as const;
 
     for (const [name, service] of namedServices) {
@@ -79,6 +81,7 @@ describe('ServiceRegistry', () => {
       ['https://us1.api.mailchimp.com/3.0/lists', MAILCHIMP],
       ['https://sts.amazonaws.com/?Action=GetCallerIdentity', AWS],
       ['https://s3.us-east-1.amazonaws.com/my-bucket', AWS],
+      ['https://api.todoist.com/api/v1/projects', TODOIST],
     ] as const;
 
     for (const [url, service] of urlMappings) {


### PR DESCRIPTION
## Summary

Adds **Todoist** as a new latchkey service.

- `src/services/todoist.ts` — `Todoist` service + `TodoistServiceSession` (browser followup, modeled on `linear`/`github`/`dropbox`). Login opens the Developer settings page, detects sign-in via an authenticated Todoist API response, then reads the existing personal API token and stores it as `Authorization: Bearer`.
- `baseApiUrls` matches the whole `api.todoist.com` domain; credential check hits `GET /api/v1/projects`.
- Exported from `services/index.ts`, registered as `TODOIST` in `serviceRegistry.ts`.
- Registry name/URL tests added; README "Currently supported services" updated.

The personal API token is available on Todoist's free tier, so the browser flow doesn't require a paid plan.

## Testing

- `npm run typecheck`, `npm run lint` — clean.
- `npm test` — full suite passes (incl. new `serviceRegistry` cases for Todoist).

## Cross-repo note

Fine-grained permission enforcement for Todoist relies on built-in schemas added in the companion **detent** PR (imbue-ai/detent — `todoist-*` schemas). Those need to be released and the `@imbue-ai/detent` dependency bumped before latchkey's permission layer recognizes `todoist-*` rules. The service itself (auth + credential injection) works independently.

> Note: this PR intentionally excludes a local working-tree change that removed the `@imbue-ai/detent` dependency from `package.json` (an `npm link` artifact from local cross-repo testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)