### PR TITLE
Configure the consent screen for reused Google projects

### DIFF
--- a/src/services/google/base.ts
+++ b/src/services/google/base.ts
@@ -345,21 +345,48 @@ interface BrandingResult {
   supportEmail: string;
 }
 
+/**
+ * Configure the OAuth consent screen (branding) for a project.
+ *
+ * Idempotent: returns null when the consent screen is already configured (e.g.
+ * a reused project), so callers can safely invoke it on every run. Google
+ * blocks OAuth-client creation ("you must first configure your consent screen")
+ * until this is done, so it must run before {@link createOAuthClient}.
+ */
 async function configureBranding(
   page: Page,
   projectSlug: string,
   appName: string
-): Promise<BrandingResult> {
+): Promise<BrandingResult | null> {
   await page.goto(`https://console.cloud.google.com/auth/branding?project=${projectSlug}`, {
     timeout: DEFAULT_TIMEOUT_MS,
   });
   const getStartedButton = page.locator('cfc-empty-state-actions .mdc-button__label');
-  await getStartedButton.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
-  await getStartedButton.click();
   const appNameInput = page.locator('input[formcontrolname="displayName"]');
+  // The branding page renders in one of two states: an empty-state "Get
+  // started" CTA when the consent screen hasn't been configured, or the
+  // editable branding form (with the app-name field) when it already has. Wait
+  // for whichever appears; if neither does in time, fall through and treat the
+  // screen as already configured (the CTA visibility check below will be false).
+  try {
+    await getStartedButton.or(appNameInput).first().waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+  } catch {
+    // Neither state materialized in time; let the visibility check below decide.
+  }
+  if (!(await getStartedButton.isVisible())) {
+    // Consent screen already configured — nothing to do.
+    return null;
+  }
+  await getStartedButton.click();
   await appNameInput.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
   await appNameInput.fill(appName);
-  const emailSelector = page.locator('svg[data-icon-name="arrowDropDownIcon"]').nth(0);
+  // Google renders multiple arrowDropDownIcon SVGs on this page, some hidden.
+  // Target the first visible one so waitFor() (which waits for visibility)
+  // doesn't latch onto a hidden element and time out.
+  const emailSelector = page
+    .locator('svg[data-icon-name="arrowDropDownIcon"]')
+    .filter({ visible: true })
+    .first();
   await emailSelector.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
   await emailSelector.click();
   const supportEmailOption = page.locator('mat-option > span:nth-child(1)').first();
@@ -478,11 +505,19 @@ async function createOAuthClient(
   await oauthClientIdOption.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
   await oauthClientIdOption.click();
 
-  const applicationTypeDropdown = page.locator('svg[data-icon-name="arrowDropDownIcon"]').nth(0);
+  // Google renders multiple arrowDropDownIcon SVGs on this page, some hidden.
+  // Target the first visible one so waitFor() (which waits for visibility)
+  // doesn't latch onto a hidden element and time out.
+  const applicationTypeDropdown = page
+    .locator('svg[data-icon-name="arrowDropDownIcon"]')
+    .filter({ visible: true })
+    .first();
   await applicationTypeDropdown.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
   await applicationTypeDropdown.click();
 
-  const desktopAppOption = page.locator('#_1rif_mat-option-5');
+  // Select by visible label rather than an auto-generated Angular Material id
+  // (e.g. "#_1rif_mat-option-5"), which changes between page loads/versions.
+  const desktopAppOption = page.getByRole('option', { name: 'Desktop app' });
   await desktopAppOption.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
   await desktopAppOption.click();
 
@@ -706,26 +741,36 @@ class GoogleServiceSession extends BrowserFollowupServiceSession {
       this.appNamePrefix,
       spinnerPage
     );
+    // Use a deterministic project name (e.g. "Latchkey-gmail") rather than
+    // one with date/random bits: projects are now reused per service, so a
+    // stable name keeps the reuse lookup predictable. Google still derives
+    // a globally-unique project ID from this display name on its own.
+    const appName = `${this.appNamePrefix}${serviceSuffix}`;
+    // Google limits the OAuth project name to 30 characters.
+    if (appName.length > 30) {
+      throw new LoginFailedError(
+        `Generated app name "${appName}" exceeds Google OAuth project name limit of 30 characters.`
+      );
+    }
+
     let projectSlug: string;
     if (existingProjectSlug === null) {
-      // Use a deterministic project name (e.g. "Latchkey-gmail") rather than
-      // one with date/random bits: projects are now reused per service, so a
-      // stable name keeps the reuse lookup predictable. Google still derives
-      // a globally-unique project ID from this display name on its own.
-      const appName = `${this.appNamePrefix}${serviceSuffix}`;
-      // Google limits the OAuth project name to 30 characters.
-      if (appName.length > 30) {
-        throw new LoginFailedError(
-          `Generated app name "${appName}" exceeds Google OAuth project name limit of 30 characters.`
-        );
-      }
       projectSlug = await createProject(page, appName);
-      const { isExternalApp, supportEmail } = await configureBranding(page, projectSlug, appName);
-      if (isExternalApp && supportEmail) {
-        await addTestUser(page, projectSlug, supportEmail);
-      }
     } else {
       projectSlug = existingProjectSlug;
+    }
+
+    // Always make sure the OAuth consent screen (branding) is configured,
+    // whether the project was just created or reused. A reused project may be a
+    // half-configured leftover from an earlier run that crashed before the
+    // consent screen was set up; Google then blocks OAuth-client creation with
+    // "you must first configure your consent screen". configureBranding is
+    // idempotent and returns null when the screen is already configured, in
+    // which case any required test user was already added on the run that set
+    // it up, so there's nothing left to do here.
+    const branding = await configureBranding(page, projectSlug, appName);
+    if (branding && branding.isExternalApp && branding.supportEmail) {
+      await addTestUser(page, projectSlug, branding.supportEmail);
     }
 
     // Always make sure every required API is enabled, whether the project was


### PR DESCRIPTION
## Problem

`latchkey auth browser-prepare google-gmail` failed with a Playwright timeout:

```
locator.waitFor: Timeout 12000ms exceeded.
  - waiting for locator('svg[data-icon-name="arrowDropDownIcon"]').first() to be visible
    6 × locator resolved to hidden <svg ... data-icon-name="arrowDropDownIcon">
  at createOAuthClient (.../services/google/base.js)
```

The cryptic timeout was a symptom. The real state of the page was Google's banner:

> ⚠️ To create an OAuth client ID, you must first configure your consent screen

## Root cause

To respect Google's per-account project cap, `browser-prepare` **reuses** a per-service project (e.g. `Latchkey-gmail`) across runs. But the OAuth consent screen (branding) was only configured on the **new-project** path — the reuse path skipped it entirely.

A project left half-configured by an earlier crashed run therefore never got its consent screen set up. On the next run the project was reused, branding was skipped, and `createOAuthClient` hit Google's wall. Because the banner replaced the form, the application-type dropdown never rendered, so the dropdown-arrow locator matched a *hidden* decorative SVG and timed out.

This mirrors a gap the code already acknowledged: it re-runs `enableApi` on every run to self-heal half-configured leftovers, but did not do the same for branding.

## Fix

- **Always configure the consent screen before creating the OAuth client**, for reused projects too (moved `configureBranding` out of the new-project-only branch).
- **Made `configureBranding` idempotent** — it detects whether the screen is already set up (empty-state "Get started" CTA vs. the populated branding form) and returns `null` (no-op) when it is, so running it on every run is safe. A reused project with a missing consent screen now self-heals.
- **Hardened two brittle selectors** on the OAuth-client page (cleanup in the same area):
  - Filter the `arrowDropDownIcon` dropdown arrow to the **visible** element (Google renders several, some hidden).
  - Select the **"Desktop app"** option by visible label instead of the auto-generated Angular id `#_1rif_mat-option-5`, which changes between page versions.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run build` — all clean.
- `npm test` — 547 passed, 2 skipped, 1 todo.
- **Verified end-to-end:** `latchkey auth browser-prepare google-gmail` now completes successfully against a previously-stuck reused project (it self-healed the missing consent screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
