### PR TITLE
Version 2.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "latchkey",
-  "version": "2.19.1",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "latchkey",
-      "version": "2.19.1",
+      "version": "2.20.0",
       "license": "MIT",
       "dependencies": {
         "@imbue-ai/detent": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "latchkey",
-  "version": "2.19.1",
+  "version": "2.20.0",
   "description": "A CLI tool that injects API credentials into curl requests to third-party services",
   "author": "Imbue <hynek@imbue.com>",
   "repository": {

--- a/src/curlInjection.ts
+++ b/src/curlInjection.ts
@@ -17,6 +17,7 @@ import { CurlParseError, extractUrlFromCurlArguments } from './curl.js';
 import { parseCurlArgs } from '@imbue-ai/detent';
 import { ErrorMessages } from './errorMessages.js';
 import type { ServiceRegistry } from './serviceRegistry.js';
+import type { Service } from './services/core/base.js';
 
 export class RequestNotPermittedError extends Error {
   constructor() {
@@ -143,21 +144,48 @@ export async function prepareCurlInvocation(
     throw new UrlExtractionFailedError();
   }
 
-  const service = dependencies.registry.getByUrl(url);
-  if (service === null) {
+  // A single URL can match several services when an API is shared (e.g. the
+  // Google Drive files API is used by Drive, Docs, and Sheets). Pick the
+  // matching service that actually has usable credentials, preferring one
+  // whose credentials are not expired so we avoid unnecessary refreshes and
+  // network round-trips. Registration order breaks ties, which lets the
+  // canonical owner win when it too has usable credentials.
+  const candidates = dependencies.registry.getCandidatesByUrl(url);
+  const firstCandidate = candidates[0];
+  if (firstCandidate === undefined) {
     if (dependencies.passthroughUnknown) {
       return [...curlArguments];
     }
     throw new NoServiceForUrlError(url);
   }
 
-  let apiCredentials: ApiCredentials | null = apiCredentialStore.get(service.name);
-  if (apiCredentials === null) {
+  let selection: { service: Service; apiCredentials: ApiCredentials } | null = null;
+  let fallbackWithCredentials: { service: Service; apiCredentials: ApiCredentials } | null = null;
+  for (const candidate of candidates) {
+    const candidateCredentials = apiCredentialStore.get(candidate.name);
+    if (candidateCredentials === null) {
+      continue;
+    }
+    fallbackWithCredentials ??= { service: candidate, apiCredentials: candidateCredentials };
+    if (candidateCredentials.isExpired() !== true) {
+      selection = { service: candidate, apiCredentials: candidateCredentials };
+      break;
+    }
+  }
+
+  // Fall back to the first candidate that has credentials at all (they may be
+  // expired and refreshable below). If nothing has credentials, report against
+  // the first matching service for a sensible error message.
+  const chosen = selection ?? fallbackWithCredentials;
+  if (chosen === null) {
     if (dependencies.passthroughUnknown) {
       return [...curlArguments];
     }
-    throw new NoCredentialsForServiceError(service.name);
+    throw new NoCredentialsForServiceError(firstCandidate.name);
   }
+
+  const service = chosen.service;
+  let apiCredentials: ApiCredentials = chosen.apiCredentials;
 
   if (apiCredentials.isExpired() === true) {
     apiCredentials = await maybeRefreshCredentials(

--- a/src/serviceRegistry.ts
+++ b/src/serviceRegistry.ts
@@ -117,6 +117,17 @@ export class ServiceRegistry {
   getCandidatesByUrl(url: string): readonly Service[] {
     return this._services.filter((service) => this.matchesUrl(service, url));
   }
+
+  /**
+   * The primary (first-registered) service matching a URL, or null if none do.
+   *
+   * The injection pipeline uses {@link getCandidatesByUrl} to consider every
+   * match and disambiguate by credential availability; this remains as a
+   * convenience for SDK consumers that just want the canonical owner.
+   */
+  getByUrl(url: string): Service | null {
+    return this.getCandidatesByUrl(url)[0] ?? null;
+  }
 }
 
 export function loadRegisteredServicesIntoServiceRegistry(

--- a/src/serviceRegistry.ts
+++ b/src/serviceRegistry.ts
@@ -90,21 +90,32 @@ export class ServiceRegistry {
     return null;
   }
 
-  getByUrl(url: string): Service | null {
-    for (const service of this._services) {
-      for (const baseApiUrl of service.baseApiUrls) {
-        if (typeof baseApiUrl === 'string') {
-          if (url.startsWith(baseApiUrl)) {
-            return service;
-          }
-        } else {
-          if (baseApiUrl.test(url)) {
-            return service;
-          }
+  private matchesUrl(service: Service, url: string): boolean {
+    for (const baseApiUrl of service.baseApiUrls) {
+      if (typeof baseApiUrl === 'string') {
+        if (url.startsWith(baseApiUrl)) {
+          return true;
+        }
+      } else {
+        if (baseApiUrl.test(url)) {
+          return true;
         }
       }
     }
-    return null;
+    return false;
+  }
+
+  /**
+   * Return every service whose base API URLs match the given URL, in
+   * registration order.
+   *
+   * Some APIs are shared across services (e.g. the Google Drive files API is
+   * used by Drive, Docs, and Sheets), so a single URL can legitimately match
+   * more than one service. Callers disambiguate by picking the candidate that
+   * actually has usable credentials.
+   */
+  getCandidatesByUrl(url: string): readonly Service[] {
+    return this._services.filter((service) => this.matchesUrl(service, url));
   }
 }
 

--- a/src/services/dropbox.ts
+++ b/src/services/dropbox.ts
@@ -2,7 +2,7 @@
  * Dropbox service implementation.
  */
 
-import type { Response, BrowserContext } from 'playwright';
+import type { Response, BrowserContext, Page } from 'playwright';
 import { ApiCredentials, AuthorizationBearer } from '../apiCredentials/base.js';
 import { typeLikeHuman } from '../playwrightUtils.js';
 import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
@@ -42,6 +42,25 @@ class DropboxServiceSession extends BrowserFollowupServiceSession {
     return this.isLoggedIn;
   }
 
+  /**
+   * When more than one account is linked, Dropbox asks which account should own
+   * the app before enabling the "Create app" button. Pick the work account if
+   * one is available, otherwise fall back to the personal account.
+   */
+  private async selectOwningAccount(page: Page): Promise<void> {
+    const workAccount = page.locator('input#company[name="_subject_uid"]');
+    const personalAccount = page.locator('input#personal[name="_subject_uid"]');
+
+    if ((await workAccount.count()) > 0) {
+      await workAccount.check();
+      return;
+    }
+
+    if ((await personalAccount.count()) > 0) {
+      await personalAccount.check();
+    }
+  }
+
   protected async performBrowserFollowup(
     context: BrowserContext,
     _oldCredentials?: ApiCredentials
@@ -66,7 +85,11 @@ class DropboxServiceSession extends BrowserFollowupServiceSession {
     await appNameInput.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
     await typeLikeHuman(page, appNameInput, appName);
 
-    const createButton = page.locator('//*[@id="create-button" and not(@disabled)]');
+    await this.selectOwningAccount(page);
+
+    const createButton = page.locator(
+      '//button[@id="create-button" and @type="submit" and not(@disabled)]'
+    );
     await createButton.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
     await createButton.click();
 

--- a/src/services/dropbox.ts
+++ b/src/services/dropbox.ts
@@ -31,11 +31,16 @@ const TOKEN_ENDPOINT = 'https://api.dropboxapi.com/oauth2/token';
 // Scopes enabled on the created app. The same list is requested during
 // authorization so the resulting token carries exactly these permissions.
 const DROPBOX_SCOPES = [
+  'account_info.read',
   'files.metadata.write',
+  'files.metadata.read',
   'files.content.write',
   'files.content.read',
+  'sharing.read',
   'sharing.write',
+  'file_requests.read',
   'file_requests.write',
+  'contacts.read',
   'contacts.write',
 ] as const;
 

--- a/src/services/dropbox.ts
+++ b/src/services/dropbox.ts
@@ -220,6 +220,10 @@ class DropboxServiceSession extends BrowserFollowupServiceSession {
       authorizeUrl.searchParams.set('code_challenge_method', 'S256');
       authorizeUrl.searchParams.set('scope', DROPBOX_SCOPES.join(' '));
 
+      // The finalize spinner runs in a separate tab that is kept in the
+      // foreground. Bring the working page forward so the user can actually see
+      // and confirm the authorization dialog.
+      await page.bringToFront();
       await page.goto(authorizeUrl.toString());
 
       const code = await codePromise;

--- a/src/services/dropbox.ts
+++ b/src/services/dropbox.ts
@@ -3,11 +3,44 @@
  */
 
 import type { Response, BrowserContext, Page } from 'playwright';
-import { ApiCredentials, AuthorizationBearer } from '../apiCredentials/base.js';
+import { ApiCredentials, OAuthCredentials } from '../apiCredentials/base.js';
 import { typeLikeHuman } from '../playwrightUtils.js';
-import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
+import {
+  exchangeCodeForTokens,
+  generateCodeChallenge,
+  generateCodeVerifier,
+  refreshAccessToken,
+  startOAuthCallbackServer,
+} from '../oauthUtils.js';
+import {
+  Service,
+  BrowserFollowupServiceSession,
+  LoginFailedError,
+  isBrowserClosedError,
+  LoginCancelledError,
+} from './core/base.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
+
+// Dropbox deprecated non-expiring tokens, so we run the authorization-code flow
+// with PKCE and `token_access_type=offline` to obtain a refresh token instead
+// of relying on the app console's short-lived "Generate token" button.
+const AUTHORIZE_ENDPOINT = 'https://www.dropbox.com/oauth2/authorize';
+const TOKEN_ENDPOINT = 'https://api.dropboxapi.com/oauth2/token';
+
+// Scopes enabled on the created app. The same list is requested during
+// authorization so the resulting token carries exactly these permissions.
+const DROPBOX_SCOPES = [
+  'files.metadata.write',
+  'files.content.write',
+  'files.content.read',
+  'sharing.write',
+  'file_requests.write',
+  'contacts.write',
+] as const;
+
+// Time allowed for the user to approve the authorization request in the browser.
+const AUTHORIZATION_TIMEOUT_MS = 120000;
 
 class DropboxServiceSession extends BrowserFollowupServiceSession {
   private isLoggedIn = false;
@@ -112,22 +145,13 @@ class DropboxServiceSession extends BrowserFollowupServiceSession {
       timeout: DEFAULT_TIMEOUT_MS,
     });
 
-    // Configure permissions before generating token
+    // Configure permissions before authorizing
     const permissionsTab = page.locator('a.c-tabs__label[data-hash="permissions"]');
     await permissionsTab.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
     await permissionsTab.click();
 
     // Enable all necessary permissions
-    const permissionIds = [
-      'files.metadata.write',
-      'files.content.write',
-      'files.content.read',
-      'sharing.write',
-      'file_requests.write',
-      'contacts.write',
-    ];
-
-    for (const permissionId of permissionIds) {
+    for (const permissionId of DROPBOX_SCOPES) {
       const escapedPermissionId = permissionId.replace(/\./g, '\\.');
       const checkbox = page.locator(`input#${escapedPermissionId}`);
       await checkbox.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
@@ -142,26 +166,105 @@ class DropboxServiceSession extends BrowserFollowupServiceSession {
     // Wait for permissions to be saved
     await page.waitForTimeout(512);
 
-    // Return to Settings tab to generate token
+    // Return to Settings tab to read the app key and register the redirect URI
     const settingsTab = page.locator('a.c-tabs__label[data-hash="settings"]');
     await settingsTab.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
     await settingsTab.click();
 
-    const generateButton = page.locator('input#generate-token-button');
-    await generateButton.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
-    await generateButton.click();
-
-    const tokenInput = page.locator('input#generated-token[data-token]');
-    await tokenInput.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
-
-    const token = await tokenInput.getAttribute('data-token');
-    if (token === null || token === '') {
-      throw new LoginFailedError('Failed to extract token from Dropbox.');
+    const appKeyLocator = page.locator('.app-key');
+    await appKeyLocator.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+    const appKey = (await appKeyLocator.textContent())?.trim();
+    if (!appKey) {
+      throw new LoginFailedError('Failed to read Dropbox app key.');
     }
 
-    await page.close();
+    return await this.authorizeApp(page, appKey);
+  }
 
-    return new AuthorizationBearer(token);
+  /**
+   * Run the authorization-code + PKCE flow against the freshly created app to
+   * obtain a refresh token. The redirect URI is registered on the app first
+   * because Dropbox requires it to match the authorization request exactly.
+   */
+  private async authorizeApp(page: Page, appKey: string): Promise<ApiCredentials> {
+    const abortController = new AbortController();
+    const closeHandler = () => {
+      abortController.abort();
+    };
+    page.on('close', closeHandler);
+    page.context().on('close', closeHandler);
+
+    try {
+      const { port, codePromise } = await startOAuthCallbackServer(
+        AUTHORIZATION_TIMEOUT_MS,
+        abortController.signal
+      );
+      const redirectUri = `http://localhost:${port.toString()}/oauth2callback`;
+
+      await this.registerRedirectUri(page, redirectUri);
+
+      const codeVerifier = generateCodeVerifier();
+      const codeChallenge = generateCodeChallenge(codeVerifier);
+
+      const authorizeUrl = new URL(AUTHORIZE_ENDPOINT);
+      authorizeUrl.searchParams.set('client_id', appKey);
+      authorizeUrl.searchParams.set('response_type', 'code');
+      authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+      authorizeUrl.searchParams.set('token_access_type', 'offline');
+      authorizeUrl.searchParams.set('code_challenge', codeChallenge);
+      authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+      authorizeUrl.searchParams.set('scope', DROPBOX_SCOPES.join(' '));
+
+      await page.goto(authorizeUrl.toString());
+
+      const code = await codePromise;
+
+      const tokens = exchangeCodeForTokens(
+        TOKEN_ENDPOINT,
+        code,
+        appKey,
+        '', // public client using PKCE, no secret
+        redirectUri,
+        codeVerifier
+      );
+
+      const accessTokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString();
+
+      await page.close();
+
+      return new OAuthCredentials(
+        appKey,
+        '', // public client, no secret stored
+        tokens.access_token,
+        tokens.refresh_token,
+        accessTokenExpiresAt
+      );
+    } catch (error: unknown) {
+      if (error instanceof Error && isBrowserClosedError(error)) {
+        throw new LoginCancelledError();
+      }
+      throw error;
+    } finally {
+      page.off('close', closeHandler);
+      page.context().off('close', closeHandler);
+    }
+  }
+
+  /**
+   * Register the localhost redirect URI on the app's OAuth 2 settings so the
+   * subsequent authorization request is accepted.
+   */
+  private async registerRedirectUri(page: Page, redirectUri: string): Promise<void> {
+    const redirectUriInput = page.locator('#oauth-add-uri-form input[name="oauth_uri"]');
+    await redirectUriInput.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+    await typeLikeHuman(page, redirectUriInput, redirectUri);
+
+    const addButton = page.locator('#oauth-add-uri-form input[type="submit"]:not([disabled])');
+    await addButton.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+    await addButton.click();
+
+    // Wait for the redirect URI to be saved before navigating away.
+    await page.waitForTimeout(512);
   }
 }
 
@@ -194,6 +297,36 @@ export class Dropbox extends Service {
 
   override getSession(appNamePrefix: string): DropboxServiceSession {
     return new DropboxServiceSession(this, appNamePrefix);
+  }
+
+  override refreshCredentials(apiCredentials: ApiCredentials): Promise<ApiCredentials | null> {
+    if (!(apiCredentials instanceof OAuthCredentials) || !apiCredentials.refreshToken) {
+      return Promise.resolve(null);
+    }
+
+    const tokens = refreshAccessToken(
+      TOKEN_ENDPOINT,
+      apiCredentials.refreshToken,
+      apiCredentials.clientId,
+      apiCredentials.clientSecret
+    );
+
+    if (tokens === null) {
+      return Promise.resolve(null);
+    }
+
+    const accessTokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString();
+
+    return Promise.resolve(
+      new OAuthCredentials(
+        apiCredentials.clientId,
+        apiCredentials.clientSecret,
+        tokens.access_token,
+        tokens.refresh_token ?? apiCredentials.refreshToken,
+        accessTokenExpiresAt,
+        apiCredentials.refreshTokenExpiresAt
+      )
+    );
   }
 }
 

--- a/src/services/dropbox.ts
+++ b/src/services/dropbox.ts
@@ -43,10 +43,7 @@ const DROPBOX_SCOPES = [
   'contacts.read',
   'contacts.write',
 ] as const;
-const IMPLICITLY_GRANTED_SCOPES = [
-   'account_info.read',
-   'files.metadata.read',
-] as const;
+const IMPLICITLY_GRANTED_SCOPES = ['account_info.read', 'files.metadata.read'] as const;
 
 // Time allowed for the user to approve the authorization request in the browser.
 const AUTHORIZATION_TIMEOUT_MS = 120000;

--- a/src/services/dropbox.ts
+++ b/src/services/dropbox.ts
@@ -43,6 +43,10 @@ const DROPBOX_SCOPES = [
   'contacts.read',
   'contacts.write',
 ] as const;
+const IMPLICITLY_GRANTED_SCOPES = [
+   'account_info.read',
+   'files.metadata.read',
+] as const;
 
 // Time allowed for the user to approve the authorization request in the browser.
 const AUTHORIZATION_TIMEOUT_MS = 120000;
@@ -157,6 +161,13 @@ class DropboxServiceSession extends BrowserFollowupServiceSession {
 
     // Enable all necessary permissions
     for (const permissionId of DROPBOX_SCOPES) {
+      if (
+        IMPLICITLY_GRANTED_SCOPES.includes(
+          permissionId as (typeof IMPLICITLY_GRANTED_SCOPES)[number]
+        )
+      ) {
+        continue;
+      }
       const escapedPermissionId = permissionId.replace(/\./g, '\\.');
       const checkbox = page.locator(`input#${escapedPermissionId}`);
       await checkbox.waitFor({ timeout: DEFAULT_TIMEOUT_MS });

--- a/src/services/dropbox.ts
+++ b/src/services/dropbox.ts
@@ -11,6 +11,7 @@ const DEFAULT_TIMEOUT_MS = 8000;
 
 class DropboxServiceSession extends BrowserFollowupServiceSession {
   private isLoggedIn = false;
+  private currentAccountUid?: string;
 
   onResponse(response: Response): void {
     if (this.isLoggedIn) {
@@ -35,6 +36,9 @@ class DropboxServiceSession extends BrowserFollowupServiceSession {
       return;
     }
 
+    // Remember the currently active account so the app can be created under the
+    // account the user is actually logged in as when several are linked.
+    this.currentAccountUid = uidHeader;
     this.isLoggedIn = true;
   }
 
@@ -44,10 +48,21 @@ class DropboxServiceSession extends BrowserFollowupServiceSession {
 
   /**
    * When more than one account is linked, Dropbox asks which account should own
-   * the app before enabling the "Create app" button. Pick the work account if
-   * one is available, otherwise fall back to the personal account.
+   * the app before enabling the "Create app" button. Prefer the account the
+   * user is currently logged in as, then the work account, then the personal
+   * account.
    */
   private async selectOwningAccount(page: Page): Promise<void> {
+    if (this.currentAccountUid !== undefined) {
+      const currentAccount = page.locator(
+        `input[name="_subject_uid"][value="${this.currentAccountUid}"]`
+      );
+      if ((await currentAccount.count()) > 0) {
+        await currentAccount.check();
+        return;
+      }
+    }
+
     const workAccount = page.locator('input#company[name="_subject_uid"]');
     const personalAccount = page.locator('input#personal[name="_subject_uid"]');
 

--- a/src/services/google/docs.ts
+++ b/src/services/google/docs.ts
@@ -11,7 +11,14 @@ const CONFIG: GoogleServiceConfig = {
 export class GoogleDocs extends GoogleService {
   readonly name = 'google-docs';
   readonly displayName = 'Google Docs';
-  readonly baseApiUrls = ['https://docs.googleapis.com/'] as const;
+  // Docs workflows also reach into the Drive files API to find, read, and
+  // export documents, so match that subset of the Drive API too. The routing
+  // layer resolves the overlap with Google Drive by preferring whichever
+  // matching service has usable credentials.
+  readonly baseApiUrls = [
+    'https://docs.googleapis.com/',
+    /^https:\/\/www\.googleapis\.com\/drive\/v\d+\/files\b/,
+  ] as const;
   readonly info =
     'https://developers.google.com/docs/api/reference/rest. ' +
     'If needed, run "latchkey auth browser-prepare google-docs" to create an OAuth client first. ' +

--- a/src/services/google/sheets.ts
+++ b/src/services/google/sheets.ts
@@ -11,7 +11,14 @@ const CONFIG: GoogleServiceConfig = {
 export class GoogleSheets extends GoogleService {
   readonly name = 'google-sheets';
   readonly displayName = 'Google Sheets';
-  readonly baseApiUrls = ['https://sheets.googleapis.com/'] as const;
+  // Sheets workflows also reach into the Drive files API to find, read, and
+  // export spreadsheets, so match that subset of the Drive API too. The
+  // routing layer resolves the overlap with Google Drive by preferring
+  // whichever matching service has usable credentials.
+  readonly baseApiUrls = [
+    'https://sheets.googleapis.com/',
+    /^https:\/\/www\.googleapis\.com\/drive\/v\d+\/files\b/,
+  ] as const;
   readonly info =
     'https://developers.google.com/sheets/api/reference/rest. ' +
     'If needed, run "latchkey auth browser-prepare google-sheets" to create an OAuth client first. ' +

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // Auto-generated from package.json by scripts/generateVersion.js.
 // Do not edit by hand; run `node scripts/generateVersion.js` to refresh.
-export const VERSION = "2.19.1";
+export const VERSION = "2.20.0";

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -22,6 +22,8 @@ import {
 } from '../src/gateway/permissionsOverride.js';
 import { TELEGRAM } from '../src/services/telegram.js';
 import { GOOGLE_GMAIL } from '../src/services/google/gmail.js';
+import { GOOGLE_DRIVE } from '../src/services/google/drive.js';
+import { GOOGLE_DOCS } from '../src/services/google/docs.js';
 import {
   deleteRegisteredService,
   loadRegisteredServices,
@@ -1391,6 +1393,116 @@ describe('CLI commands with dependency injection', () => {
       expect(errorLogs.length).toBeGreaterThan(0);
     });
 
+    it('should route a shared Drive files call to the Docs service when only Docs is authed', async () => {
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(
+        storePath,
+        JSON.stringify({
+          'google-docs': {
+            objectType: 'oauth',
+            clientId: 'cid',
+            clientSecret: 'csecret',
+            accessToken: 'docs-token',
+          },
+        })
+      );
+
+      const deps = createMockDependencies({
+        registry: new ServiceRegistry([GOOGLE_DRIVE, GOOGLE_DOCS]),
+      });
+
+      await runCommand(['curl', 'https://www.googleapis.com/drive/v3/files?pageSize=1'], deps);
+
+      expect(exitCode).toBe(0);
+      expect(capturedArgs).toContain('Authorization: Bearer docs-token');
+    });
+
+    it('should prefer the canonical Drive service for a shared Drive files call when both are authed', async () => {
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(
+        storePath,
+        JSON.stringify({
+          'google-drive': {
+            objectType: 'oauth',
+            clientId: 'cid',
+            clientSecret: 'csecret',
+            accessToken: 'drive-token',
+          },
+          'google-docs': {
+            objectType: 'oauth',
+            clientId: 'cid',
+            clientSecret: 'csecret',
+            accessToken: 'docs-token',
+          },
+        })
+      );
+
+      const deps = createMockDependencies({
+        registry: new ServiceRegistry([GOOGLE_DRIVE, GOOGLE_DOCS]),
+      });
+
+      await runCommand(['curl', 'https://www.googleapis.com/drive/v3/files?pageSize=1'], deps);
+
+      expect(exitCode).toBe(0);
+      expect(capturedArgs).toContain('Authorization: Bearer drive-token');
+    });
+
+    it('should skip an expired candidate in favor of one with unexpired credentials', async () => {
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(
+        storePath,
+        JSON.stringify({
+          'google-drive': {
+            objectType: 'oauth',
+            clientId: 'cid',
+            clientSecret: 'csecret',
+            accessToken: 'drive-token',
+            accessTokenExpiresAt: '2000-01-01T00:00:00.000Z',
+          },
+          'google-docs': {
+            objectType: 'oauth',
+            clientId: 'cid',
+            clientSecret: 'csecret',
+            accessToken: 'docs-token',
+          },
+        })
+      );
+
+      const deps = createMockDependencies({
+        registry: new ServiceRegistry([GOOGLE_DRIVE, GOOGLE_DOCS]),
+        config: createMockConfig({ credentialsRefreshDisabled: true }),
+      });
+
+      await runCommand(['curl', 'https://www.googleapis.com/drive/v3/files?pageSize=1'], deps);
+
+      expect(exitCode).toBe(0);
+      expect(capturedArgs).toContain('Authorization: Bearer docs-token');
+    });
+
+    it('should not route a non-files Drive call to the Docs service', async () => {
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(
+        storePath,
+        JSON.stringify({
+          'google-docs': {
+            objectType: 'oauth',
+            clientId: 'cid',
+            clientSecret: 'csecret',
+            accessToken: 'docs-token',
+          },
+        })
+      );
+
+      const deps = createMockDependencies({
+        registry: new ServiceRegistry([GOOGLE_DRIVE, GOOGLE_DOCS]),
+      });
+
+      await runCommand(['curl', 'https://www.googleapis.com/drive/v3/about?fields=user'], deps);
+
+      expect(exitCode).toBe(1);
+      expect(errorLogs.some((line) => line.includes('google-drive'))).toBe(true);
+    });
+
     it('should pass through unknown service when passthroughUnknown is enabled', async () => {
       const deps = createMockDependencies({
         config: createMockConfig({ passthroughUnknown: true }),
@@ -1720,7 +1832,9 @@ describe('CLI commands with dependency injection', () => {
       expect(deps.registry.getByName('my-gitlab')).not.toBeNull();
 
       // Should be findable by URL
-      expect(deps.registry.getByUrl('https://gitlab.mycompany.com/api/v4/user')).not.toBeNull();
+      expect(
+        deps.registry.getCandidatesByUrl('https://gitlab.mycompany.com/api/v4/user')
+      ).not.toHaveLength(0);
     });
 
     it('should persist registration to config.json', async () => {
@@ -2014,7 +2128,9 @@ describe('CLI commands with dependency injection', () => {
       expect(deps.registry.getByName('my-api')).not.toBeNull();
 
       // Should be findable by URL
-      expect(deps.registry.getByUrl('https://api.example.com/v1/users')).not.toBeNull();
+      expect(
+        deps.registry.getCandidatesByUrl('https://api.example.com/v1/users')
+      ).not.toHaveLength(0);
     });
 
     it('should persist registration without service family to config.json', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2128,9 +2128,9 @@ describe('CLI commands with dependency injection', () => {
       expect(deps.registry.getByName('my-api')).not.toBeNull();
 
       // Should be findable by URL
-      expect(
-        deps.registry.getCandidatesByUrl('https://api.example.com/v1/users')
-      ).not.toHaveLength(0);
+      expect(deps.registry.getCandidatesByUrl('https://api.example.com/v1/users')).not.toHaveLength(
+        0
+      );
     });
 
     it('should persist registration without service family to config.json', async () => {

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -6,34 +6,33 @@ import {
 } from '../src/services/github.js';
 import { AuthorizationBearer, RawCurlCredentials } from '../src/apiCredentials/base.js';
 import { SERVICE_REGISTRY } from '../src/serviceRegistry.js';
+import type { Service } from '../src/services/core/base.js';
+
+function primaryServiceForUrl(url: string): Service | null {
+  return SERVICE_REGISTRY.getCandidatesByUrl(url)[0] ?? null;
+}
 
 describe('Github URL matching', () => {
   it('matches the REST API host', () => {
-    expect(SERVICE_REGISTRY.getByUrl('https://api.github.com/user')).toBe(GITHUB);
-    expect(SERVICE_REGISTRY.getByUrl('https://uploads.github.com/anything')).toBe(GITHUB);
+    expect(primaryServiceForUrl('https://api.github.com/user')).toBe(GITHUB);
+    expect(primaryServiceForUrl('https://uploads.github.com/anything')).toBe(GITHUB);
   });
 
   it('matches git smart-HTTP operation URLs', () => {
     expect(
-      SERVICE_REGISTRY.getByUrl(
-        'https://github.com/owner/repo.git/info/refs?service=git-upload-pack'
-      )
+      primaryServiceForUrl('https://github.com/owner/repo.git/info/refs?service=git-upload-pack')
     ).toBe(GITHUB);
-    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo/info/refs')).toBe(GITHUB);
-    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo.git/git-upload-pack')).toBe(
-      GITHUB
-    );
-    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo/git-receive-pack')).toBe(
-      GITHUB
-    );
+    expect(primaryServiceForUrl('https://github.com/owner/repo/info/refs')).toBe(GITHUB);
+    expect(primaryServiceForUrl('https://github.com/owner/repo.git/git-upload-pack')).toBe(GITHUB);
+    expect(primaryServiceForUrl('https://github.com/owner/repo/git-receive-pack')).toBe(GITHUB);
   });
 
   it('does not match repository web pages or website routes', () => {
-    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo')).toBeNull();
-    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo/issues/1')).toBeNull();
-    expect(SERVICE_REGISTRY.getByUrl('https://github.com/settings/tokens')).toBeNull();
-    expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner')).toBeNull();
-    expect(SERVICE_REGISTRY.getByUrl('https://example.com/owner/repo.git/info/refs')).toBeNull();
+    expect(primaryServiceForUrl('https://github.com/owner/repo')).toBeNull();
+    expect(primaryServiceForUrl('https://github.com/owner/repo/issues/1')).toBeNull();
+    expect(primaryServiceForUrl('https://github.com/settings/tokens')).toBeNull();
+    expect(primaryServiceForUrl('https://github.com/owner')).toBeNull();
+    expect(primaryServiceForUrl('https://example.com/owner/repo.git/info/refs')).toBeNull();
   });
 });
 

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -9,7 +9,7 @@ import { SERVICE_REGISTRY } from '../src/serviceRegistry.js';
 import type { Service } from '../src/services/core/base.js';
 
 function primaryServiceForUrl(url: string): Service | null {
-  return SERVICE_REGISTRY.getCandidatesByUrl(url)[0] ?? null;
+  return SERVICE_REGISTRY.getByUrl(url);
 }
 
 describe('Github URL matching', () => {

--- a/tests/serviceRegistry.test.ts
+++ b/tests/serviceRegistry.test.ts
@@ -34,7 +34,7 @@ import type { Service } from '../src/services/core/base.js';
  * injection pipeline treats registration order as the tie-breaker.
  */
 function primaryServiceForUrl(registry: ServiceRegistry, url: string): Service | null {
-  return registry.getCandidatesByUrl(url)[0] ?? null;
+  return registry.getByUrl(url);
 }
 
 describe('ServiceRegistry', () => {

--- a/tests/serviceRegistry.test.ts
+++ b/tests/serviceRegistry.test.ts
@@ -27,6 +27,15 @@ import {
   RAMP,
   TODOIST,
 } from '../src/services/index.js';
+import type { Service } from '../src/services/core/base.js';
+
+/**
+ * The primary (first-registered) service that matches a URL. Mirrors how the
+ * injection pipeline treats registration order as the tie-breaker.
+ */
+function primaryServiceForUrl(registry: ServiceRegistry, url: string): Service | null {
+  return registry.getCandidatesByUrl(url)[0] ?? null;
+}
 
 describe('ServiceRegistry', () => {
   describe('getByName', () => {
@@ -65,7 +74,7 @@ describe('ServiceRegistry', () => {
     });
   });
 
-  describe('getByUrl', () => {
+  describe('primary service resolution', () => {
     const urlMappings = [
       ['https://slack.com/api/auth.test', SLACK],
       ['https://discord.com/api/v9/users/@me', DISCORD],
@@ -89,32 +98,59 @@ describe('ServiceRegistry', () => {
 
     for (const [url, service] of urlMappings) {
       it(`should find ${service.name} by URL ${url}`, () => {
-        expect(SERVICE_REGISTRY.getByUrl(url)).toBe(service);
+        expect(primaryServiceForUrl(SERVICE_REGISTRY, url)).toBe(service);
       });
     }
 
     it('should return null for unknown URL', () => {
-      expect(SERVICE_REGISTRY.getByUrl('https://example.com/api')).toBeNull();
+      expect(primaryServiceForUrl(SERVICE_REGISTRY, 'https://example.com/api')).toBeNull();
     });
 
     it('should not match partial URLs', () => {
-      expect(SERVICE_REGISTRY.getByUrl('https://slack.com/')).toBeNull();
+      expect(primaryServiceForUrl(SERVICE_REGISTRY, 'https://slack.com/')).toBeNull();
     });
 
     it('should match GitHub git smart-HTTP operation URLs', () => {
       expect(
-        SERVICE_REGISTRY.getByUrl(
+        primaryServiceForUrl(
+          SERVICE_REGISTRY,
           'https://github.com/owner/repo.git/info/refs?service=git-upload-pack'
         )
       ).toBe(GITHUB);
-      expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo/git-upload-pack')).toBe(
-        GITHUB
-      );
+      expect(
+        primaryServiceForUrl(SERVICE_REGISTRY, 'https://github.com/owner/repo/git-upload-pack')
+      ).toBe(GITHUB);
     });
 
     it('should not match GitHub web pages as git operations', () => {
-      expect(SERVICE_REGISTRY.getByUrl('https://github.com/owner/repo')).toBeNull();
-      expect(SERVICE_REGISTRY.getByUrl('https://github.com/settings/tokens')).toBeNull();
+      expect(primaryServiceForUrl(SERVICE_REGISTRY, 'https://github.com/owner/repo')).toBeNull();
+      expect(
+        primaryServiceForUrl(SERVICE_REGISTRY, 'https://github.com/settings/tokens')
+      ).toBeNull();
+    });
+  });
+
+  describe('getCandidatesByUrl', () => {
+    it('should return every service matching a shared Drive files URL', () => {
+      const candidates = SERVICE_REGISTRY.getCandidatesByUrl(
+        'https://www.googleapis.com/drive/v3/files?pageSize=1'
+      );
+      expect(candidates).toContain(GOOGLE_DRIVE);
+      expect(candidates).toContain(GOOGLE_DOCS);
+      expect(candidates).toContain(GOOGLE_SHEETS);
+      // Drive is the canonical owner and is registered first, so it wins ties.
+      expect(candidates[0]).toBe(GOOGLE_DRIVE);
+    });
+
+    it('should only match Drive itself for non-files Drive URLs', () => {
+      const candidates = SERVICE_REGISTRY.getCandidatesByUrl(
+        'https://www.googleapis.com/drive/v3/about?fields=user'
+      );
+      expect(candidates).toEqual([GOOGLE_DRIVE]);
+    });
+
+    it('should return an empty list for unknown URLs', () => {
+      expect(SERVICE_REGISTRY.getCandidatesByUrl('https://example.com/api')).toEqual([]);
     });
   });
 
@@ -148,7 +184,9 @@ describe('ServiceRegistry', () => {
       registry.addService(registered);
 
       expect(registry.getByName('my-gitlab')).toBe(registered);
-      expect(registry.getByUrl('https://gitlab.mycompany.com/api/v4/user')).toBe(registered);
+      expect(primaryServiceForUrl(registry, 'https://gitlab.mycompany.com/api/v4/user')).toBe(
+        registered
+      );
     });
 
     it('should throw DuplicateServiceNameError for existing built-in name', () => {


### PR DESCRIPTION
- Fix Dropbox browser login when an additional account is linked to the primary one.
- Use OAuth with Dropbox so that we can repeatedly refresh tokens. (Previously, only 4h access tokens were generated.)
- Improve the logic for shared APIs (like Google's drive API which is also used by Google Docs and Google Sheets).