### PR TITLE
Add Todoist to supported services list in latchkey skills

### DIFF
--- a/skills/generic/latchkey/SKILL.md
+++ b/skills/generic/latchkey/SKILL.md
@@ -106,7 +106,7 @@ used to see how to provide credentials for a specific service.
 Latchkey currently offers varying levels of support for the
 following services: AWS, Calendly, Coolify, Discord, Dropbox, Figma, GitHub, GitLab,
 Gmail, Google Analytics, Google Calendar, Google Docs, Google Drive, Google Sheets,
-Linear, Mailchimp, Notion, Sentry, Slack, Stripe, Telegram, Umami, Yelp, Zoom, and more.
+Linear, Mailchimp, Notion, Sentry, Slack, Stripe, Telegram, Todoist, Umami, Yelp, Zoom, and more.
 
 ### User-registered services
 

--- a/skills/openclaw/latchkey/SKILL.md
+++ b/skills/openclaw/latchkey/SKILL.md
@@ -98,7 +98,7 @@ used to see how to provide credentials for a specific service.
 Latchkey currently offers varying levels of support for the
 following services: AWS, Calendly, Coolify, Discord, Dropbox, Figma, GitHub, GitLab,
 Gmail, Google Analytics, Google Calendar, Google Docs, Google Drive, Google Sheets,
-Linear, Mailchimp, Notion, Sentry, Slack, Stripe, Telegram, Umami, Yelp, Zoom, and more.
+Linear, Mailchimp, Notion, Sentry, Slack, Stripe, Telegram, Todoist, Umami, Yelp, Zoom, and more.
 
 ### User-registered services
 


### PR DESCRIPTION
## Summary

Todoist service support already landed in `main` (PR #88, `src/services/todoist.ts`), but the "Currently supported services" list in both latchkey skill files was never updated to mention it.

This PR adds **Todoist** after **Telegram** in both files (which also keeps the list alphabetical):

- `skills/generic/latchkey/SKILL.md`
- `skills/openclaw/latchkey/SKILL.md`

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)