### PR TITLE
Add support for multiple accounts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,13 @@ account (including everything migrated from older Latchkey
 versions) live under a "default" account and are used whenever
 `--account` is not given.
 
+Browser logins (`latchkey auth browser`) determine the account
+automatically: after the login completes, Latchkey asks the
+service which account the fresh credentials belong to (usually
+via the same request used for credential checks) and stores them
+under that account. Running the login again with a different
+user adds a second account instead of overwriting the first.
+
 
 ### Self-hosted services
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ versions) live under a "default" account and are used whenever
 Browser logins (`latchkey auth browser`) determine the account
 automatically: after the login completes, Latchkey asks the
 service which account the fresh credentials belong to (usually
-via the same request used for credential checks) and stores them
+via an identity-revealing API endpoint) and stores them
 under that account. Running the login again with a different
 user adds a second account instead of overwriting the first.
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,22 @@ via the same request used for credential checks) and stores them
 under that account. Running the login again with a different
 user adds a second account instead of overwriting the first.
 
+Some services need to be prepared before the first browser login
+(`latchkey auth prepare` or `latchkey auth browser-prepare`),
+typically to set up an OAuth client. Preparations are stored per
+service (not per account) and are reused by every subsequent
+login, so several accounts can share one prepared client. When
+no preparation is stored, `latchkey auth browser` can instead
+borrow the client from an already logged-in account:
+
+```bash
+latchkey --account hynek@imbue.com auth browser google-gmail
+```
+
+This reuses the OAuth client stored with `hynek@imbue.com`'s
+credentials while the resulting login is stored under whichever
+account you actually sign in as.
+
 
 ### Self-hosted services
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,33 @@ code, stdout and stderr are passed back from curl to the caller
 of `latchkey`.
 
 
+### Multiple accounts
+
+Credentials for a service can be stored under several *accounts*.
+An account is a string that uniquely identifies the account
+behind the credentials — typically an e-mail, but for some
+services it may be an id. Use the global `--account` option to
+select one:
+
+```bash
+# Store credentials for a specific account.
+latchkey --account hynek@imbue.com auth set slack -H "Authorization: Bearer xoxb-..."
+
+# Use them in a request.
+latchkey --account hynek@imbue.com curl https://slack.com/api/auth.test
+
+# Clear just that account's credentials.
+latchkey --account hynek@imbue.com auth clear slack
+```
+
+When `--account` is omitted, the single stored account is used
+automatically. If a service has more than one stored account,
+`--account` becomes required. Credentials stored without an
+account (including everything migrated from older Latchkey
+versions) live under a "default" account and are used whenever
+`--account` is not given.
+
+
 ### Self-hosted services
 
 For services that can be self-hosted, like GitLab, first make Latchkey aware of your service instance:

--- a/README.md
+++ b/README.md
@@ -254,13 +254,16 @@ calls.
 ### Inspecting the status of stored credentials
 
 Calling `latchkey services info <service_name>` will show information
-about the service, including the credentials status. The
-credentials status line will show one of:
+about the service, including a `credentials` object keyed by account
+(the default account uses the empty string). Each entry mirrors the
+`latchkey auth list` format and reports a credentials status of:
 
-- `missing`
 - `invalid`
 - `valid`
 - `unknown` (for user-registered services)
+
+A service with no stored credentials shows an empty `credentials`
+object.
 
 ### Clearing credentials
 

--- a/README.md
+++ b/README.md
@@ -164,55 +164,30 @@ of `latchkey`.
 
 ### Multiple accounts
 
-Credentials for a service can be stored under several *accounts*.
+Credentials for a service can be stored under several accounts.
 An account is a string that uniquely identifies the account
-behind the credentials — typically an e-mail, but for some
+behind the credentials - typically an e-mail, but for some
 services it may be an id. Use the global `--account` option to
 select one:
 
 ```bash
 # Store credentials for a specific account.
-latchkey --account hynek@imbue.com auth set slack -H "Authorization: Bearer xoxb-..."
+latchkey --account bob@example.com auth set slack -H "Authorization: Bearer xoxb-..."
 
 # Use them in a request.
-latchkey --account hynek@imbue.com curl https://slack.com/api/auth.test
-
-# Clear just that account's credentials.
-latchkey --account hynek@imbue.com auth clear slack
+latchkey --account bob@example.com curl https://slack.com/api/auth.test
 ```
 
 When `--account` is omitted, the single stored account is used
 automatically. If a service has more than one stored account,
 `--account` becomes required. Credentials stored without an
-account (including everything migrated from older Latchkey
-versions) live under a "default" account and are used whenever
-`--account` is not given.
+account live under a "default" account (empty string, `""`).
 
 Browser logins (`latchkey auth browser`) determine the account
-automatically: after the login completes, Latchkey asks the
-service which account the fresh credentials belong to (usually
-via an identity-revealing API endpoint) and stores them
-under that account. Running the login again with a different
-user adds a second account instead of overwriting the first.
-
-Some services need to be prepared before the first browser login
-(`latchkey auth prepare` or `latchkey auth browser-prepare`),
-typically to set up an OAuth client. Preparations are stored per
-service (not per account) and are reused by every subsequent
-login, so several accounts can share one prepared client. To
-remove a service's preparation along with all of its accounts,
-run `latchkey auth clear <service_name> --all`. When
-no preparation is stored, `latchkey auth browser` can instead
-borrow the client from an already logged-in account:
-
-```bash
-latchkey --account hynek@imbue.com auth browser google-gmail
-```
-
-This reuses the OAuth client stored with `hynek@imbue.com`'s
-credentials while the resulting login is stored under whichever
-account you actually sign in as.
-
+automatically. The `--account` option here merely allows users
+to specify which existing OAuth client configuration to use for
+the login (selecting one associated with an existing account) if
+needed.
 
 ### Self-hosted services
 
@@ -278,10 +253,10 @@ calls.
 
 ### Inspecting the status of stored credentials
 
-Calling `latchkey services info <service_name>` will show information
-about the service, including a `credentials` object keyed by account
-(the default account uses the empty string). Each entry mirrors the
-`latchkey auth list` format and reports a credentials status of:
+Calling `latchkey services info <service_name>` will show
+information about the service, including a `credentials` object
+keyed by account (the default account uses the empty string).
+Each entry reports a credentials status of:
 
 - `invalid`
 - `valid`

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ Some services need to be prepared before the first browser login
 (`latchkey auth prepare` or `latchkey auth browser-prepare`),
 typically to set up an OAuth client. Preparations are stored per
 service (not per account) and are reused by every subsequent
-login, so several accounts can share one prepared client. When
+login, so several accounts can share one prepared client. To
+remove a service's preparation along with all of its accounts,
+run `latchkey auth clear <service_name> --all`. When
 no preparation is stored, `latchkey auth browser` can instead
 borrow the client from an already logged-in account:
 

--- a/skills/generic/latchkey/SKILL.md
+++ b/skills/generic/latchkey/SKILL.md
@@ -109,9 +109,11 @@ And then reference it in curl calls:
 latchkey --account alice@example.com curl ...
 ```
 
-You can see the accounts as keys in the credential dictionary
-produced by `latchkey services info`. An empty string means
-an "unknown account".
+The `--account` option must go right after `latchkey`.
+
+You can see the existing accounts as keys in the credential
+dictionary produced by `latchkey services info`. An empty string
+in the key means "unknown account".
 
 
 ## Notes

--- a/skills/generic/latchkey/SKILL.md
+++ b/skills/generic/latchkey/SKILL.md
@@ -95,6 +95,25 @@ credentials yet. `latchkey service info <service_name>` can be
 used to see how to provide credentials for a specific service.
 
 
+## Using multiple accounts
+
+It is possible to associate credentials with a specific account:
+
+```bash
+latchkey --account alice@example.com auth set ...
+```
+
+And then reference it in curl calls:
+
+```bash
+latchkey --account alice@example.com curl ...
+```
+
+You can see the accounts as keys in the credential dictionary
+produced by `latchkey services info`. An empty string means
+an "unknown account".
+
+
 ## Notes
 
 - All curl arguments are passed through unchanged

--- a/skills/openclaw/latchkey/SKILL.md
+++ b/skills/openclaw/latchkey/SKILL.md
@@ -87,6 +87,27 @@ credentials yet. `latchkey service info <service_name>` can be
 used to see how to provide credentials for a specific service.
 
 
+## Using multiple accounts
+
+It is possible to associate credentials with a specific account:
+
+```bash
+latchkey --account alice@example.com auth set ...
+```
+
+And then reference it in curl calls:
+
+```bash
+latchkey --account alice@example.com curl ...
+```
+
+The `--account` option must go right after `latchkey`.
+
+You can see the existing accounts as keys in the credential
+dictionary produced by `latchkey services info`. An empty string
+in the key means "unknown account".
+
+
 ## Notes
 
 - All curl arguments are passed through unchanged

--- a/src/apiCredentials/account.ts
+++ b/src/apiCredentials/account.ts
@@ -18,8 +18,8 @@ export const DEFAULT_ACCOUNT = '';
 
 /**
  * Parse a JSON response body, returning null instead of throwing on malformed
- * input. Credential-check bodies come from arbitrary servers, so account
- * parsing must never crash on unexpected content.
+ * input. Response bodies come from arbitrary servers, so account parsing must
+ * never crash on unexpected content.
  */
 export function tryParseJson(body: string): unknown {
   try {
@@ -30,17 +30,15 @@ export function tryParseJson(body: string): unknown {
 }
 
 /**
- * Fetch the account behind the given credentials from a dedicated endpoint,
- * best-effort: returns null when the credentials cannot be injected or when
- * the parser finds no identity in the response. Used by services whose
- * credential-check endpoint carries no identity but that have a separate
- * endpoint revealing it — a response that reveals the account also proves the
- * credentials valid, so those services try this before the plain check.
+ * Fetch the account behind the given credentials from an identity-revealing
+ * endpoint, best-effort: returns null when the credentials cannot be injected
+ * or when the parser finds no identity in the response body. The shared
+ * implementation behind the services' `getAccount()`.
  */
 export async function fetchAccountFromEndpoint(
   apiCredentials: ApiCredentials,
   accountCurlArguments: readonly string[],
-  parseAccount: (responseData: unknown) => string | null
+  parseAccount: (responseBody: string) => string | null
 ): Promise<string | null> {
   let curlArguments: readonly string[];
   try {
@@ -52,5 +50,5 @@ export async function fetchAccountFromEndpoint(
     throw error;
   }
   const result = runCaptured(curlArguments, 10);
-  return parseAccount(tryParseJson(result.stdout));
+  return parseAccount(result.stdout);
 }

--- a/src/apiCredentials/account.ts
+++ b/src/apiCredentials/account.ts
@@ -1,14 +1,56 @@
 /**
- * Account identifiers for stored credentials.
+ * Account identifiers for stored credentials, and helpers for determining the
+ * account behind a set of credentials.
  *
  * An account is a string that uniquely identifies the account behind a set of
  * credentials (typically an e-mail, sometimes an opaque id). The empty string
  * denotes the "default" account.
  *
- * This lives in its own leaf module (with no other imports) so that service
- * implementations can reference the default account without importing the
- * credential store, which would create an import cycle
+ * This module must not import the credential store or any service module, so
+ * that service implementations can use it without creating an import cycle
  * (store -> serialization -> service -> core/base -> store).
  */
 
+import { type ApiCredentials, ApiCredentialsUsageError } from './base.js';
+import { runCaptured } from '../curl.js';
+
 export const DEFAULT_ACCOUNT = '';
+
+/**
+ * Parse a JSON response body, returning null instead of throwing on malformed
+ * input. Credential-check bodies come from arbitrary servers, so account
+ * parsing must never crash on unexpected content.
+ */
+export function tryParseJson(body: string): unknown {
+  try {
+    return JSON.parse(body);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch the account behind the given credentials from a dedicated endpoint,
+ * best-effort: returns null when the credentials cannot be injected or when
+ * the parser finds no identity in the response. Used by services whose
+ * credential-check endpoint carries no identity but that have a separate
+ * endpoint revealing it — a response that reveals the account also proves the
+ * credentials valid, so those services try this before the plain check.
+ */
+export async function fetchAccountFromEndpoint(
+  apiCredentials: ApiCredentials,
+  accountCurlArguments: readonly string[],
+  parseAccount: (responseData: unknown) => string | null
+): Promise<string | null> {
+  let curlArguments: readonly string[];
+  try {
+    curlArguments = await apiCredentials.injectIntoCurlCall(['-s', ...accountCurlArguments]);
+  } catch (error) {
+    if (error instanceof ApiCredentialsUsageError) {
+      return null;
+    }
+    throw error;
+  }
+  const result = runCaptured(curlArguments, 10);
+  return parseAccount(tryParseJson(result.stdout));
+}

--- a/src/apiCredentials/account.ts
+++ b/src/apiCredentials/account.ts
@@ -1,0 +1,14 @@
+/**
+ * Account identifiers for stored credentials.
+ *
+ * An account is a string that uniquely identifies the account behind a set of
+ * credentials (typically an e-mail, sometimes an opaque id). The empty string
+ * denotes the "default" account.
+ *
+ * This lives in its own leaf module (with no other imports) so that service
+ * implementations can reference the default account without importing the
+ * credential store, which would create an import cycle
+ * (store -> serialization -> service -> core/base -> store).
+ */
+
+export const DEFAULT_ACCOUNT = '';

--- a/src/apiCredentials/store.ts
+++ b/src/apiCredentials/store.ts
@@ -1,16 +1,22 @@
 /**
  * API credential store for persisting and loading API credentials.
  *
- * On disk, credentials are stored per service and, within each service, per
- * account. An account is a string that uniquely identifies the account behind
- * the credentials (typically an e-mail, sometimes an opaque id). The empty
- * string denotes the "default" account, which is what pre-multi-account data
- * is migrated into.
+ * The store has two top-level sections:
  *
- * All read/write methods accept an optional account. When it is omitted the
- * account is resolved from the data itself: the single stored account is used,
- * or an {@link AmbiguousAccountError} is raised when several accounts exist and
- * the caller must disambiguate.
+ * - "credentials": complete credentials, stored per service and, within each
+ *   service, per account. An account is a string that uniquely identifies the
+ *   account behind the credentials (typically an e-mail, sometimes an opaque
+ *   id). The empty string denotes the "default" account (when we don't know
+ *   anything more).
+ * - "preparations": prepared / incomplete credentials (e.g. an OAuth client
+ *   id and secret created by `auth prepare` or `auth browser-prepare`),
+ *   stored per service only. A service has at most one preparation; storing a
+ *   new one overwrites the previous one.
+ *
+ * All credential read/write methods accept an optional account. When it is
+ * omitted the account is resolved from the data itself: the single stored
+ * account is used, or an {@link AmbiguousAccountError} is raised when several
+ * accounts exist and the caller must disambiguate.
  */
 
 import { DEFAULT_ACCOUNT } from './account.js';
@@ -49,8 +55,12 @@ export class AmbiguousAccountError extends Error {
   }
 }
 
-// service name -> account -> serialized credentials
-type StoreData = Record<string, Record<string, unknown>>;
+interface StoreData {
+  // service name -> account -> serialized credentials
+  credentials: Record<string, Record<string, unknown>>;
+  // service name -> serialized prepared (incomplete) credentials
+  preparations: Record<string, unknown>;
+}
 
 export class ApiCredentialStore {
   readonly path: string;
@@ -65,9 +75,13 @@ export class ApiCredentialStore {
     try {
       const content = this.encryptedStorage.readFile(this.path);
       if (content === null) {
-        return {};
+        return { credentials: {}, preparations: {} };
       }
-      return JSON.parse(content) as StoreData;
+      const parsed = JSON.parse(content) as Partial<StoreData>;
+      return {
+        credentials: parsed.credentials ?? {},
+        preparations: parsed.preparations ?? {},
+      };
     } catch (error) {
       throw new ApiCredentialStoreError(
         `Failed to read credential store: ${error instanceof Error ? error.message : String(error)}`
@@ -112,7 +126,7 @@ export class ApiCredentialStore {
 
   get(serviceName: string, account?: string): ApiCredentials | null {
     const data = this.loadStoreData();
-    const serviceData = data[serviceName];
+    const serviceData = data.credentials[serviceName];
     const accounts = serviceData === undefined ? [] : Object.keys(serviceData);
     const resolvedAccount = account ?? this.resolveImplicitAccount(serviceName, accounts);
     if (resolvedAccount === null) {
@@ -127,14 +141,40 @@ export class ApiCredentialStore {
 
   save(serviceName: string, apiCredentials: ApiCredentials, account?: string): void {
     const data = this.loadStoreData();
-    const serviceData = data[serviceName] ?? {};
+    const serviceData = data.credentials[serviceName] ?? {};
     const accounts = Object.keys(serviceData);
     // A brand-new service with no account specified defaults to the default
     // account; otherwise an unspecified account updates the single existing one
     // (and raises for ambiguity), keeping writes consistent with reads.
     const resolvedAccount =
       account ?? this.resolveImplicitAccount(serviceName, accounts) ?? DEFAULT_ACCOUNT;
-    data[serviceName] = { ...serviceData, [resolvedAccount]: serializeCredentials(apiCredentials) };
+    data.credentials[serviceName] = {
+      ...serviceData,
+      [resolvedAccount]: serializeCredentials(apiCredentials),
+    };
+    this.saveStoreData(data);
+  }
+
+  /**
+   * Return the prepared (incomplete) credentials stored for a service, or null
+   * when the service has no preparation.
+   */
+  getPreparation(serviceName: string): ApiCredentials | null {
+    const data = this.loadStoreData();
+    const preparationData = data.preparations[serviceName];
+    if (preparationData === undefined) {
+      return null;
+    }
+    return this.parseCredentials(serviceName, preparationData);
+  }
+
+  /**
+   * Store prepared (incomplete) credentials for a service, overwriting any
+   * previous preparation for that service.
+   */
+  savePreparation(serviceName: string, apiCredentials: ApiCredentials): void {
+    const data = this.loadStoreData();
+    data.preparations[serviceName] = serializeCredentials(apiCredentials);
     this.saveStoreData(data);
   }
 
@@ -145,7 +185,7 @@ export class ApiCredentialStore {
    */
   listAccounts(serviceName: string): readonly string[] {
     const data = this.loadStoreData();
-    const serviceData = data[serviceName];
+    const serviceData = data.credentials[serviceName];
     return serviceData === undefined ? [] : Object.keys(serviceData);
   }
 
@@ -156,7 +196,7 @@ export class ApiCredentialStore {
   getAll(): ReadonlyMap<string, ReadonlyMap<string, ApiCredentials>> {
     const data = this.loadStoreData();
     const result = new Map<string, ReadonlyMap<string, ApiCredentials>>();
-    for (const [serviceName, serviceData] of Object.entries(data)) {
+    for (const [serviceName, serviceData] of Object.entries(data.credentials)) {
       const accountMap = new Map<string, ApiCredentials>();
       for (const [account, credentialData] of Object.entries(serviceData)) {
         accountMap.set(account, this.parseCredentials(serviceName, credentialData));
@@ -169,29 +209,42 @@ export class ApiCredentialStore {
   /**
    * Delete stored credentials for the given account (resolving an unspecified
    * account the same way reads do). If that leaves the service with no
-   * accounts, the service entry is removed entirely. Returns whether anything
-   * was deleted.
+   * accounts, the service entry is removed entirely. When no account is
+   * specified, the service's preparation (if any) is deleted as well. Returns
+   * whether anything was deleted.
    */
   delete(serviceName: string, account?: string): boolean {
     const data = this.loadStoreData();
-    const serviceData = data[serviceName];
-    if (serviceData === undefined) {
-      return false;
-    }
+    const serviceData = data.credentials[serviceName] ?? {};
     const accounts = Object.keys(serviceData);
+    // May throw AmbiguousAccountError, in which case nothing is deleted.
     const resolvedAccount = account ?? this.resolveImplicitAccount(serviceName, accounts);
-    if (resolvedAccount === null || !(resolvedAccount in serviceData)) {
-      return false;
+
+    const credentialsDeleted = resolvedAccount !== null && resolvedAccount in serviceData;
+    let credentials = data.credentials;
+    if (credentialsDeleted) {
+      const { [resolvedAccount]: _, ...remainingAccounts } = serviceData;
+      if (Object.keys(remainingAccounts).length === 0) {
+        const { [serviceName]: __, ...remainingServices } = credentials;
+        credentials = remainingServices;
+      } else {
+        credentials = { ...credentials, [serviceName]: remainingAccounts };
+      }
     }
 
-    const { [resolvedAccount]: _, ...remainingAccounts } = serviceData;
-    if (Object.keys(remainingAccounts).length === 0) {
-      const { [serviceName]: __, ...rest } = data;
-      this.saveStoreData(rest);
-    } else {
-      data[serviceName] = remainingAccounts;
-      this.saveStoreData(data);
+    // Without an explicit account the caller means "clear this service", which
+    // includes any prepared credentials.
+    const preparationDeleted = account === undefined && serviceName in data.preparations;
+    let preparations = data.preparations;
+    if (preparationDeleted) {
+      const { [serviceName]: _, ...remainingPreparations } = preparations;
+      preparations = remainingPreparations;
     }
+
+    if (!credentialsDeleted && !preparationDeleted) {
+      return false;
+    }
+    this.saveStoreData({ credentials, preparations });
     return true;
   }
 }

--- a/src/apiCredentials/store.ts
+++ b/src/apiCredentials/store.ts
@@ -13,6 +13,7 @@
  * the caller must disambiguate.
  */
 
+import { DEFAULT_ACCOUNT } from './account.js';
 import type { ApiCredentials } from './base.js';
 import {
   ApiCredentialsSchema,
@@ -47,11 +48,6 @@ export class AmbiguousAccountError extends Error {
     this.accounts = accounts;
   }
 }
-
-/**
- * The account key used when no account is specified.
- */
-export const DEFAULT_ACCOUNT = '';
 
 // service name -> account -> serialized credentials
 type StoreData = Record<string, Record<string, unknown>>;

--- a/src/apiCredentials/store.ts
+++ b/src/apiCredentials/store.ts
@@ -209,42 +209,48 @@ export class ApiCredentialStore {
   /**
    * Delete stored credentials for the given account (resolving an unspecified
    * account the same way reads do). If that leaves the service with no
-   * accounts, the service entry is removed entirely. When no account is
-   * specified, the service's preparation (if any) is deleted as well. Returns
-   * whether anything was deleted.
+   * accounts, the service entry is removed entirely. Preparations are never
+   * touched; use {@link deleteAll} for that. Returns whether anything was
+   * deleted.
    */
   delete(serviceName: string, account?: string): boolean {
     const data = this.loadStoreData();
-    const serviceData = data.credentials[serviceName] ?? {};
-    const accounts = Object.keys(serviceData);
-    // May throw AmbiguousAccountError, in which case nothing is deleted.
-    const resolvedAccount = account ?? this.resolveImplicitAccount(serviceName, accounts);
-
-    const credentialsDeleted = resolvedAccount !== null && resolvedAccount in serviceData;
-    let credentials = data.credentials;
-    if (credentialsDeleted) {
-      const { [resolvedAccount]: _, ...remainingAccounts } = serviceData;
-      if (Object.keys(remainingAccounts).length === 0) {
-        const { [serviceName]: __, ...remainingServices } = credentials;
-        credentials = remainingServices;
-      } else {
-        credentials = { ...credentials, [serviceName]: remainingAccounts };
-      }
-    }
-
-    // Without an explicit account the caller means "clear this service", which
-    // includes any prepared credentials.
-    const preparationDeleted = account === undefined && serviceName in data.preparations;
-    let preparations = data.preparations;
-    if (preparationDeleted) {
-      const { [serviceName]: _, ...remainingPreparations } = preparations;
-      preparations = remainingPreparations;
-    }
-
-    if (!credentialsDeleted && !preparationDeleted) {
+    const serviceData = data.credentials[serviceName];
+    if (serviceData === undefined) {
       return false;
     }
-    this.saveStoreData({ credentials, preparations });
+    const accounts = Object.keys(serviceData);
+    const resolvedAccount = account ?? this.resolveImplicitAccount(serviceName, accounts);
+    if (resolvedAccount === null || !(resolvedAccount in serviceData)) {
+      return false;
+    }
+
+    const { [resolvedAccount]: _, ...remainingAccounts } = serviceData;
+    if (Object.keys(remainingAccounts).length === 0) {
+      const { [serviceName]: __, ...remainingServices } = data.credentials;
+      this.saveStoreData({ ...data, credentials: remainingServices });
+    } else {
+      this.saveStoreData({
+        ...data,
+        credentials: { ...data.credentials, [serviceName]: remainingAccounts },
+      });
+    }
+    return true;
+  }
+
+  /**
+   * Delete everything stored for a service: the credentials of all its
+   * accounts as well as its preparation (if any). Returns whether anything
+   * was deleted.
+   */
+  deleteAll(serviceName: string): boolean {
+    const data = this.loadStoreData();
+    if (!(serviceName in data.credentials) && !(serviceName in data.preparations)) {
+      return false;
+    }
+    const { [serviceName]: _, ...remainingServices } = data.credentials;
+    const { [serviceName]: __, ...remainingPreparations } = data.preparations;
+    this.saveStoreData({ credentials: remainingServices, preparations: remainingPreparations });
     return true;
   }
 }

--- a/src/apiCredentials/store.ts
+++ b/src/apiCredentials/store.ts
@@ -1,5 +1,16 @@
 /**
  * API credential store for persisting and loading API credentials.
+ *
+ * On disk, credentials are stored per service and, within each service, per
+ * account. An account is a string that uniquely identifies the account behind
+ * the credentials (typically an e-mail, sometimes an opaque id). The empty
+ * string denotes the "default" account, which is what pre-multi-account data
+ * is migrated into.
+ *
+ * All read/write methods accept an optional account. When it is omitted the
+ * account is resolved from the data itself: the single stored account is used,
+ * or an {@link AmbiguousAccountError} is raised when several accounts exist and
+ * the caller must disambiguate.
  */
 
 import type { ApiCredentials } from './base.js';
@@ -17,7 +28,33 @@ export class ApiCredentialStoreError extends Error {
   }
 }
 
-type StoreData = Record<string, unknown>;
+/**
+ * Thrown when a service has more than one account stored and no account was
+ * specified to disambiguate between them.
+ */
+export class AmbiguousAccountError extends Error {
+  readonly serviceName: string;
+  readonly accounts: readonly string[];
+
+  constructor(serviceName: string, accounts: readonly string[]) {
+    super(
+      `Multiple accounts are stored for service '${serviceName}': ` +
+        `${accounts.map((account) => `'${account}'`).join(', ')}. ` +
+        'Specify which one to use with --account.'
+    );
+    this.name = 'AmbiguousAccountError';
+    this.serviceName = serviceName;
+    this.accounts = accounts;
+  }
+}
+
+/**
+ * The account key used when no account is specified.
+ */
+export const DEFAULT_ACCOUNT = '';
+
+// service name -> account -> serialized credentials
+type StoreData = Record<string, Record<string, unknown>>;
 
 export class ApiCredentialStore {
   readonly path: string;
@@ -52,51 +89,113 @@ export class ApiCredentialStore {
     }
   }
 
-  get(serviceName: string): ApiCredentials | null {
-    const data = this.loadStoreData();
-    const credentialData = data[serviceName];
-    if (credentialData === undefined) {
-      return null;
-    }
-
+  private parseCredentials(serviceName: string, credentialData: unknown): ApiCredentials {
     const parseResult = ApiCredentialsSchema.safeParse(credentialData);
     if (!parseResult.success) {
       throw new ApiCredentialStoreError(
         `Invalid credential data for service ${serviceName}: ${parseResult.error.message}`
       );
     }
-
     return deserializeCredentials(parseResult.data);
   }
 
-  save(serviceName: string, apiCredentials: ApiCredentials): void {
+  /**
+   * Resolve which stored account to operate on when the caller did not name
+   * one. Returns null when the service has no stored accounts. Throws
+   * {@link AmbiguousAccountError} when several accounts exist.
+   */
+  private resolveImplicitAccount(serviceName: string, accounts: readonly string[]): string | null {
+    if (accounts.length === 0) {
+      return null;
+    }
+    if (accounts.length === 1) {
+      return accounts[0]!;
+    }
+    throw new AmbiguousAccountError(serviceName, accounts);
+  }
+
+  get(serviceName: string, account?: string): ApiCredentials | null {
     const data = this.loadStoreData();
-    data[serviceName] = serializeCredentials(apiCredentials);
+    const serviceData = data[serviceName];
+    const accounts = serviceData === undefined ? [] : Object.keys(serviceData);
+    const resolvedAccount = account ?? this.resolveImplicitAccount(serviceName, accounts);
+    if (resolvedAccount === null) {
+      return null;
+    }
+    const credentialData = serviceData?.[resolvedAccount];
+    if (credentialData === undefined) {
+      return null;
+    }
+    return this.parseCredentials(serviceName, credentialData);
+  }
+
+  save(serviceName: string, apiCredentials: ApiCredentials, account?: string): void {
+    const data = this.loadStoreData();
+    const serviceData = data[serviceName] ?? {};
+    const accounts = Object.keys(serviceData);
+    // A brand-new service with no account specified defaults to the default
+    // account; otherwise an unspecified account updates the single existing one
+    // (and raises for ambiguity), keeping writes consistent with reads.
+    const resolvedAccount =
+      account ?? this.resolveImplicitAccount(serviceName, accounts) ?? DEFAULT_ACCOUNT;
+    data[serviceName] = { ...serviceData, [resolvedAccount]: serializeCredentials(apiCredentials) };
     this.saveStoreData(data);
   }
 
-  getAll(): ReadonlyMap<string, ApiCredentials> {
+  /**
+   * List the accounts that have credentials stored for a service, in the order
+   * they appear in the store. Returns an empty array when the service has no
+   * stored credentials.
+   */
+  listAccounts(serviceName: string): readonly string[] {
     const data = this.loadStoreData();
-    const result = new Map<string, ApiCredentials>();
-    for (const [serviceName, credentialData] of Object.entries(data)) {
-      const parseResult = ApiCredentialsSchema.safeParse(credentialData);
-      if (!parseResult.success) {
-        throw new ApiCredentialStoreError(
-          `Invalid credential data for service ${serviceName}: ${parseResult.error.message}`
-        );
+    const serviceData = data[serviceName];
+    return serviceData === undefined ? [] : Object.keys(serviceData);
+  }
+
+  /**
+   * Return all stored credentials as a map of service name to a map of account
+   * to credentials.
+   */
+  getAll(): ReadonlyMap<string, ReadonlyMap<string, ApiCredentials>> {
+    const data = this.loadStoreData();
+    const result = new Map<string, ReadonlyMap<string, ApiCredentials>>();
+    for (const [serviceName, serviceData] of Object.entries(data)) {
+      const accountMap = new Map<string, ApiCredentials>();
+      for (const [account, credentialData] of Object.entries(serviceData)) {
+        accountMap.set(account, this.parseCredentials(serviceName, credentialData));
       }
-      result.set(serviceName, deserializeCredentials(parseResult.data));
+      result.set(serviceName, accountMap);
     }
     return result;
   }
 
-  delete(serviceName: string): boolean {
+  /**
+   * Delete stored credentials for the given account (resolving an unspecified
+   * account the same way reads do). If that leaves the service with no
+   * accounts, the service entry is removed entirely. Returns whether anything
+   * was deleted.
+   */
+  delete(serviceName: string, account?: string): boolean {
     const data = this.loadStoreData();
-    if (!(serviceName in data)) {
+    const serviceData = data[serviceName];
+    if (serviceData === undefined) {
       return false;
     }
-    const { [serviceName]: _, ...rest } = data;
-    this.saveStoreData(rest);
+    const accounts = Object.keys(serviceData);
+    const resolvedAccount = account ?? this.resolveImplicitAccount(serviceName, accounts);
+    if (resolvedAccount === null || !(resolvedAccount in serviceData)) {
+      return false;
+    }
+
+    const { [resolvedAccount]: _, ...remainingAccounts } = serviceData;
+    if (Object.keys(remainingAccounts).length === 0) {
+      const { [serviceName]: __, ...rest } = data;
+      this.saveStoreData(rest);
+    } else {
+      data[serviceName] = remainingAccounts;
+      this.saveStoreData(data);
+    }
     return true;
   }
 }

--- a/src/apiCredentials/utils.ts
+++ b/src/apiCredentials/utils.ts
@@ -55,5 +55,5 @@ export async function getCredentialStatus(
     disableRefresh,
     account
   );
-  return await service.checkApiCredentials(refreshed);
+  return (await service.checkApiCredentials(refreshed)).status;
 }

--- a/src/apiCredentials/utils.ts
+++ b/src/apiCredentials/utils.ts
@@ -55,5 +55,5 @@ export async function getCredentialStatus(
     disableRefresh,
     account
   );
-  return (await service.checkApiCredentials(refreshed)).status;
+  return service.checkApiCredentials(refreshed);
 }

--- a/src/apiCredentials/utils.ts
+++ b/src/apiCredentials/utils.ts
@@ -18,14 +18,15 @@ export async function maybeRefreshCredentials(
   service: Service,
   apiCredentials: ApiCredentials,
   apiCredentialStore: ApiCredentialStore,
-  disableRefresh = false
+  disableRefresh = false,
+  account?: string
 ): Promise<ApiCredentials> {
   if (disableRefresh || apiCredentials.isExpired() !== true || !service.refreshCredentials) {
     return apiCredentials;
   }
   const refreshedCredentials = await service.refreshCredentials(apiCredentials);
   if (refreshedCredentials !== null) {
-    apiCredentialStore.save(service.name, refreshedCredentials);
+    apiCredentialStore.save(service.name, refreshedCredentials, account);
     return refreshedCredentials;
   }
   return apiCredentials;
@@ -36,7 +37,8 @@ export async function getCredentialStatus(
   credentials: ApiCredentials | null,
   apiCredentialStore: ApiCredentialStore,
   disableRefresh = false,
-  offline = false
+  offline = false,
+  account?: string
 ): Promise<ApiCredentialStatus> {
   if (credentials === null) {
     return ApiCredentialStatus.Missing;
@@ -50,7 +52,8 @@ export async function getCredentialStatus(
     service,
     credentials,
     apiCredentialStore,
-    disableRefresh
+    disableRefresh,
+    account
   );
   return await service.checkApiCredentials(refreshed);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,7 +53,7 @@ if (!gatewayMode) {
       accountName: deps.config.accountName,
       allowKeyGeneration: !hasEncryptedData,
     });
-    runMigrations(deps.config, new EncryptedStorage(encryptionKey));
+    await runMigrations(deps.config, new EncryptedStorage(encryptionKey));
   } catch (error) {
     if (error instanceof KeychainTimeoutError) {
       console.error(`Error: ${error.message}`);

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -264,7 +264,8 @@ async function createEncryptedStorageFromConfig(config: Config): Promise<Encrypt
 async function clearService(
   deps: CliDependencies,
   serviceName: string,
-  account: string | undefined
+  account: string | undefined,
+  all: boolean
 ): Promise<void> {
   const service = deps.registry.getByName(serviceName);
   if (service === null) {
@@ -281,7 +282,9 @@ async function clearService(
 
   let deleted: boolean;
   try {
-    deleted = apiCredentialStore.delete(serviceName, account);
+    deleted = all
+      ? apiCredentialStore.deleteAll(serviceName)
+      : apiCredentialStore.delete(serviceName, account);
   } catch (error) {
     if (error instanceof AmbiguousAccountError) {
       deps.errorLog(`Error: ${error.message}`);
@@ -557,12 +560,25 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
     .description('Clear stored API credentials.')
     .argument('[service_name]', 'Name of the service to clear API credentials for')
     .option('-y, --yes', 'Skip confirmation prompt when clearing all data')
-    .action(async (serviceName: string | undefined, options: { yes?: boolean }) => {
+    .option(
+      '--all',
+      "Clear all of the service's accounts as well as its preparation (if any)"
+    )
+    .action(async (serviceName: string | undefined, options: { yes?: boolean; all?: boolean }) => {
       refuseInGatewayMode(deps, 'auth clear');
+      const all = options.all ?? false;
+      if (all && serviceName === undefined) {
+        deps.errorLog('Error: --all requires a service name.');
+        deps.exit(1);
+      }
+      if (all && getAccount() !== undefined) {
+        deps.errorLog('Error: --all cannot be combined with --account.');
+        deps.exit(1);
+      }
       if (serviceName === undefined) {
         await clearAll(deps, options.yes ?? false);
       } else {
-        await clearService(deps, serviceName, getAccount());
+        await clearService(deps, serviceName, getAccount(), all);
       }
     });
 

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -6,7 +6,11 @@ import type { Command } from 'commander';
 import { existsSync, statSync, unlinkSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { createInterface } from 'node:readline';
-import { ApiCredentialStore, ApiCredentialStoreError } from './apiCredentials/store.js';
+import {
+  AmbiguousAccountError,
+  ApiCredentialStore,
+  ApiCredentialStoreError,
+} from './apiCredentials/store.js';
 import {
   ApiCredentials,
   ApiCredentialsUsageError,
@@ -256,7 +260,11 @@ async function createEncryptedStorageFromConfig(config: Config): Promise<Encrypt
   return new EncryptedStorage(key);
 }
 
-async function clearService(deps: CliDependencies, serviceName: string): Promise<void> {
+async function clearService(
+  deps: CliDependencies,
+  serviceName: string,
+  account: string | undefined
+): Promise<void> {
   const service = deps.registry.getByName(serviceName);
   if (service === null) {
     deps.errorLog(`Error: Unknown service: ${serviceName}`);
@@ -269,7 +277,17 @@ async function clearService(deps: CliDependencies, serviceName: string): Promise
     deps.config.credentialStorePath,
     encryptedStorage
   );
-  const deleted = apiCredentialStore.delete(serviceName);
+
+  let deleted: boolean;
+  try {
+    deleted = apiCredentialStore.delete(serviceName, account);
+  } catch (error) {
+    if (error instanceof AmbiguousAccountError) {
+      deps.errorLog(`Error: ${error.message}`);
+      deps.exit(1);
+    }
+    throw error;
+  }
 
   if (deleted) {
     deps.log(`API credentials for ${serviceName} have been cleared.`);
@@ -282,6 +300,17 @@ async function clearService(deps: CliDependencies, serviceName: string): Promise
  * Register all CLI commands on the given program.
  */
 export function registerCommands(program: Command, deps: CliDependencies): void {
+  program.option(
+    '--account <account>',
+    'Account (e.g. an e-mail) whose credentials to use. Required when a service ' +
+      'has more than one stored account.'
+  );
+
+  // The account is a global option; commander exposes it on the root program
+  // regardless of which subcommand is invoked.
+  const getAccount = (): string | undefined =>
+    program.opts<{ account?: string }>().account;
+
   const servicesCommand = program
     .command('services')
     .description('Manage and inspect supported services.');
@@ -340,11 +369,12 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           apiCredentialStore,
           deps.config,
           serviceName,
-          options.offline ?? false
+          options.offline ?? false,
+          getAccount()
         );
         deps.log(JSON.stringify(info, null, 2));
       } catch (error) {
-        if (error instanceof UnknownServiceError) {
+        if (error instanceof UnknownServiceError || error instanceof AmbiguousAccountError) {
           deps.errorLog(`Error: ${error.message}`);
           deps.exit(1);
         }
@@ -461,8 +491,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
         deps.config.credentialStorePath,
         encryptedStorage
       );
-      const credentials = apiCredentialStore.get(serviceName);
-      if (credentials !== null) {
+      if (apiCredentialStore.listAccounts(serviceName).length > 0) {
         deps.errorLog(
           `Error: Credentials still exist for '${serviceName}'. ` +
             `Run 'latchkey auth clear ${serviceName}' before deregistering.`
@@ -487,7 +516,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
       if (serviceName === undefined) {
         await clearAll(deps, options.yes ?? false);
       } else {
-        await clearService(deps, serviceName);
+        await clearService(deps, serviceName, getAccount());
       }
     });
 
@@ -551,7 +580,15 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
       );
 
       const credentials = new RawCurlCredentials(curlArguments);
-      apiCredentialStore.save(serviceName, credentials);
+      try {
+        apiCredentialStore.save(serviceName, credentials, getAccount());
+      } catch (error) {
+        if (error instanceof AmbiguousAccountError) {
+          deps.errorLog(`Error: ${error.message}`);
+          deps.exit(1);
+        }
+        throw error;
+      }
       deps.log('Credentials stored.');
     });
 
@@ -601,7 +638,15 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
         throw error;
       }
 
-      apiCredentialStore.save(serviceName, credentials);
+      try {
+        apiCredentialStore.save(serviceName, credentials, getAccount());
+      } catch (error) {
+        if (error instanceof AmbiguousAccountError) {
+          deps.errorLog(`Error: ${error.message}`);
+          deps.exit(1);
+        }
+        throw error;
+      }
       deps.log('Credentials stored.');
     });
 
@@ -629,11 +674,12 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           apiCredentialStore,
           encryptedStorage,
           deps.config,
-          serviceName
+          serviceName,
+          getAccount()
         );
         deps.log('Done');
       } catch (error) {
-        if (error instanceof UnknownServiceError) {
+        if (error instanceof UnknownServiceError || error instanceof AmbiguousAccountError) {
           deps.errorLog(`Error: ${error.message}`);
           deps.exit(1);
         }
@@ -701,7 +747,8 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           apiCredentialStore,
           encryptedStorage,
           deps.config,
-          serviceName
+          serviceName,
+          getAccount()
         );
         if (result.alreadyPrepared) {
           deps.log('Already prepared.');
@@ -709,7 +756,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           deps.log('Done');
         }
       } catch (error) {
-        if (error instanceof UnknownServiceError) {
+        if (error instanceof UnknownServiceError || error instanceof AmbiguousAccountError) {
           deps.errorLog(`Error: ${error.message}`);
           deps.exit(1);
         }
@@ -770,13 +817,14 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           deps.config.credentialStorePath,
           encryptedStorage
         );
-        prepareService(deps.registry, apiCredentialStore, serviceName, json);
+        prepareService(deps.registry, apiCredentialStore, serviceName, json, getAccount());
         deps.log(`Done`);
       } catch (error) {
         if (
           error instanceof UnknownServiceError ||
           error instanceof PrepareNotSupportedError ||
-          error instanceof PrepareInputInvalidError
+          error instanceof PrepareInputInvalidError ||
+          error instanceof AmbiguousAccountError
         ) {
           deps.errorLog(`Error: ${error.message}`);
           deps.exit(1);
@@ -847,6 +895,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           permissionsDoNotUseBuiltinSchemas: deps.config.permissionsDoNotUseBuiltinSchemas,
           passthroughUnknown: deps.config.passthroughUnknown,
           credentialsRefreshDisabled: deps.config.credentialsRefreshDisabled,
+          account: getAccount(),
         });
       } catch (error) {
         if (error instanceof RequestNotPermittedError) {
@@ -862,6 +911,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           error instanceof NoServiceForUrlError ||
           error instanceof NoCredentialsForServiceError ||
           error instanceof CredentialsExpiredError ||
+          error instanceof AmbiguousAccountError ||
           error instanceof ApiCredentialsUsageError
         ) {
           deps.errorLog(error.message);
@@ -1054,7 +1104,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
       const sourceStorage = new EncryptedStorage(sourceKey);
       const sourceStore = new ApiCredentialStore(deps.config.credentialStorePath, sourceStorage);
 
-      let allCredentials: ReadonlyMap<string, ApiCredentials>;
+      let allCredentials: ReadonlyMap<string, ReadonlyMap<string, ApiCredentials>>;
       try {
         allCredentials = sourceStore.getAll();
       } catch (error) {
@@ -1085,9 +1135,11 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
       const destinationStorage = new EncryptedStorage(destinationKey);
       const destinationStore = new ApiCredentialStore(destination, destinationStorage);
       for (const serviceName of selectedServiceNames) {
-        const credentials = allCredentials.get(serviceName);
-        if (credentials !== undefined) {
-          destinationStore.save(serviceName, credentials);
+        const accountMap = allCredentials.get(serviceName);
+        if (accountMap !== undefined) {
+          for (const [account, credentials] of accountMap) {
+            destinationStore.save(serviceName, credentials, account);
+          }
         }
       }
 

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -562,7 +562,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
     .description('Clear stored API credentials.')
     .argument('[service_name]', 'Name of the service to clear API credentials for')
     .option('-y, --yes', 'Skip confirmation prompt when clearing all data')
-    .option('--all', "Clear all of the service's accounts as well as its preparation (if any)")
+    .option('--all', "Clear all of the service's accounts")
     .action(async (serviceName: string | undefined, options: { yes?: boolean; all?: boolean }) => {
       refuseInGatewayMode(deps, 'auth clear');
       const all = options.all ?? false;

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -539,10 +539,13 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
         deps.config.credentialStorePath,
         encryptedStorage
       );
-      if (apiCredentialStore.listAccounts(serviceName).length > 0) {
+      if (
+        apiCredentialStore.listAccounts(serviceName).length > 0 ||
+        apiCredentialStore.getPreparation(serviceName) !== null
+      ) {
         deps.errorLog(
-          `Error: Credentials still exist for '${serviceName}'. ` +
-            `Run 'latchkey auth clear ${serviceName}' before deregistering.`
+          `Error: Credentials or a preparation still exist for '${serviceName}'. ` +
+            `Run 'latchkey auth clear ${serviceName} --all' before deregistering.`
         );
         deps.exit(1);
       }

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -337,8 +337,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
 
   // The account is a global option; commander exposes it on the root program
   // regardless of which subcommand is invoked.
-  const getAccount = (): string | undefined =>
-    program.opts<{ account?: string }>().account;
+  const getAccount = (): string | undefined => program.opts<{ account?: string }>().account;
 
   // Only these commands act on a specific account. Every other command must
   // reject --account rather than silently ignore it, so users are never misled
@@ -560,10 +559,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
     .description('Clear stored API credentials.')
     .argument('[service_name]', 'Name of the service to clear API credentials for')
     .option('-y, --yes', 'Skip confirmation prompt when clearing all data')
-    .option(
-      '--all',
-      "Clear all of the service's accounts as well as its preparation (if any)"
-    )
+    .option('--all', "Clear all of the service's accounts as well as its preparation (if any)")
     .action(async (serviceName: string | undefined, options: { yes?: boolean; all?: boolean }) => {
       refuseInGatewayMode(deps, 'auth clear');
       const all = options.all ?? false;

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -297,19 +297,65 @@ async function clearService(
 }
 
 /**
+ * Build the "Done" message for a completed browser flow, naming the account the
+ * credentials were stored under when it is not the default (unnamed) account.
+ */
+function loginDoneMessage(account: string | undefined): string {
+  return account !== undefined && account !== ''
+    ? `Done. Stored credentials for account '${account}'.`
+    : 'Done';
+}
+
+/**
+ * Build the space-separated command path (e.g. "auth set") for a command,
+ * excluding the root program name.
+ */
+function fullCommandPath(command: Command): string {
+  const parts: string[] = [];
+  let current: Command = command;
+  while (current.parent) {
+    parts.unshift(current.name());
+    current = current.parent;
+  }
+  return parts.join(' ');
+}
+
+/**
  * Register all CLI commands on the given program.
  */
 export function registerCommands(program: Command, deps: CliDependencies): void {
   program.option(
     '--account <account>',
-    'Account (e.g. an e-mail) whose credentials to use. Required when a service ' +
-      'has more than one stored account.'
+    "Account (e.g. an e-mail) whose credentials to use. Supported by 'curl', " +
+      "'auth set', 'auth set-nocurl', 'auth clear', and 'auth prepare'. Required " +
+      'when a service has more than one stored account.'
   );
 
   // The account is a global option; commander exposes it on the root program
   // regardless of which subcommand is invoked.
   const getAccount = (): string | undefined =>
     program.opts<{ account?: string }>().account;
+
+  // Only these commands act on a specific account. Every other command must
+  // reject --account rather than silently ignore it, so users are never misled
+  // into thinking it took effect.
+  const accountAwareCommands = new Set([
+    'curl',
+    'auth set',
+    'auth set-nocurl',
+    'auth clear',
+    'auth prepare',
+  ]);
+  program.hook('preAction', (_thisCommand, actionCommand) => {
+    if (getAccount() === undefined) {
+      return;
+    }
+    const commandPath = fullCommandPath(actionCommand);
+    if (!accountAwareCommands.has(commandPath)) {
+      deps.errorLog(`Error: The --account option is not supported by 'latchkey ${commandPath}'.`);
+      deps.exit(1);
+    }
+  });
 
   const servicesCommand = program
     .command('services')
@@ -369,8 +415,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           apiCredentialStore,
           deps.config,
           serviceName,
-          options.offline ?? false,
-          getAccount()
+          options.offline ?? false
         );
         deps.log(JSON.stringify(info, null, 2));
       } catch (error) {
@@ -656,11 +701,11 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
     .argument('<service_name>', 'Name of the service to login to')
     .action(async (serviceName: string) => {
       if (deps.config.gatewayUrl !== null) {
-        await forwardToGateway(deps, {
+        const result = (await forwardToGateway(deps, {
           command: 'auth browser',
           params: { serviceName },
-        });
-        deps.log('Done');
+        })) as { account?: string } | null;
+        deps.log(loginDoneMessage(result?.account));
         return;
       }
       try {
@@ -669,15 +714,14 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           deps.config.credentialStorePath,
           encryptedStorage
         );
-        await authBrowser(
+        const { account } = await authBrowser(
           deps.registry,
           apiCredentialStore,
           encryptedStorage,
           deps.config,
-          serviceName,
-          getAccount()
+          serviceName
         );
-        deps.log('Done');
+        deps.log(loginDoneMessage(account));
       } catch (error) {
         if (error instanceof UnknownServiceError || error instanceof AmbiguousAccountError) {
           deps.errorLog(`Error: ${error.message}`);
@@ -728,11 +772,11 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
         const result = (await forwardToGateway(deps, {
           command: 'auth browser-prepare',
           params: { serviceName },
-        })) as { alreadyPrepared?: boolean } | null;
+        })) as { alreadyPrepared?: boolean; account?: string } | null;
         if (result !== null && result.alreadyPrepared === true) {
           deps.log('Already prepared.');
         } else {
-          deps.log('Done');
+          deps.log(loginDoneMessage(result?.account));
         }
         return;
       }
@@ -747,13 +791,12 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           apiCredentialStore,
           encryptedStorage,
           deps.config,
-          serviceName,
-          getAccount()
+          serviceName
         );
         if (result.alreadyPrepared) {
           deps.log('Already prepared.');
         } else {
-          deps.log('Done');
+          deps.log(loginDoneMessage(result.account));
         }
       } catch (error) {
         if (error instanceof UnknownServiceError || error instanceof AmbiguousAccountError) {

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -89,6 +89,7 @@ import {
   authBrowserPrepare,
   prepareService,
   UnknownServiceError,
+  AccountNotFoundError,
   BrowserNotConfiguredError,
   PreparationRequiredError,
 } from './sharedOperations.js';
@@ -327,7 +328,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
   program.option(
     '--account <account>',
     "Account (e.g. an e-mail) whose credentials to use. Supported by 'curl', " +
-      "'auth set', 'auth set-nocurl', 'auth clear', and 'auth prepare'. Required " +
+      "'auth set', 'auth set-nocurl', 'auth clear', and 'auth browser'. Required " +
       'when a service has more than one stored account.'
   );
 
@@ -344,7 +345,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
     'auth set',
     'auth set-nocurl',
     'auth clear',
-    'auth prepare',
+    'auth browser',
   ]);
   program.hook('preAction', (_thisCommand, actionCommand) => {
     if (getAccount() === undefined) {
@@ -703,7 +704,7 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
       if (deps.config.gatewayUrl !== null) {
         const result = (await forwardToGateway(deps, {
           command: 'auth browser',
-          params: { serviceName },
+          params: { serviceName, account: getAccount() },
         })) as { account?: string } | null;
         deps.log(loginDoneMessage(result?.account));
         return;
@@ -719,11 +720,12 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           apiCredentialStore,
           encryptedStorage,
           deps.config,
-          serviceName
+          serviceName,
+          getAccount()
         );
         deps.log(loginDoneMessage(account));
       } catch (error) {
-        if (error instanceof UnknownServiceError || error instanceof AmbiguousAccountError) {
+        if (error instanceof UnknownServiceError || error instanceof AccountNotFoundError) {
           deps.errorLog(`Error: ${error.message}`);
           deps.exit(1);
         }
@@ -772,11 +774,11 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
         const result = (await forwardToGateway(deps, {
           command: 'auth browser-prepare',
           params: { serviceName },
-        })) as { alreadyPrepared?: boolean; account?: string } | null;
+        })) as { alreadyPrepared?: boolean } | null;
         if (result !== null && result.alreadyPrepared === true) {
           deps.log('Already prepared.');
         } else {
-          deps.log(loginDoneMessage(result?.account));
+          deps.log('Done');
         }
         return;
       }
@@ -796,10 +798,10 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
         if (result.alreadyPrepared) {
           deps.log('Already prepared.');
         } else {
-          deps.log(loginDoneMessage(result.account));
+          deps.log('Done');
         }
       } catch (error) {
-        if (error instanceof UnknownServiceError || error instanceof AmbiguousAccountError) {
+        if (error instanceof UnknownServiceError) {
           deps.errorLog(`Error: ${error.message}`);
           deps.exit(1);
         }
@@ -860,14 +862,13 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           deps.config.credentialStorePath,
           encryptedStorage
         );
-        prepareService(deps.registry, apiCredentialStore, serviceName, json, getAccount());
+        prepareService(deps.registry, apiCredentialStore, serviceName, json);
         deps.log(`Done`);
       } catch (error) {
         if (
           error instanceof UnknownServiceError ||
           error instanceof PrepareNotSupportedError ||
-          error instanceof PrepareInputInvalidError ||
-          error instanceof AmbiguousAccountError
+          error instanceof PrepareInputInvalidError
         ) {
           deps.errorLog(`Error: ${error.message}`);
           deps.exit(1);
@@ -1183,6 +1184,10 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           for (const [account, credentials] of accountMap) {
             destinationStore.save(serviceName, credentials, account);
           }
+        }
+        const preparation = sourceStore.getPreparation(serviceName);
+        if (preparation !== null) {
+          destinationStore.savePreparation(serviceName, preparation);
         }
       }
 

--- a/src/curlInjection.ts
+++ b/src/curlInjection.ts
@@ -50,8 +50,8 @@ export class NoServiceForUrlError extends Error {
 export class NoCredentialsForServiceError extends Error {
   readonly serviceName: string;
 
-  constructor(serviceName: string) {
-    super(ErrorMessages.noCredentialsFound(serviceName));
+  constructor(serviceName: string, account?: string) {
+    super(ErrorMessages.noCredentialsFound(serviceName, account));
     this.name = 'NoCredentialsForServiceError';
     this.serviceName = serviceName;
   }
@@ -60,8 +60,8 @@ export class NoCredentialsForServiceError extends Error {
 export class CredentialsExpiredError extends Error {
   readonly serviceName: string;
 
-  constructor(serviceName: string) {
-    super(ErrorMessages.credentialsExpired(serviceName));
+  constructor(serviceName: string, account?: string) {
+    super(ErrorMessages.credentialsExpired(serviceName, account));
     this.name = 'CredentialsExpiredError';
     this.serviceName = serviceName;
   }
@@ -196,7 +196,7 @@ export async function prepareCurlInvocation(
     if (dependencies.passthroughUnknown) {
       return [...curlArguments];
     }
-    throw new NoCredentialsForServiceError(firstCandidate.name);
+    throw new NoCredentialsForServiceError(firstCandidate.name, account);
   }
 
   const service = chosen.service;
@@ -211,7 +211,7 @@ export async function prepareCurlInvocation(
       account
     );
     if (apiCredentials.isExpired() === true) {
-      throw new CredentialsExpiredError(service.name);
+      throw new CredentialsExpiredError(service.name, account);
     }
   }
 

--- a/src/curlInjection.ts
+++ b/src/curlInjection.ts
@@ -78,6 +78,12 @@ export interface CurlInjectionDependencies {
   readonly permissionsDoNotUseBuiltinSchemas: boolean;
   readonly passthroughUnknown: boolean;
   readonly credentialsRefreshDisabled: boolean;
+  /**
+   * Account to use for the credentials. When omitted, the single stored
+   * account is used automatically; if a service has multiple accounts an
+   * `AmbiguousAccountError` is raised so the caller can require `--account`.
+   */
+  readonly account?: string;
 }
 
 /**
@@ -159,10 +165,19 @@ export async function prepareCurlInvocation(
     throw new NoServiceForUrlError(url);
   }
 
-  let selection: { service: Service; apiCredentials: ApiCredentials } | null = null;
-  let fallbackWithCredentials: { service: Service; apiCredentials: ApiCredentials } | null = null;
+  interface Selection {
+    service: Service;
+    apiCredentials: ApiCredentials;
+  }
+  let selection: Selection | null = null;
+  let fallbackWithCredentials: Selection | null = null;
+  const account = dependencies.account;
+  // `get` resolves the account itself: it returns null when the requested
+  // account is absent (so we move on to the next candidate) and raises
+  // AmbiguousAccountError when several accounts exist and none was requested,
+  // which bubbles up so the caller can require --account.
   for (const candidate of candidates) {
-    const candidateCredentials = apiCredentialStore.get(candidate.name);
+    const candidateCredentials = apiCredentialStore.get(candidate.name, account);
     if (candidateCredentials === null) {
       continue;
     }
@@ -192,7 +207,8 @@ export async function prepareCurlInvocation(
       service,
       apiCredentials,
       apiCredentialStore,
-      dependencies.credentialsRefreshDisabled
+      dependencies.credentialsRefreshDisabled,
+      account
     );
     if (apiCredentials.isExpired() === true) {
       throw new CredentialsExpiredError(service.name);

--- a/src/errorMessages.ts
+++ b/src/errorMessages.ts
@@ -2,6 +2,22 @@
  * Centralized error messages used by both the CLI and the gateway.
  */
 
+/**
+ * Pieces used to mention a specific account in credential error messages: a
+ * `--account` prefix for suggested commands and a suffix naming the account.
+ * Both are empty when no account was explicitly requested (or it is the
+ * default, unnamed account).
+ */
+function accountMessageParts(account: string | undefined): {
+  commandPrefix: string;
+  serviceSuffix: string;
+} {
+  if (account === undefined || account === '') {
+    return { commandPrefix: '', serviceSuffix: '' };
+  }
+  return { commandPrefix: `--account ${account} `, serviceSuffix: ` (account '${account}')` };
+}
+
 export const ErrorMessages = {
   requestNotPermitted: 'Error: Request not permitted by the user.',
   couldNotExtractUrl:
@@ -14,17 +30,21 @@ export const ErrorMessages = {
     return `Error: No service matches URL: ${url}`;
   },
 
-  noCredentialsFound(serviceName: string): string {
+  noCredentialsFound(serviceName: string, account?: string): string {
+    const { commandPrefix, serviceSuffix } = accountMessageParts(account);
     return (
-      `Error: No credentials found for ${serviceName}.\n` +
-      `Run 'latchkey auth browser ${serviceName}' or 'latchkey auth set ${serviceName}' first.`
+      `Error: No credentials found for ${serviceName}${serviceSuffix}.\n` +
+      `Run 'latchkey ${commandPrefix}auth browser ${serviceName}' or ` +
+      `'latchkey ${commandPrefix}auth set ${serviceName}' first.`
     );
   },
 
-  credentialsExpired(serviceName: string): string {
+  credentialsExpired(serviceName: string, account?: string): string {
+    const { commandPrefix, serviceSuffix } = accountMessageParts(account);
     return (
-      `Error: Credentials for ${serviceName} are expired.\n` +
-      `Run 'latchkey auth browser ${serviceName}' or 'latchkey auth set ${serviceName}' to refresh them.`
+      `Error: Credentials for ${serviceName}${serviceSuffix} are expired.\n` +
+      `Run 'latchkey ${commandPrefix}auth browser ${serviceName}' or ` +
+      `'latchkey ${commandPrefix}auth set ${serviceName}' to refresh them.`
     );
   },
 } as const;

--- a/src/gateway/gatewayEndpoint.ts
+++ b/src/gateway/gatewayEndpoint.ts
@@ -10,7 +10,7 @@ import * as http from 'node:http';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import type { ApiCredentialStore } from '../apiCredentials/store.js';
+import { AmbiguousAccountError, type ApiCredentialStore } from '../apiCredentials/store.js';
 import type { AsyncCurlResult } from '../curl.js';
 import type { CliDependencies } from '../cliCommands.js';
 import {
@@ -367,7 +367,8 @@ export async function handleGatewayRequest(
       error instanceof UrlExtractionFailedError ||
       error instanceof NoServiceForUrlError ||
       error instanceof NoCredentialsForServiceError ||
-      error instanceof CredentialsExpiredError
+      error instanceof CredentialsExpiredError ||
+      error instanceof AmbiguousAccountError
     ) {
       deps.log(`${method} ${targetUrl} -> 400`);
       sendErrorResponse(response, 400, error.message);

--- a/src/gateway/latchkeyEndpoint.ts
+++ b/src/gateway/latchkeyEndpoint.ts
@@ -19,6 +19,7 @@ import {
   authBrowserPrepare,
   prepareService,
   UnknownServiceError,
+  AccountNotFoundError,
   BrowserNotConfiguredError,
   PreparationRequiredError,
 } from '../sharedOperations.js';
@@ -66,7 +67,9 @@ const AuthListRequestSchema = z.object({
 
 const AuthBrowserRequestSchema = z.object({
   command: z.literal('auth browser'),
-  params: serviceNameParams,
+  params: serviceNameParams.extend({
+    account: z.string().optional(),
+  }),
 });
 
 const AuthBrowserPrepareRequestSchema = z.object({
@@ -94,6 +97,7 @@ export type LatchkeyRequest = z.infer<typeof LatchkeyRequestSchema>;
 
 const KNOWN_ERROR_CLASSES: readonly (abstract new (...args: never[]) => Error)[] = [
   UnknownServiceError,
+  AccountNotFoundError,
   BrowserDisabledError,
   GraphicalEnvironmentNotFoundError,
   BrowserNotConfiguredError,
@@ -162,7 +166,8 @@ async function dispatch(
         apiCredentialStore,
         encryptedStorage,
         deps.config,
-        parsed.params.serviceName
+        parsed.params.serviceName,
+        parsed.params.account
       );
 
     case 'auth browser-prepare':

--- a/src/gateway/latchkeyEndpoint.ts
+++ b/src/gateway/latchkeyEndpoint.ts
@@ -157,14 +157,13 @@ async function dispatch(
       return authList(deps.registry, apiCredentialStore, deps.config);
 
     case 'auth browser':
-      await authBrowser(
+      return authBrowser(
         deps.registry,
         apiCredentialStore,
         encryptedStorage,
         deps.config,
         parsed.params.serviceName
       );
-      return null;
 
     case 'auth browser-prepare':
       return authBrowserPrepare(

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,6 @@ export {
   ServiceSession,
   SimpleServiceSession,
   BrowserFollowupServiceSession,
-  type CredentialCheck,
   type LoginResult,
   LoginCancelledError,
   LoginFailedError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,8 @@ export {
   ServiceSession,
   SimpleServiceSession,
   BrowserFollowupServiceSession,
+  type CredentialCheck,
+  type LoginResult,
   LoginCancelledError,
   LoginFailedError,
   Slack,

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -55,7 +55,17 @@ async function resolveCredentialViaServiceRegistry(
 
   try {
     const credentials = deserializeCredentials(parsed.data);
-    return await service.checkApiCredentials(credentials);
+    const check = await service.checkApiCredentials(credentials);
+    // Some services (notably the Google OAuth ones) validate credentials via a
+    // check endpoint that carries no identity, and instead learn the account
+    // from a separate source by overriding determineAccount(). For those the
+    // check reports a valid status but a null account, so fall back to
+    // determineAccount() to find out which account the credentials belong to.
+    if (check.status === ApiCredentialStatus.Valid && check.account === null) {
+      const account = await service.determineAccount(credentials);
+      return { status: check.status, account };
+    }
+    return check;
   } catch {
     return { status: ApiCredentialStatus.Unknown, account: null };
   }

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -48,7 +48,30 @@ function migrationSplitGoogleCredentials(config: Config, encryptedStorage: Encry
   encryptedStorage.writeFile(config.credentialStorePath, JSON.stringify(rest, null, 2));
 }
 
-const MIGRATIONS: readonly MigrationFunction[] = [migrationSplitGoogleCredentials];
+/**
+ * Wrap each service's credentials in an account-keyed dictionary, using the
+ * empty string as the default account. Converts the pre-multi-account format
+ * `{ service: credentials }` into `{ service: { "": credentials } }`.
+ */
+function migrationIntroduceAccounts(config: Config, encryptedStorage: EncryptedStorage): void {
+  const content = encryptedStorage.readFile(config.credentialStorePath);
+  if (content === null) {
+    return;
+  }
+
+  const store = JSON.parse(content) as Record<string, unknown>;
+  const migrated: Record<string, Record<string, unknown>> = {};
+  for (const [serviceName, credentials] of Object.entries(store)) {
+    migrated[serviceName] = { '': credentials };
+  }
+
+  encryptedStorage.writeFile(config.credentialStorePath, JSON.stringify(migrated, null, 2));
+}
+
+const MIGRATIONS: readonly MigrationFunction[] = [
+  migrationSplitGoogleCredentials,
+  migrationIntroduceAccounts,
+];
 
 export const LATEST_VERSION = MIGRATIONS.length;
 

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -62,10 +62,11 @@ async function resolveCredentialViaServiceRegistry(
 
   try {
     const credentials = deserializeCredentials(parsed.data);
-    const status = await service.checkApiCredentials(credentials);
-    const account =
-      status === ApiCredentialStatus.Valid ? await service.getAccount(credentials) : null;
-    return { status, account };
+    const [status, account] = await Promise.all([
+      service.checkApiCredentials(credentials),
+      service.getAccount(credentials),
+    ]);
+    return { status, account: status === ApiCredentialStatus.Valid ? account : null };
   } catch {
     return { status: ApiCredentialStatus.Unknown, account: null };
   }

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -7,7 +7,6 @@ import { ApiCredentialsSchema, deserializeCredentials } from './apiCredentials/s
 import type { Config } from './config.js';
 import type { EncryptedStorage } from './encryptedStorage.js';
 import { SERVICE_REGISTRY } from './serviceRegistry.js';
-import type { CredentialCheck } from './services/core/base.js';
 
 export class MigrationError extends Error {
   constructor(message: string) {
@@ -17,6 +16,15 @@ export class MigrationError extends Error {
 }
 
 const DATA_FORMAT_VERSION_FILENAME = 'data-format-version';
+
+/**
+ * The resolved validity and owning account of a service's stored credentials.
+ * The account is null when it cannot be determined.
+ */
+export interface ResolvedCredential {
+  readonly status: ApiCredentialStatus;
+  readonly account: string | null;
+}
 
 /**
  * Resolves the validity and owning account of a service's stored credentials.
@@ -31,16 +39,17 @@ const DATA_FORMAT_VERSION_FILENAME = 'data-format-version';
 export type CredentialResolver = (
   serviceName: string,
   credentialData: unknown
-) => Promise<CredentialCheck>;
+) => Promise<ResolvedCredential>;
 
 /**
- * Default resolver: look the service up in the registry and ask it to check the
- * credentials, translating every failure mode into an inconclusive result.
+ * Default resolver: look the service up in the registry, ask it to check the
+ * credentials and — when they are valid — which account they belong to,
+ * translating every failure mode into an inconclusive result.
  */
 async function resolveCredentialViaServiceRegistry(
   serviceName: string,
   credentialData: unknown
-): Promise<CredentialCheck> {
+): Promise<ResolvedCredential> {
   const service = SERVICE_REGISTRY.getByName(serviceName);
   if (service === null) {
     return { status: ApiCredentialStatus.Unknown, account: null };
@@ -53,7 +62,10 @@ async function resolveCredentialViaServiceRegistry(
 
   try {
     const credentials = deserializeCredentials(parsed.data);
-    return await service.checkApiCredentials(credentials);
+    const status = await service.checkApiCredentials(credentials);
+    const account =
+      status === ApiCredentialStatus.Valid ? await service.getAccount(credentials) : null;
+    return { status, account };
   } catch {
     return { status: ApiCredentialStatus.Unknown, account: null };
   }

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -1,8 +1,16 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { writeFileAtomic } from './atomicWrite.js';
+import { DEFAULT_ACCOUNT } from './apiCredentials/account.js';
+import { ApiCredentialStatus } from './apiCredentials/base.js';
+import {
+  ApiCredentialsSchema,
+  deserializeCredentials,
+} from './apiCredentials/serialization.js';
 import type { Config } from './config.js';
 import type { EncryptedStorage } from './encryptedStorage.js';
+import { SERVICE_REGISTRY } from './serviceRegistry.js';
+import type { CredentialCheck } from './services/core/base.js';
 
 export class MigrationError extends Error {
   constructor(message: string) {
@@ -13,7 +21,51 @@ export class MigrationError extends Error {
 
 const DATA_FORMAT_VERSION_FILENAME = 'data-format-version';
 
-type MigrationFunction = (config: Config, encryptedStorage: EncryptedStorage) => void;
+/**
+ * Resolves the validity and owning account of a service's stored credentials.
+ * Injected into migrations so tests can avoid real network calls.
+ *
+ * A resolver must be best-effort: it should never reject. Anything it cannot
+ * determine (unknown service, unparseable data, network error, timeout) is
+ * reported as {@link ApiCredentialStatus.Unknown} so the migration leaves the
+ * default account in place rather than dropping credentials.
+ */
+export type CredentialResolver = (
+  serviceName: string,
+  credentialData: unknown
+) => Promise<CredentialCheck>;
+
+/**
+ * Default resolver: look the service up in the registry and ask it to check the
+ * credentials, translating every failure mode into an inconclusive result.
+ */
+async function resolveCredentialViaServiceRegistry(
+  serviceName: string,
+  credentialData: unknown
+): Promise<CredentialCheck> {
+  const service = SERVICE_REGISTRY.getByName(serviceName);
+  if (service === null) {
+    return { status: ApiCredentialStatus.Unknown, account: null };
+  }
+
+  const parsed = ApiCredentialsSchema.safeParse(credentialData);
+  if (!parsed.success) {
+    return { status: ApiCredentialStatus.Unknown, account: null };
+  }
+
+  try {
+    const credentials = deserializeCredentials(parsed.data);
+    return await service.checkApiCredentials(credentials);
+  } catch {
+    return { status: ApiCredentialStatus.Unknown, account: null };
+  }
+}
+
+type MigrationFunction = (
+  config: Config,
+  encryptedStorage: EncryptedStorage,
+  resolveCredential: CredentialResolver
+) => void | Promise<void>;
 
 const GOOGLE_OAUTH_SERVICE_NAMES = [
   'google-gmail',
@@ -49,20 +101,51 @@ function migrationSplitGoogleCredentials(config: Config, encryptedStorage: Encry
 }
 
 /**
- * Wrap each service's credentials in an account-keyed dictionary, using the
- * empty string as the default account. Converts the pre-multi-account format
- * `{ service: credentials }` into `{ service: { "": credentials } }`.
+ * Wrap each service's credentials in an account-keyed dictionary. Converts the
+ * pre-multi-account format `{ service: credentials }` into
+ * `{ service: { account: credentials } }`.
+ *
+ * For every service, the stored credentials are validated in parallel:
+ *   - valid credentials whose account can be determined are keyed by that
+ *     account instead of the default one,
+ *   - valid credentials whose account cannot be determined stay under the
+ *     default account,
+ *   - definitively invalid credentials are dropped,
+ *   - anything inconclusive (unknown service, network error, timeout) is left
+ *     under the default account (best-effort).
  */
-function migrationIntroduceAccounts(config: Config, encryptedStorage: EncryptedStorage): void {
+async function migrationIntroduceAccounts(
+  config: Config,
+  encryptedStorage: EncryptedStorage,
+  resolveCredential: CredentialResolver
+): Promise<void> {
   const content = encryptedStorage.readFile(config.credentialStorePath);
   if (content === null) {
     return;
   }
 
   const store = JSON.parse(content) as Record<string, unknown>;
+
+  const resolvedEntries = await Promise.all(
+    Object.entries(store).map(async ([serviceName, credentials]) => ({
+      serviceName,
+      credentials,
+      check: await resolveCredential(serviceName, credentials),
+    }))
+  );
+
   const migrated: Record<string, Record<string, unknown>> = {};
-  for (const [serviceName, credentials] of Object.entries(store)) {
-    migrated[serviceName] = { '': credentials };
+  for (const { serviceName, credentials, check } of resolvedEntries) {
+    if (check.status === ApiCredentialStatus.Invalid) {
+      continue;
+    }
+    const account =
+      check.status === ApiCredentialStatus.Valid &&
+      check.account !== null &&
+      check.account !== DEFAULT_ACCOUNT
+        ? check.account
+        : DEFAULT_ACCOUNT;
+    migrated[serviceName] = { [account]: credentials };
   }
 
   encryptedStorage.writeFile(config.credentialStorePath, JSON.stringify(migrated, null, 2));
@@ -99,7 +182,11 @@ function isFirstInstallation(config: Config): boolean {
   return !existsSync(config.directory) || !existsSync(config.credentialStorePath);
 }
 
-export function runMigrations(config: Config, encryptedStorage: EncryptedStorage): void {
+export async function runMigrations(
+  config: Config,
+  encryptedStorage: EncryptedStorage,
+  resolveCredential: CredentialResolver = resolveCredentialViaServiceRegistry
+): Promise<void> {
   if (isFirstInstallation(config)) {
     return;
   }
@@ -118,7 +205,7 @@ export function runMigrations(config: Config, encryptedStorage: EncryptedStorage
     if (migration === undefined) {
       throw new MigrationError(`Missing migration function for version ${String(i + 1)}.`);
     }
-    migration(config, encryptedStorage);
+    await migration(config, encryptedStorage, resolveCredential);
   }
 
   if (currentVersion < LATEST_VERSION) {

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { writeFileAtomic } from './atomicWrite.js';
 import { DEFAULT_ACCOUNT } from './apiCredentials/account.js';
@@ -161,9 +161,107 @@ async function migrationIntroduceAccounts(
   encryptedStorage.writeFile(config.credentialStorePath, JSON.stringify(migrated, null, 2));
 }
 
+/**
+ * The serialized shape of an OAuth credential entry, as far as this migration
+ * needs it: the client pair plus the access token whose absence marks the
+ * entry as "prepared but not yet logged in".
+ */
+interface OAuthCredentialData {
+  readonly objectType: 'oauth';
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly accessToken?: string;
+}
+
+function asOAuthCredentialData(credentialData: unknown): OAuthCredentialData | null {
+  if (typeof credentialData !== 'object' || credentialData === null) {
+    return null;
+  }
+  const record = credentialData as Record<string, unknown>;
+  if (
+    record.objectType !== 'oauth' ||
+    typeof record.clientId !== 'string' ||
+    typeof record.clientSecret !== 'string'
+  ) {
+    return null;
+  }
+  return record as unknown as OAuthCredentialData;
+}
+
+/**
+ * Split the store into the two top-level sections "credentials" and
+ * "preparations". Converts `{ service: { account: credentials } }` into
+ * `{ credentials: { service: { account: credentials } }, preparations: { service: credentials } }`.
+ *
+ * Preparations are populated from two sources:
+ *   - a token-less OAuth client under the default account is the placeholder
+ *     that `auth prepare` / `auth browser-prepare` used to create; it is moved
+ *     out of the credentials section into preparations,
+ *   - otherwise, for every service with complete OAuth credentials (e.g. the
+ *     Google services), a token-less copy of the client id/secret is derived
+ *     so that future logins to additional accounts can reuse the client
+ *     without a fresh browser-prepare.
+ */
+function migrationSeparatePreparations(config: Config, encryptedStorage: EncryptedStorage): void {
+  const content = encryptedStorage.readFile(config.credentialStorePath);
+  if (content === null) {
+    return;
+  }
+
+  const store = JSON.parse(content) as Record<string, Record<string, unknown>>;
+
+  const credentials: Record<string, Record<string, unknown>> = {};
+  const preparations: Record<string, unknown> = {};
+
+  for (const [serviceName, accountMap] of Object.entries(store)) {
+    const remainingAccounts: Record<string, unknown> = {};
+    for (const [account, credentialData] of Object.entries(accountMap)) {
+      const oauthData = asOAuthCredentialData(credentialData);
+      const isPreparedPlaceholder =
+        account === DEFAULT_ACCOUNT && oauthData !== null && oauthData.accessToken === undefined;
+      if (isPreparedPlaceholder) {
+        preparations[serviceName] = credentialData;
+      } else {
+        remainingAccounts[account] = credentialData;
+      }
+    }
+    if (Object.keys(remainingAccounts).length > 0) {
+      credentials[serviceName] = remainingAccounts;
+    }
+  }
+
+  for (const [serviceName, accountMap] of Object.entries(credentials)) {
+    if (serviceName in preparations) {
+      continue;
+    }
+    // Prefer the default account's client, matching the account preference the
+    // pre-preparations login flow used when reusing stored credentials.
+    const orderedEntries = Object.values({
+      [DEFAULT_ACCOUNT]: accountMap[DEFAULT_ACCOUNT],
+      ...accountMap,
+    });
+    const oauthData = orderedEntries
+      .map(asOAuthCredentialData)
+      .find((candidate) => candidate !== null && candidate.clientId !== '');
+    if (oauthData !== null && oauthData !== undefined) {
+      preparations[serviceName] = {
+        objectType: 'oauth',
+        clientId: oauthData.clientId,
+        clientSecret: oauthData.clientSecret,
+      };
+    }
+  }
+
+  encryptedStorage.writeFile(
+    config.credentialStorePath,
+    JSON.stringify({ credentials, preparations }, null, 2)
+  );
+}
+
 const MIGRATIONS: readonly MigrationFunction[] = [
   migrationSplitGoogleCredentials,
   migrationIntroduceAccounts,
+  migrationSeparatePreparations,
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length;
@@ -198,6 +296,12 @@ export async function runMigrations(
   resolveCredential: CredentialResolver = resolveCredentialViaServiceRegistry
 ): Promise<void> {
   if (isFirstInstallation(config)) {
+    // A fresh installation starts out in the newest data format. Stamp the
+    // version right away so that a later run does not mistake the newly
+    // created store for one in the oldest format and "migrate" (i.e. corrupt)
+    // it.
+    mkdirSync(config.directory, { recursive: true, mode: 0o700 });
+    writeDataFormatVersion(config, LATEST_VERSION);
     return;
   }
 

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -23,7 +23,8 @@ const DATA_FORMAT_VERSION_FILENAME = 'data-format-version';
 
 /**
  * Resolves the validity and owning account of a service's stored credentials.
- * Injected into migrations so tests can avoid real network calls.
+ * Injected into migrations so tests can dictate check outcomes directly
+ * instead of stubbing the service registry and the curl subprocess layer.
  *
  * A resolver must be best-effort: it should never reject. Anything it cannot
  * determine (unknown service, unparseable data, network error, timeout) is
@@ -101,57 +102,6 @@ function migrationSplitGoogleCredentials(config: Config, encryptedStorage: Encry
 }
 
 /**
- * Wrap each service's credentials in an account-keyed dictionary. Converts the
- * pre-multi-account format `{ service: credentials }` into
- * `{ service: { account: credentials } }`.
- *
- * For every service, the stored credentials are validated in parallel:
- *   - valid credentials whose account can be determined are keyed by that
- *     account instead of the default one,
- *   - valid credentials whose account cannot be determined stay under the
- *     default account,
- *   - definitively invalid credentials are dropped,
- *   - anything inconclusive (unknown service, network error, timeout) is left
- *     under the default account (best-effort).
- */
-async function migrationIntroduceAccounts(
-  config: Config,
-  encryptedStorage: EncryptedStorage,
-  resolveCredential: CredentialResolver
-): Promise<void> {
-  const content = encryptedStorage.readFile(config.credentialStorePath);
-  if (content === null) {
-    return;
-  }
-
-  const store = JSON.parse(content) as Record<string, unknown>;
-
-  const resolvedEntries = await Promise.all(
-    Object.entries(store).map(async ([serviceName, credentials]) => ({
-      serviceName,
-      credentials,
-      check: await resolveCredential(serviceName, credentials),
-    }))
-  );
-
-  const migrated: Record<string, Record<string, unknown>> = {};
-  for (const { serviceName, credentials, check } of resolvedEntries) {
-    if (check.status === ApiCredentialStatus.Invalid) {
-      continue;
-    }
-    const account =
-      check.status === ApiCredentialStatus.Valid &&
-      check.account !== null &&
-      check.account !== DEFAULT_ACCOUNT
-        ? check.account
-        : DEFAULT_ACCOUNT;
-    migrated[serviceName] = { [account]: credentials };
-  }
-
-  encryptedStorage.writeFile(config.credentialStorePath, JSON.stringify(migrated, null, 2));
-}
-
-/**
  * The serialized shape of an OAuth credential entry, as far as this migration
  * needs it: the client pair plus the access token whose absence marks the
  * entry as "prepared but not yet logged in".
@@ -179,67 +129,72 @@ function asOAuthCredentialData(credentialData: unknown): OAuthCredentialData | n
 }
 
 /**
- * Split the store into the two top-level sections "credentials" and
- * "preparations". Converts `{ service: { account: credentials } }` into
- * `{ credentials: { service: { account: credentials } }, preparations: { service: credentials } }`.
+ * Convert the pre-multi-account format `{ service: credentials }` into the
+ * account-keyed store with separate preparations:
+ * `{ credentials: { service: { account: credentials } }, preparations: { service: oauthClient } }`.
  *
- * Preparations are populated from two sources:
- *   - a token-less OAuth client under the default account is the placeholder
- *     that `auth prepare` / `auth browser-prepare` used to create; it is moved
- *     out of the credentials section into preparations,
- *   - otherwise, for every service with complete OAuth credentials (e.g. the
- *     Google services), a token-less copy of the client id/secret is derived
- *     so that future logins to additional accounts can reuse the client
- *     without a fresh browser-prepare.
+ * For every service, the stored credentials are validated in parallel:
+ *   - valid credentials whose account can be determined are keyed by that
+ *     account instead of the default one,
+ *   - valid credentials whose account cannot be determined stay under the
+ *     default account,
+ *   - definitively invalid credentials are dropped,
+ *   - anything inconclusive (unknown service, network error, timeout) is left
+ *     under the default account (best-effort).
+ *
+ * Independently of validity, the OAuth client (id/secret) of every OAuth
+ * credential entry is saved as a preparation, so that future logins — also to
+ * additional accounts — can reuse the client without a fresh browser-prepare.
+ * This deliberately includes dropped invalid credentials (an expired token
+ * says nothing about the client) and the token-less placeholders that `auth
+ * prepare` / `auth browser-prepare` used to store as credentials; the
+ * placeholders live on only as preparations.
  */
-function migrationSeparatePreparations(config: Config, encryptedStorage: EncryptedStorage): void {
+async function migrationIntroduceAccountsAndPreparations(
+  config: Config,
+  encryptedStorage: EncryptedStorage,
+  resolveCredential: CredentialResolver
+): Promise<void> {
   const content = encryptedStorage.readFile(config.credentialStorePath);
   if (content === null) {
     return;
   }
 
-  const store = JSON.parse(content) as Record<string, Record<string, unknown>>;
+  const store = JSON.parse(content) as Record<string, unknown>;
+
+  const resolvedEntries = await Promise.all(
+    Object.entries(store).map(async ([serviceName, credentialData]) => ({
+      serviceName,
+      credentialData,
+      check: await resolveCredential(serviceName, credentialData),
+    }))
+  );
 
   const credentials: Record<string, Record<string, unknown>> = {};
   const preparations: Record<string, unknown> = {};
 
-  for (const [serviceName, accountMap] of Object.entries(store)) {
-    const remainingAccounts: Record<string, unknown> = {};
-    for (const [account, credentialData] of Object.entries(accountMap)) {
-      const oauthData = asOAuthCredentialData(credentialData);
-      const isPreparedPlaceholder =
-        account === DEFAULT_ACCOUNT && oauthData !== null && oauthData.accessToken === undefined;
-      if (isPreparedPlaceholder) {
-        preparations[serviceName] = credentialData;
-      } else {
-        remainingAccounts[account] = credentialData;
-      }
-    }
-    if (Object.keys(remainingAccounts).length > 0) {
-      credentials[serviceName] = remainingAccounts;
-    }
-  }
-
-  for (const [serviceName, accountMap] of Object.entries(credentials)) {
-    if (serviceName in preparations) {
-      continue;
-    }
-    // Prefer the default account's client, matching the account preference the
-    // pre-preparations login flow used when reusing stored credentials.
-    const orderedEntries = Object.values({
-      [DEFAULT_ACCOUNT]: accountMap[DEFAULT_ACCOUNT],
-      ...accountMap,
-    });
-    const oauthData = orderedEntries
-      .map(asOAuthCredentialData)
-      .find((candidate) => candidate !== null && candidate.clientId !== '');
-    if (oauthData !== null && oauthData !== undefined) {
+  for (const { serviceName, credentialData, check } of resolvedEntries) {
+    const oauthData = asOAuthCredentialData(credentialData);
+    if (oauthData !== null && oauthData.clientId !== '') {
       preparations[serviceName] = {
         objectType: 'oauth',
         clientId: oauthData.clientId,
         clientSecret: oauthData.clientSecret,
       };
     }
+
+    const isPreparedPlaceholder = oauthData !== null && oauthData.accessToken === undefined;
+    if (isPreparedPlaceholder || check.status === ApiCredentialStatus.Invalid) {
+      continue;
+    }
+
+    const account =
+      check.status === ApiCredentialStatus.Valid &&
+      check.account !== null &&
+      check.account !== DEFAULT_ACCOUNT
+        ? check.account
+        : DEFAULT_ACCOUNT;
+    credentials[serviceName] = { [account]: credentialData };
   }
 
   encryptedStorage.writeFile(
@@ -250,8 +205,7 @@ function migrationSeparatePreparations(config: Config, encryptedStorage: Encrypt
 
 const MIGRATIONS: readonly MigrationFunction[] = [
   migrationSplitGoogleCredentials,
-  migrationIntroduceAccounts,
-  migrationSeparatePreparations,
+  migrationIntroduceAccountsAndPreparations,
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length;

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -55,17 +55,7 @@ async function resolveCredentialViaServiceRegistry(
 
   try {
     const credentials = deserializeCredentials(parsed.data);
-    const check = await service.checkApiCredentials(credentials);
-    // Some services (notably the Google OAuth ones) validate credentials via a
-    // check endpoint that carries no identity, and instead learn the account
-    // from a separate source by overriding determineAccount(). For those the
-    // check reports a valid status but a null account, so fall back to
-    // determineAccount() to find out which account the credentials belong to.
-    if (check.status === ApiCredentialStatus.Valid && check.account === null) {
-      const account = await service.determineAccount(credentials);
-      return { status: check.status, account };
-    }
-    return check;
+    return await service.checkApiCredentials(credentials);
   } catch {
     return { status: ApiCredentialStatus.Unknown, account: null };
   }

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -3,10 +3,7 @@ import { join } from 'node:path';
 import { writeFileAtomic } from './atomicWrite.js';
 import { DEFAULT_ACCOUNT } from './apiCredentials/account.js';
 import { ApiCredentialStatus } from './apiCredentials/base.js';
-import {
-  ApiCredentialsSchema,
-  deserializeCredentials,
-} from './apiCredentials/serialization.js';
+import { ApiCredentialsSchema, deserializeCredentials } from './apiCredentials/serialization.js';
 import type { Config } from './config.js';
 import type { EncryptedStorage } from './encryptedStorage.js';
 import { SERVICE_REGISTRY } from './serviceRegistry.js';

--- a/src/services/aws.ts
+++ b/src/services/aws.ts
@@ -1,6 +1,7 @@
 import { createHash, createHmac } from 'node:crypto';
 import { z } from 'zod';
 import { type ApiCredentials } from '../apiCredentials/base.js';
+import { fetchAccountFromEndpoint } from '../apiCredentials/account.js';
 import { CurlParseError, parseCurlArgs } from '../curl.js';
 import { NoCurlCredentialsNotSupportedError, Service } from './core/base.js';
 
@@ -299,15 +300,21 @@ export class Aws extends Service {
     return new AwsCredentials(accessKeyId, secretAccessKey);
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    // GetCallerIdentity responds with XML; the ARN identifies both the AWS
-    // account and the IAM user behind the access key.
-    const arnMatch = /<Arn>([^<]+)<\/Arn>/.exec(responseBody);
-    if (arnMatch?.[1] !== undefined) {
-      return arnMatch[1];
-    }
-    const accountMatch = /<Account>([^<]+)<\/Account>/.exec(responseBody);
-    return accountMatch?.[1] ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        // GetCallerIdentity responds with XML; the ARN identifies both the AWS
+        // account and the IAM user behind the access key.
+        const arnMatch = /<Arn>([^<]+)<\/Arn>/.exec(responseBody);
+        if (arnMatch?.[1] !== undefined) {
+          return arnMatch[1];
+        }
+        const accountMatch = /<Account>([^<]+)<\/Account>/.exec(responseBody);
+        return accountMatch?.[1] ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/aws.ts
+++ b/src/services/aws.ts
@@ -298,6 +298,17 @@ export class Aws extends Service {
     }
     return new AwsCredentials(accessKeyId, secretAccessKey);
   }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    // GetCallerIdentity responds with XML; the ARN identifies both the AWS
+    // account and the IAM user behind the access key.
+    const arnMatch = /<Arn>([^<]+)<\/Arn>/.exec(responseBody);
+    if (arnMatch?.[1] !== undefined) {
+      return arnMatch[1];
+    }
+    const accountMatch = /<Account>([^<]+)<\/Account>/.exec(responseBody);
+    return accountMatch?.[1] ?? null;
+  }
 }
 
 class AwsCredentialError extends NoCurlCredentialsNotSupportedError {

--- a/src/services/calendly.ts
+++ b/src/services/calendly.ts
@@ -1,5 +1,6 @@
+import type { ApiCredentials } from '../apiCredentials/base.js';
 import { Service } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 export class Calendly extends Service {
   readonly name = 'calendly';
@@ -18,11 +19,17 @@ export class Calendly extends Service {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    const data = tryParseJson(responseBody) as {
-      resource?: { email?: string; name?: string };
-    } | null;
-    return data?.resource?.email ?? data?.resource?.name ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as {
+          resource?: { email?: string; name?: string };
+        } | null;
+        return data?.resource?.email ?? data?.resource?.name ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/calendly.ts
+++ b/src/services/calendly.ts
@@ -1,4 +1,4 @@
-import { Service } from './core/base.js';
+import { Service, tryParseJson } from './core/base.js';
 
 export class Calendly extends Service {
   readonly name = 'calendly';
@@ -15,6 +15,13 @@ export class Calendly extends Service {
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    const data = tryParseJson(responseBody) as {
+      resource?: { email?: string; name?: string };
+    } | null;
+    return data?.resource?.email ?? data?.resource?.name ?? null;
   }
 }
 

--- a/src/services/calendly.ts
+++ b/src/services/calendly.ts
@@ -1,4 +1,5 @@
-import { Service, tryParseJson } from './core/base.js';
+import { Service } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 export class Calendly extends Service {
   readonly name = 'calendly';

--- a/src/services/coolify.ts
+++ b/src/services/coolify.ts
@@ -1,4 +1,4 @@
-import { Service } from './core/base.js';
+import { Service, tryParseJson } from './core/base.js';
 
 export class Coolify extends Service {
   readonly name = 'coolify';
@@ -7,10 +7,17 @@ export class Coolify extends Service {
   readonly loginUrl = 'https://app.coolify.io/login';
   readonly info = 'https://coolify.io/docs/llms.txt';
 
-  readonly credentialCheckCurlArguments = ['https://app.coolify.io/api/v1/version'] as const;
+  // teams/current both validates the token and identifies the team it belongs
+  // to (API tokens are scoped to a team, so the team is the account).
+  readonly credentialCheckCurlArguments = ['https://app.coolify.io/api/v1/teams/current'] as const;
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    const data = tryParseJson(responseBody) as { name?: string; id?: number } | null;
+    return data?.name ?? data?.id?.toString() ?? null;
   }
 }
 

--- a/src/services/coolify.ts
+++ b/src/services/coolify.ts
@@ -1,5 +1,6 @@
+import type { ApiCredentials } from '../apiCredentials/base.js';
 import { Service } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 export class Coolify extends Service {
   readonly name = 'coolify';
@@ -16,9 +17,15 @@ export class Coolify extends Service {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    const data = tryParseJson(responseBody) as { name?: string; id?: number } | null;
-    return data?.name ?? data?.id?.toString() ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as { name?: string; id?: number } | null;
+        return data?.name ?? data?.id?.toString() ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/coolify.ts
+++ b/src/services/coolify.ts
@@ -1,4 +1,5 @@
-import { Service, tryParseJson } from './core/base.js';
+import { Service } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 export class Coolify extends Service {
   readonly name = 'coolify';

--- a/src/services/core/base.ts
+++ b/src/services/core/base.ts
@@ -217,16 +217,16 @@ export abstract class Service {
   /**
    * Determine which account the given credentials belong to: an e-mail when
    * available, otherwise a human-readable handle, otherwise an opaque id.
-   * Returns null when the account cannot be determined — the default for
-   * services that have not (yet) opted in.
+   * Returns null when the account cannot be determined.
    *
    * Best-effort and entirely separate from the credential check: services
    * typically implement it via `fetchAccountFromEndpoint()`, asking an
    * identity-revealing endpoint and parsing the account from its body.
+   * Services whose credentials carry no queryable identity (e.g. app-scoped
+   * API keys) must still implement this — explicitly returning null — so that
+   * the decision is a conscious one for every service.
    */
-  getAccount(_apiCredentials: ApiCredentials): Promise<string | null> {
-    return Promise.resolve(null);
-  }
+  abstract getAccount(apiCredentials: ApiCredentials): Promise<string | null>;
 
   /**
    * Return an example showing how to set credentials for this service via the CLI.

--- a/src/services/core/base.ts
+++ b/src/services/core/base.ts
@@ -140,19 +140,6 @@ export function isTimeoutError(error: Error): boolean {
 }
 
 /**
- * The outcome of a credential check: whether the credentials are valid, and —
- * when the check response reveals it — which account they belong to.
- *
- * The account is null when the check cannot determine it (invalid credentials,
- * a check endpoint that carries no identity, or a service that does not parse
- * it). Callers that need a concrete account fall back to the default account.
- */
-export interface CredentialCheck {
-  readonly status: ApiCredentialStatus;
-  readonly account: string | null;
-}
-
-/**
  * Abstract base class for services that latchkey can authenticate with.
  */
 export abstract class Service {
@@ -181,20 +168,14 @@ export abstract class Service {
   adjustCredentials?(apiCredentials: ApiCredentials, url: string): ApiCredentials;
 
   /**
-   * Check if the given API credentials are valid for this service, and report
-   * which account they belong to when the check response reveals it.
+   * Check if the given API credentials are valid for this service.
    *
-   * The check is a single request: the response status decides validity (via
-   * {@link isCredentialCheckResponseValid}) and the response body yields the
-   * account (via {@link parseAccountFromCredentialCheckBody}). Services
-   * customize either aspect by overriding those hooks rather than this method.
-   *
-   * Services whose check endpoint carries no identity but that have a separate
-   * account endpoint override this method instead: they try the account
-   * endpoint first (via `fetchAccountFromEndpoint()`) and fall back to this
-   * plain check when it reveals nothing.
+   * The check is a single request whose response decides validity via
+   * {@link isCredentialCheckResponseValid}; services whose check endpoint
+   * reports auth failures inside the body customize that hook rather than
+   * this method.
    */
-  async checkApiCredentials(apiCredentials: ApiCredentials): Promise<CredentialCheck> {
+  async checkApiCredentials(apiCredentials: ApiCredentials): Promise<ApiCredentialStatus> {
     let allCurlArgs: readonly string[];
     try {
       allCurlArgs = await apiCredentials.injectIntoCurlCall([
@@ -205,7 +186,7 @@ export abstract class Service {
       ]);
     } catch (error) {
       if (error instanceof ApiCredentialsUsageError) {
-        return { status: ApiCredentialStatus.Missing, account: null };
+        return ApiCredentialStatus.Missing;
       }
       throw error;
     }
@@ -219,12 +200,9 @@ export abstract class Service {
     const responseBody = separatorIndex === -1 ? '' : result.stdout.slice(0, separatorIndex);
 
     if (!this.isCredentialCheckResponseValid(httpStatusCode, responseBody)) {
-      return { status: ApiCredentialStatus.Invalid, account: null };
+      return ApiCredentialStatus.Invalid;
     }
-    return {
-      status: ApiCredentialStatus.Valid,
-      account: this.parseAccountFromCredentialCheckBody(responseBody),
-    };
+    return ApiCredentialStatus.Valid;
   }
 
   /**
@@ -237,13 +215,17 @@ export abstract class Service {
   }
 
   /**
-   * Extract the account from the body of a successful credential-check
-   * response: an e-mail when available, otherwise a human-readable handle,
-   * otherwise an opaque id. Returns null when the body carries no identity,
-   * which is the default for services that have not (yet) opted in.
+   * Determine which account the given credentials belong to: an e-mail when
+   * available, otherwise a human-readable handle, otherwise an opaque id.
+   * Returns null when the account cannot be determined — the default for
+   * services that have not (yet) opted in.
+   *
+   * Best-effort and entirely separate from the credential check: services
+   * typically implement it via `fetchAccountFromEndpoint()`, asking an
+   * identity-revealing endpoint and parsing the account from its body.
    */
-  protected parseAccountFromCredentialCheckBody(_responseBody: string): string | null {
-    return null;
+  getAccount(_apiCredentials: ApiCredentials): Promise<string | null> {
+    return Promise.resolve(null);
   }
 
   /**
@@ -418,10 +400,10 @@ export abstract class ServiceSession {
         throw new LoginFailedError();
       }
 
-      // Run the credential check with the fresh credentials to learn which
-      // account they belong to, falling back to the unnamed default account.
-      const credentialCheck = await this.service.checkApiCredentials(apiCredentials);
-      return { credentials: apiCredentials, account: credentialCheck.account ?? DEFAULT_ACCOUNT };
+      // Ask the service which account the fresh credentials belong to,
+      // falling back to the unnamed default account.
+      const account = (await this.service.getAccount(apiCredentials)) ?? DEFAULT_ACCOUNT;
+      return { credentials: apiCredentials, account };
     });
   }
 }

--- a/src/services/core/base.ts
+++ b/src/services/core/base.ts
@@ -153,19 +153,6 @@ export interface CredentialCheck {
 }
 
 /**
- * Parse a JSON response body, returning null instead of throwing on malformed
- * input. Credential-check bodies come from arbitrary servers, so account
- * parsing must never crash on unexpected content.
- */
-export function tryParseJson(body: string): unknown {
-  try {
-    return JSON.parse(body);
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Abstract base class for services that latchkey can authenticate with.
  */
 export abstract class Service {
@@ -201,6 +188,11 @@ export abstract class Service {
    * {@link isCredentialCheckResponseValid}) and the response body yields the
    * account (via {@link parseAccountFromCredentialCheckBody}). Services
    * customize either aspect by overriding those hooks rather than this method.
+   *
+   * Services whose check endpoint carries no identity but that have a separate
+   * account endpoint override this method instead: they try the account
+   * endpoint first (via `fetchAccountFromEndpoint()`) and fall back to this
+   * plain check when it reveals nothing.
    */
   async checkApiCredentials(apiCredentials: ApiCredentials): Promise<CredentialCheck> {
     let allCurlArgs: readonly string[];
@@ -252,17 +244,6 @@ export abstract class Service {
    */
   protected parseAccountFromCredentialCheckBody(_responseBody: string): string | null {
     return null;
-  }
-
-  /**
-   * Determine which account the given credentials belong to, or null when it
-   * cannot be determined. The default derives it from the credential check;
-   * services whose check endpoint carries no identity but that have another
-   * way to learn it (e.g. an OAuth userinfo endpoint) override this.
-   */
-  async determineAccount(apiCredentials: ApiCredentials): Promise<string | null> {
-    const credentialCheck = await this.checkApiCredentials(apiCredentials);
-    return credentialCheck.account;
   }
 
   /**
@@ -376,25 +357,6 @@ export abstract class ServiceSession {
   }
 
   /**
-   * Determine which account the finalized credentials belong to, so it can be
-   * stored alongside them. Called after login completes, while the browser and
-   * context are still open, so services can read the account from the page or
-   * from an API call made with the fresh credentials.
-   *
-   * The default asks the service (which runs the credential check with the
-   * fresh credentials) and falls back to the unnamed default account. Sessions
-   * only override this when the account is easier to read from the still-open
-   * browser than from the API.
-   */
-  protected async determineAccount(
-    apiCredentials: ApiCredentials,
-    _browser: Browser,
-    _context: BrowserContext
-  ): Promise<string> {
-    return (await this.service.determineAccount(apiCredentials)) ?? DEFAULT_ACCOUNT;
-  }
-
-  /**
    * Optional preparation step before login.
    * Services can override this to perform setup (e.g., creating OAuth clients).
    *
@@ -456,8 +418,10 @@ export abstract class ServiceSession {
         throw new LoginFailedError();
       }
 
-      const account = await this.determineAccount(apiCredentials, browser, context);
-      return { credentials: apiCredentials, account };
+      // Run the credential check with the fresh credentials to learn which
+      // account they belong to, falling back to the unnamed default account.
+      const credentialCheck = await this.service.checkApiCredentials(apiCredentials);
+      return { credentials: apiCredentials, account: credentialCheck.account ?? DEFAULT_ACCOUNT };
     });
   }
 }

--- a/src/services/core/base.ts
+++ b/src/services/core/base.ts
@@ -360,14 +360,14 @@ export abstract class ServiceSession {
    * Optional preparation step before login.
    * Services can override this to perform setup (e.g., creating OAuth clients).
    *
-   * Like {@link login}, this reports the account alongside the credentials.
-   * Preparation usually happens before any user is signed in, so services
-   * typically return the default account here.
+   * Unlike {@link login}, this returns bare credentials without an account:
+   * preparations are service-level artifacts shared by all of a service's
+   * accounts, and usually happen before any user is signed in.
    */
   prepare?(
     encryptedStorage: EncryptedStorage,
     launchOptions?: BrowserLaunchOptions
-  ): Promise<LoginResult>;
+  ): Promise<ApiCredentials>;
 
   /**
    * Perform the login flow and return the extracted credentials.

--- a/src/services/core/base.ts
+++ b/src/services/core/base.ts
@@ -140,6 +140,32 @@ export function isTimeoutError(error: Error): boolean {
 }
 
 /**
+ * The outcome of a credential check: whether the credentials are valid, and —
+ * when the check response reveals it — which account they belong to.
+ *
+ * The account is null when the check cannot determine it (invalid credentials,
+ * a check endpoint that carries no identity, or a service that does not parse
+ * it). Callers that need a concrete account fall back to the default account.
+ */
+export interface CredentialCheck {
+  readonly status: ApiCredentialStatus;
+  readonly account: string | null;
+}
+
+/**
+ * Parse a JSON response body, returning null instead of throwing on malformed
+ * input. Credential-check bodies come from arbitrary servers, so account
+ * parsing must never crash on unexpected content.
+ */
+export function tryParseJson(body: string): unknown {
+  try {
+    return JSON.parse(body);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Abstract base class for services that latchkey can authenticate with.
  */
 export abstract class Service {
@@ -168,32 +194,75 @@ export abstract class Service {
   adjustCredentials?(apiCredentials: ApiCredentials, url: string): ApiCredentials;
 
   /**
-   * Check if the given API credentials are valid for this service.
+   * Check if the given API credentials are valid for this service, and report
+   * which account they belong to when the check response reveals it.
+   *
+   * The check is a single request: the response status decides validity (via
+   * {@link isCredentialCheckResponseValid}) and the response body yields the
+   * account (via {@link parseAccountFromCredentialCheckBody}). Services
+   * customize either aspect by overriding those hooks rather than this method.
    */
-  async checkApiCredentials(apiCredentials: ApiCredentials): Promise<ApiCredentialStatus> {
+  async checkApiCredentials(apiCredentials: ApiCredentials): Promise<CredentialCheck> {
     let allCurlArgs: readonly string[];
     try {
       allCurlArgs = await apiCredentials.injectIntoCurlCall([
         '-s',
-        '-o',
-        '/dev/null',
         '-w',
-        '%{http_code}',
+        '\n%{http_code}',
         ...this.credentialCheckCurlArguments,
       ]);
     } catch (error) {
       if (error instanceof ApiCredentialsUsageError) {
-        return ApiCredentialStatus.Missing;
+        return { status: ApiCredentialStatus.Missing, account: null };
       }
       throw error;
     }
 
     const result = runCaptured(allCurlArgs, 10);
 
-    if (result.stdout === '200') {
-      return ApiCredentialStatus.Valid;
+    // The `-w '\n%{http_code}'` above appends the status code as the final
+    // line, so the body is everything before the last newline.
+    const separatorIndex = result.stdout.lastIndexOf('\n');
+    const httpStatusCode = result.stdout.slice(separatorIndex + 1).trim();
+    const responseBody = separatorIndex === -1 ? '' : result.stdout.slice(0, separatorIndex);
+
+    if (!this.isCredentialCheckResponseValid(httpStatusCode, responseBody)) {
+      return { status: ApiCredentialStatus.Invalid, account: null };
     }
-    return ApiCredentialStatus.Invalid;
+    return {
+      status: ApiCredentialStatus.Valid,
+      account: this.parseAccountFromCredentialCheckBody(responseBody),
+    };
+  }
+
+  /**
+   * Decide whether a credential-check response indicates valid credentials.
+   * The default accepts HTTP 200. Services whose check endpoint reports auth
+   * failures inside the body (e.g. Slack's `ok: false`) override this.
+   */
+  protected isCredentialCheckResponseValid(httpStatusCode: string, _responseBody: string): boolean {
+    return httpStatusCode === '200';
+  }
+
+  /**
+   * Extract the account from the body of a successful credential-check
+   * response: an e-mail when available, otherwise a human-readable handle,
+   * otherwise an opaque id. Returns null when the body carries no identity,
+   * which is the default for services that have not (yet) opted in.
+   */
+  protected parseAccountFromCredentialCheckBody(_responseBody: string): string | null {
+    return null;
+  }
+
+  /**
+   * Determine which account the given credentials belong to, or null when it
+   * cannot be determined. The default derives it from the credential check;
+   * services whose check endpoint carries no identity but that have another
+   * way to learn it (e.g. an OAuth userinfo endpoint) override this.
+   */
+  async determineAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    const credentialCheck = await this.checkApiCredentials(apiCredentials);
+    return credentialCheck.account;
   }
 
   /**
@@ -312,15 +381,17 @@ export abstract class ServiceSession {
    * context are still open, so services can read the account from the page or
    * from an API call made with the fresh credentials.
    *
-   * The default returns the unnamed default account. Services override this to
-   * report the real account (e.g. the signed-in e-mail).
+   * The default asks the service (which runs the credential check with the
+   * fresh credentials) and falls back to the unnamed default account. Sessions
+   * only override this when the account is easier to read from the still-open
+   * browser than from the API.
    */
-  protected determineAccount(
-    _apiCredentials: ApiCredentials,
+  protected async determineAccount(
+    apiCredentials: ApiCredentials,
     _browser: Browser,
     _context: BrowserContext
   ): Promise<string> {
-    return Promise.resolve(DEFAULT_ACCOUNT);
+    return (await this.service.determineAccount(apiCredentials)) ?? DEFAULT_ACCOUNT;
   }
 
   /**

--- a/src/services/core/base.ts
+++ b/src/services/core/base.ts
@@ -9,6 +9,7 @@ import {
   ApiCredentials,
   ApiCredentialsUsageError,
 } from '../../apiCredentials/base.js';
+import { DEFAULT_ACCOUNT } from '../../apiCredentials/account.js';
 import { runCaptured } from '../../curl.js';
 import { EncryptedStorage } from '../../encryptedStorage.js';
 import {
@@ -89,6 +90,21 @@ export function buildPreparedCredentials<Schema extends ZodTypeAny>(
     throw new PrepareInputInvalidError(serviceName, detail);
   }
   return build(result.data as z.infer<Schema>);
+}
+
+/**
+ * The outcome of a browser login or preparation flow: the extracted
+ * credentials together with the account they belong to.
+ *
+ * The account is a string that uniquely identifies the account behind the
+ * credentials (typically an e-mail, sometimes an opaque id). Because the
+ * account is only known once the user has logged in, browser flows report it
+ * here rather than accepting it up front. Services that cannot (yet) determine
+ * the account use the default account (the empty string).
+ */
+export interface LoginResult {
+  readonly credentials: ApiCredentials;
+  readonly account: string;
 }
 
 export function isBrowserClosedError(error: Error): boolean {
@@ -291,13 +307,34 @@ export abstract class ServiceSession {
   }
 
   /**
+   * Determine which account the finalized credentials belong to, so it can be
+   * stored alongside them. Called after login completes, while the browser and
+   * context are still open, so services can read the account from the page or
+   * from an API call made with the fresh credentials.
+   *
+   * The default returns the unnamed default account. Services override this to
+   * report the real account (e.g. the signed-in e-mail).
+   */
+  protected determineAccount(
+    _apiCredentials: ApiCredentials,
+    _browser: Browser,
+    _context: BrowserContext
+  ): Promise<string> {
+    return Promise.resolve(DEFAULT_ACCOUNT);
+  }
+
+  /**
    * Optional preparation step before login.
    * Services can override this to perform setup (e.g., creating OAuth clients).
+   *
+   * Like {@link login}, this reports the account alongside the credentials.
+   * Preparation usually happens before any user is signed in, so services
+   * typically return the default account here.
    */
   prepare?(
     encryptedStorage: EncryptedStorage,
     launchOptions?: BrowserLaunchOptions
-  ): Promise<ApiCredentials>;
+  ): Promise<LoginResult>;
 
   /**
    * Perform the login flow and return the extracted credentials.
@@ -309,7 +346,7 @@ export abstract class ServiceSession {
     encryptedStorage: EncryptedStorage,
     launchOptions: BrowserLaunchOptions = {},
     oldCredentials?: ApiCredentials
-  ): Promise<ApiCredentials> {
+  ): Promise<LoginResult> {
     return withTempBrowserContext(encryptedStorage, launchOptions, async ({ browser, context }) => {
       const page = await context.newPage();
 
@@ -348,7 +385,8 @@ export abstract class ServiceSession {
         throw new LoginFailedError();
       }
 
-      return apiCredentials;
+      const account = await this.determineAccount(apiCredentials, browser, context);
+      return { credentials: apiCredentials, account };
     });
   }
 }

--- a/src/services/core/registered.ts
+++ b/src/services/core/registered.ts
@@ -46,6 +46,12 @@ export class RegisteredService extends Service {
     return Promise.resolve(ApiCredentialStatus.Unknown);
   }
 
+  // Registered services point at self-hosted instances whose API shape is
+  // unknown, so there is no endpoint to ask for an identity.
+  getAccount(): Promise<string | null> {
+    return Promise.resolve(null);
+  }
+
   setCredentialsExample(serviceName: string): string {
     if (this.familyService !== undefined) {
       return this.familyService.setCredentialsExample(serviceName);

--- a/src/services/core/registered.ts
+++ b/src/services/core/registered.ts
@@ -7,7 +7,7 @@
  */
 
 import { ApiCredentialStatus, type ApiCredentials } from '../../apiCredentials/base.js';
-import { Service, type ServiceSession } from './base.js';
+import { type CredentialCheck, Service, type ServiceSession } from './base.js';
 
 export class RegisteredService extends Service {
   readonly name: string;
@@ -42,8 +42,8 @@ export class RegisteredService extends Service {
 
   override getSession?(appNamePrefix: string): ServiceSession;
 
-  override checkApiCredentials(): Promise<ApiCredentialStatus> {
-    return Promise.resolve(ApiCredentialStatus.Unknown);
+  override checkApiCredentials(): Promise<CredentialCheck> {
+    return Promise.resolve({ status: ApiCredentialStatus.Unknown, account: null });
   }
 
   setCredentialsExample(serviceName: string): string {

--- a/src/services/core/registered.ts
+++ b/src/services/core/registered.ts
@@ -7,7 +7,7 @@
  */
 
 import { ApiCredentialStatus, type ApiCredentials } from '../../apiCredentials/base.js';
-import { type CredentialCheck, Service, type ServiceSession } from './base.js';
+import { Service, type ServiceSession } from './base.js';
 
 export class RegisteredService extends Service {
   readonly name: string;
@@ -42,8 +42,8 @@ export class RegisteredService extends Service {
 
   override getSession?(appNamePrefix: string): ServiceSession;
 
-  override checkApiCredentials(): Promise<CredentialCheck> {
-    return Promise.resolve({ status: ApiCredentialStatus.Unknown, account: null });
+  override checkApiCredentials(): Promise<ApiCredentialStatus> {
+    return Promise.resolve(ApiCredentialStatus.Unknown);
   }
 
   setCredentialsExample(serviceName: string): string {

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -4,7 +4,8 @@
 
 import type { Response } from 'playwright';
 import { ApiCredentials, AuthorizationBare } from '../apiCredentials/base.js';
-import { Service, SimpleServiceSession, tryParseJson } from './core/base.js';
+import { Service, SimpleServiceSession } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 class DiscordServiceSession extends SimpleServiceSession {
   protected async getApiCredentialsFromResponse(

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -5,7 +5,7 @@
 import type { Response } from 'playwright';
 import { ApiCredentials, AuthorizationBare } from '../apiCredentials/base.js';
 import { Service, SimpleServiceSession } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 class DiscordServiceSession extends SimpleServiceSession {
   protected async getApiCredentialsFromResponse(
@@ -53,15 +53,21 @@ export class Discord extends Service {
     return new DiscordServiceSession(this, appNamePrefix);
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    // The e-mail is present for user-session credentials; bot tokens only
-    // carry the bot's username.
-    const data = tryParseJson(responseBody) as {
-      email?: string | null;
-      username?: string;
-      id?: string;
-    } | null;
-    return data?.email ?? data?.username ?? data?.id ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        // The e-mail is present for user-session credentials; bot tokens only
+        // carry the bot's username.
+        const data = tryParseJson(responseBody) as {
+          email?: string | null;
+          username?: string;
+          id?: string;
+        } | null;
+        return data?.email ?? data?.username ?? data?.id ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -4,7 +4,7 @@
 
 import type { Response } from 'playwright';
 import { ApiCredentials, AuthorizationBare } from '../apiCredentials/base.js';
-import { Service, SimpleServiceSession } from './core/base.js';
+import { Service, SimpleServiceSession, tryParseJson } from './core/base.js';
 
 class DiscordServiceSession extends SimpleServiceSession {
   protected async getApiCredentialsFromResponse(
@@ -50,6 +50,17 @@ export class Discord extends Service {
 
   override getSession(appNamePrefix: string): DiscordServiceSession {
     return new DiscordServiceSession(this, appNamePrefix);
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    // The e-mail is present for user-session credentials; bot tokens only
+    // carry the bot's username.
+    const data = tryParseJson(responseBody) as {
+      email?: string | null;
+      username?: string;
+      id?: string;
+    } | null;
+    return data?.email ?? data?.username ?? data?.id ?? null;
   }
 }
 

--- a/src/services/dropbox.ts
+++ b/src/services/dropbox.ts
@@ -19,7 +19,7 @@ import {
   isBrowserClosedError,
   LoginCancelledError,
 } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 
@@ -308,12 +308,18 @@ export class Dropbox extends Service {
     'https://api.dropboxapi.com/2/users/get_current_account',
   ] as const;
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    const data = tryParseJson(responseBody) as {
-      email?: string;
-      account_id?: string;
-    } | null;
-    return data?.email ?? data?.account_id ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as {
+          email?: string;
+          account_id?: string;
+        } | null;
+        return data?.email ?? data?.account_id ?? null;
+      }
+    );
   }
 
   setCredentialsExample(serviceName: string): string {

--- a/src/services/dropbox.ts
+++ b/src/services/dropbox.ts
@@ -18,6 +18,7 @@ import {
   LoginFailedError,
   isBrowserClosedError,
   LoginCancelledError,
+  tryParseJson,
 } from './core/base.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
@@ -298,15 +299,22 @@ export class Dropbox extends Service {
     'https://www.dropbox.com/developers/documentation/http/documentation. ' +
     'Use api.dropboxapi.com for RPC-style endpoints and content.dropboxapi.com for content upload/download.';
 
+  // get_current_account both validates the token and identifies the account.
+  // The account_info.read scope it needs is always granted (it is mandatory in
+  // the Dropbox App Console and included in DROPBOX_SCOPES for browser login).
   readonly credentialCheckCurlArguments = [
     '-X',
     'POST',
-    '-H',
-    'Content-Type: application/json',
-    'https://api.dropboxapi.com/2/check/user',
-    '--data',
-    '{"query":"foo"}',
+    'https://api.dropboxapi.com/2/users/get_current_account',
   ] as const;
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    const data = tryParseJson(responseBody) as {
+      email?: string;
+      account_id?: string;
+    } | null;
+    return data?.email ?? data?.account_id ?? null;
+  }
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;

--- a/src/services/dropbox.ts
+++ b/src/services/dropbox.ts
@@ -18,8 +18,8 @@ import {
   LoginFailedError,
   isBrowserClosedError,
   LoginCancelledError,
-  tryParseJson,
 } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -1,5 +1,6 @@
+import type { ApiCredentials } from '../apiCredentials/base.js';
 import { Service } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 export class Figma extends Service {
   readonly name = 'figma';
@@ -14,9 +15,15 @@ export class Figma extends Service {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    const data = tryParseJson(responseBody) as { email?: string; handle?: string } | null;
-    return data?.email ?? data?.handle ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as { email?: string; handle?: string } | null;
+        return data?.email ?? data?.handle ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -1,4 +1,4 @@
-import { Service } from './core/base.js';
+import { Service, tryParseJson } from './core/base.js';
 
 export class Figma extends Service {
   readonly name = 'figma';
@@ -11,6 +11,11 @@ export class Figma extends Service {
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    const data = tryParseJson(responseBody) as { email?: string; handle?: string } | null;
+    return data?.email ?? data?.handle ?? null;
   }
 }
 

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -1,4 +1,5 @@
-import { Service, tryParseJson } from './core/base.js';
+import { Service } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 export class Figma extends Service {
   readonly name = 'figma';

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -9,8 +9,8 @@ import {
   Service,
   BrowserFollowupServiceSession,
   LoginFailedError,
-  tryParseJson,
 } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -5,7 +5,12 @@
 import type { Response, BrowserContext } from 'playwright';
 import { ApiCredentials, AuthorizationBearer } from '../apiCredentials/base.js';
 import { typeLikeHuman } from '../playwrightUtils.js';
-import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
+import {
+  Service,
+  BrowserFollowupServiceSession,
+  LoginFailedError,
+  tryParseJson,
+} from './core/base.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 
@@ -179,6 +184,13 @@ export class Github extends Service {
 
   override getSession(appNamePrefix: string): GithubServiceSession {
     return new GithubServiceSession(this, appNamePrefix);
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    // The login is the stable GitHub handle; the e-mail is null unless the
+    // user makes it public, so keying on it would be unreliable.
+    const data = tryParseJson(responseBody) as { login?: string } | null;
+    return data?.login ?? null;
   }
 }
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -5,11 +5,7 @@
 import type { Response, BrowserContext } from 'playwright';
 import { ApiCredentials, AuthorizationBearer } from '../apiCredentials/base.js';
 import { typeLikeHuman } from '../playwrightUtils.js';
-import {
-  Service,
-  BrowserFollowupServiceSession,
-  LoginFailedError,
-} from './core/base.js';
+import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
 import { tryParseJson } from '../apiCredentials/account.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -6,7 +6,7 @@ import type { Response, BrowserContext } from 'playwright';
 import { ApiCredentials, AuthorizationBearer } from '../apiCredentials/base.js';
 import { typeLikeHuman } from '../playwrightUtils.js';
 import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 
@@ -182,11 +182,17 @@ export class Github extends Service {
     return new GithubServiceSession(this, appNamePrefix);
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    // The login is the stable GitHub handle; the e-mail is null unless the
-    // user makes it public, so keying on it would be unreliable.
-    const data = tryParseJson(responseBody) as { login?: string } | null;
-    return data?.login ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        // The login is the stable GitHub handle; the e-mail is null unless the
+        // user makes it public, so keying on it would be unreliable.
+        const data = tryParseJson(responseBody) as { login?: string } | null;
+        return data?.login ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/gitlab.ts
+++ b/src/services/gitlab.ts
@@ -1,5 +1,6 @@
+import type { ApiCredentials } from '../apiCredentials/base.js';
 import { Service } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 export class Gitlab extends Service {
   readonly name = 'gitlab';
@@ -14,11 +15,17 @@ export class Gitlab extends Service {
     return `latchkey auth set ${serviceName} -H "PRIVATE-TOKEN: <token>"`;
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    // Unlike lookups of other users, /user always exposes the token owner's
-    // own e-mail, so it can be preferred over the username.
-    const data = tryParseJson(responseBody) as { username?: string; email?: string } | null;
-    return data?.email ?? data?.username ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        // Unlike lookups of other users, /user always exposes the token owner's
+        // own e-mail, so it can be preferred over the username.
+        const data = tryParseJson(responseBody) as { username?: string; email?: string } | null;
+        return data?.email ?? data?.username ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/gitlab.ts
+++ b/src/services/gitlab.ts
@@ -1,4 +1,4 @@
-import { Service } from './core/base.js';
+import { Service, tryParseJson } from './core/base.js';
 
 export class Gitlab extends Service {
   readonly name = 'gitlab';
@@ -11,6 +11,13 @@ export class Gitlab extends Service {
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "PRIVATE-TOKEN: <token>"`;
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    // Unlike lookups of other users, /user always exposes the token owner's
+    // own e-mail, so it can be preferred over the username.
+    const data = tryParseJson(responseBody) as { username?: string; email?: string } | null;
+    return data?.email ?? data?.username ?? null;
   }
 }
 

--- a/src/services/gitlab.ts
+++ b/src/services/gitlab.ts
@@ -1,4 +1,5 @@
-import { Service, tryParseJson } from './core/base.js';
+import { Service } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 export class Gitlab extends Service {
   readonly name = 'gitlab';

--- a/src/services/google/analytics.ts
+++ b/src/services/google/analytics.ts
@@ -17,9 +17,6 @@ export class GoogleAnalytics extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-analytics" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-  readonly credentialCheckCurlArguments = [
-    'https://analyticsadmin.googleapis.com/v1beta/accountSummaries',
-  ] as const;
 
   protected readonly config = CONFIG;
 }

--- a/src/services/google/analytics.ts
+++ b/src/services/google/analytics.ts
@@ -17,7 +17,6 @@ export class GoogleAnalytics extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-analytics" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-
   protected readonly config = CONFIG;
 }
 

--- a/src/services/google/base.ts
+++ b/src/services/google/base.ts
@@ -11,6 +11,7 @@ import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import type { Browser, BrowserContext, Locator, Page, Response } from 'playwright';
 import { type ApiCredentials, OAuthCredentials } from '../../apiCredentials/base.js';
+import { DEFAULT_ACCOUNT } from '../../apiCredentials/account.js';
 import { extractUrlFromCurlArguments } from '../../curl.js';
 import {
   showSpinnerPage,
@@ -29,6 +30,7 @@ import {
   Service,
   BrowserFollowupServiceSession,
   buildPreparedCredentials,
+  type LoginResult,
   LoginFailedError,
   LoginCancelledError,
   isBrowserClosedError,
@@ -720,11 +722,13 @@ class GoogleServiceSession extends BrowserFollowupServiceSession {
   override async prepare(
     encryptedStorage: EncryptedStorage,
     launchOptions?: BrowserLaunchOptions
-  ): Promise<ApiCredentials> {
+  ): Promise<LoginResult> {
     return withTempBrowserContext(encryptedStorage, launchOptions ?? {}, async ({ context }) => {
       const page = await context.newPage();
       try {
-        return await this.runPrepareFlow(context, page);
+        // Preparation only creates the OAuth client (no user is signed in yet),
+        // so the credentials belong to the default account for now.
+        return { credentials: await this.runPrepareFlow(context, page), account: DEFAULT_ACCOUNT };
       } catch (error: unknown) {
         // Google now enforces MFA for accounts that use Google Cloud. When the
         // account lacks it, the console redirects to the enable-mfa page, which

--- a/src/services/google/base.ts
+++ b/src/services/google/base.ts
@@ -10,13 +10,9 @@ import fs from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import type { Browser, BrowserContext, Locator, Page, Response } from 'playwright';
-import {
-  type ApiCredentials,
-  ApiCredentialsUsageError,
-  OAuthCredentials,
-} from '../../apiCredentials/base.js';
-import { DEFAULT_ACCOUNT } from '../../apiCredentials/account.js';
-import { extractUrlFromCurlArguments, runCaptured } from '../../curl.js';
+import { type ApiCredentials, OAuthCredentials } from '../../apiCredentials/base.js';
+import { DEFAULT_ACCOUNT, tryParseJson } from '../../apiCredentials/account.js';
+import { extractUrlFromCurlArguments } from '../../curl.js';
 import {
   showSpinnerPage,
   withTempBrowserContext,
@@ -40,7 +36,6 @@ import {
   isBrowserClosedError,
   isResponseBodyUnavailableError,
   isTimeoutError,
-  tryParseJson,
 } from '../core/base.js';
 import type { EncryptedStorage } from '../../encryptedStorage.js';
 import { DEFAULT_APP_NAME_PREFIX } from '../../config.js';
@@ -917,6 +912,24 @@ export type GooglePrepareInput = z.infer<typeof GooglePrepareInputSchema>;
 export abstract class GoogleService extends Service {
   readonly loginUrl = 'https://console.cloud.google.com/';
 
+  /**
+   * All Google services share the same credential check: the OpenID userinfo
+   * endpoint. The login scopes always include userinfo.email (see
+   * COMMON_SCOPES), so a valid token always answers there, and the response
+   * reveals the signed-in e-mail — including for services whose own API
+   * carries no identity (Analytics, Docs, Sheets, Slides). Service-specific
+   * scopes are deliberately not examined — the check only decides credential
+   * validity.
+   */
+  readonly credentialCheckCurlArguments = [
+    'https://openidconnect.googleapis.com/v1/userinfo',
+  ] as const;
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    const data = tryParseJson(responseBody) as { email?: string; sub?: string } | null;
+    return data?.email ?? data?.sub ?? null;
+  }
+
   protected abstract readonly config: GoogleServiceConfig;
 
   /**
@@ -938,30 +951,6 @@ export abstract class GoogleService extends Service {
 
   override getSession(appNamePrefix: string): GoogleServiceSession {
     return new GoogleServiceSession(this, this.config, appNamePrefix);
-  }
-
-  /**
-   * The login scopes always include userinfo.email (see COMMON_SCOPES), so
-   * the OpenID userinfo endpoint reveals the signed-in e-mail for every
-   * Google service — including those whose credential-check endpoint carries
-   * no identity (Analytics, Docs, Sheets, Slides).
-   */
-  override async determineAccount(apiCredentials: ApiCredentials): Promise<string | null> {
-    let curlArguments: readonly string[];
-    try {
-      curlArguments = await apiCredentials.injectIntoCurlCall([
-        '-s',
-        'https://openidconnect.googleapis.com/v1/userinfo',
-      ]);
-    } catch (error) {
-      if (error instanceof ApiCredentialsUsageError) {
-        return null;
-      }
-      throw error;
-    }
-    const result = runCaptured(curlArguments, 10);
-    const data = tryParseJson(result.stdout) as { email?: string; sub?: string } | null;
-    return data?.email ?? data?.sub ?? null;
   }
 
   override refreshCredentials(apiCredentials: ApiCredentials): Promise<ApiCredentials | null> {

--- a/src/services/google/base.ts
+++ b/src/services/google/base.ts
@@ -11,7 +11,7 @@ import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import type { Browser, BrowserContext, Locator, Page, Response } from 'playwright';
 import { type ApiCredentials, OAuthCredentials } from '../../apiCredentials/base.js';
-import { tryParseJson } from '../../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../../apiCredentials/account.js';
 import { extractUrlFromCurlArguments } from '../../curl.js';
 import {
   showSpinnerPage,
@@ -922,9 +922,15 @@ export abstract class GoogleService extends Service {
     'https://openidconnect.googleapis.com/v1/userinfo',
   ] as const;
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    const data = tryParseJson(responseBody) as { email?: string; sub?: string } | null;
-    return data?.email ?? data?.sub ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as { email?: string; sub?: string } | null;
+        return data?.email ?? data?.sub ?? null;
+      }
+    );
   }
 
   protected abstract readonly config: GoogleServiceConfig;

--- a/src/services/google/base.ts
+++ b/src/services/google/base.ts
@@ -11,7 +11,7 @@ import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import type { Browser, BrowserContext, Locator, Page, Response } from 'playwright';
 import { type ApiCredentials, OAuthCredentials } from '../../apiCredentials/base.js';
-import { DEFAULT_ACCOUNT, tryParseJson } from '../../apiCredentials/account.js';
+import { tryParseJson } from '../../apiCredentials/account.js';
 import { extractUrlFromCurlArguments } from '../../curl.js';
 import {
   showSpinnerPage,
@@ -30,7 +30,6 @@ import {
   Service,
   BrowserFollowupServiceSession,
   buildPreparedCredentials,
-  type LoginResult,
   LoginFailedError,
   LoginCancelledError,
   isBrowserClosedError,
@@ -722,13 +721,11 @@ class GoogleServiceSession extends BrowserFollowupServiceSession {
   override async prepare(
     encryptedStorage: EncryptedStorage,
     launchOptions?: BrowserLaunchOptions
-  ): Promise<LoginResult> {
+  ): Promise<ApiCredentials> {
     return withTempBrowserContext(encryptedStorage, launchOptions ?? {}, async ({ context }) => {
       const page = await context.newPage();
       try {
-        // Preparation only creates the OAuth client (no user is signed in yet),
-        // so the credentials belong to the default account for now.
-        return { credentials: await this.runPrepareFlow(context, page), account: DEFAULT_ACCOUNT };
+        return await this.runPrepareFlow(context, page);
       } catch (error: unknown) {
         // Google now enforces MFA for accounts that use Google Cloud. When the
         // account lacks it, the console redirects to the enable-mfa page, which

--- a/src/services/google/base.ts
+++ b/src/services/google/base.ts
@@ -10,9 +10,13 @@ import fs from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import type { Browser, BrowserContext, Locator, Page, Response } from 'playwright';
-import { type ApiCredentials, OAuthCredentials } from '../../apiCredentials/base.js';
+import {
+  type ApiCredentials,
+  ApiCredentialsUsageError,
+  OAuthCredentials,
+} from '../../apiCredentials/base.js';
 import { DEFAULT_ACCOUNT } from '../../apiCredentials/account.js';
-import { extractUrlFromCurlArguments } from '../../curl.js';
+import { extractUrlFromCurlArguments, runCaptured } from '../../curl.js';
 import {
   showSpinnerPage,
   withTempBrowserContext,
@@ -36,6 +40,7 @@ import {
   isBrowserClosedError,
   isResponseBodyUnavailableError,
   isTimeoutError,
+  tryParseJson,
 } from '../core/base.js';
 import type { EncryptedStorage } from '../../encryptedStorage.js';
 import { DEFAULT_APP_NAME_PREFIX } from '../../config.js';
@@ -933,6 +938,30 @@ export abstract class GoogleService extends Service {
 
   override getSession(appNamePrefix: string): GoogleServiceSession {
     return new GoogleServiceSession(this, this.config, appNamePrefix);
+  }
+
+  /**
+   * The login scopes always include userinfo.email (see COMMON_SCOPES), so
+   * the OpenID userinfo endpoint reveals the signed-in e-mail for every
+   * Google service — including those whose credential-check endpoint carries
+   * no identity (Analytics, Docs, Sheets, Slides).
+   */
+  override async determineAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    let curlArguments: readonly string[];
+    try {
+      curlArguments = await apiCredentials.injectIntoCurlCall([
+        '-s',
+        'https://openidconnect.googleapis.com/v1/userinfo',
+      ]);
+    } catch (error) {
+      if (error instanceof ApiCredentialsUsageError) {
+        return null;
+      }
+      throw error;
+    }
+    const result = runCaptured(curlArguments, 10);
+    const data = tryParseJson(result.stdout) as { email?: string; sub?: string } | null;
+    return data?.email ?? data?.sub ?? null;
   }
 
   override refreshCredentials(apiCredentials: ApiCredentials): Promise<ApiCredentials | null> {

--- a/src/services/google/calendar.ts
+++ b/src/services/google/calendar.ts
@@ -17,7 +17,6 @@ export class GoogleCalendar extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-calendar" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-
   protected readonly config = CONFIG;
 }
 

--- a/src/services/google/calendar.ts
+++ b/src/services/google/calendar.ts
@@ -17,9 +17,6 @@ export class GoogleCalendar extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-calendar" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-  readonly credentialCheckCurlArguments = [
-    'https://www.googleapis.com/calendar/v3/calendars/primary',
-  ] as const;
 
   protected readonly config = CONFIG;
 }

--- a/src/services/google/directions.ts
+++ b/src/services/google/directions.ts
@@ -32,6 +32,12 @@ export class GoogleDirections extends Service {
     return `latchkey auth set-nocurl ${serviceName} <api-key>`;
   }
 
+  // API keys are project-scoped and the Routes API has no endpoint that
+  // reveals the account behind them.
+  getAccount(): Promise<string | null> {
+    return Promise.resolve(null);
+  }
+
   override getCredentialsNoCurl(arguments_: readonly string[]): ApiCredentials {
     if (arguments_.length !== 1 || arguments_[0] === undefined) {
       throw new GoogleDirectionsCredentialError(

--- a/src/services/google/docs.ts
+++ b/src/services/google/docs.ts
@@ -24,7 +24,6 @@ export class GoogleDocs extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-docs" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-
   protected readonly config = CONFIG;
 }
 

--- a/src/services/google/docs.ts
+++ b/src/services/google/docs.ts
@@ -24,9 +24,6 @@ export class GoogleDocs extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-docs" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-  readonly credentialCheckCurlArguments = [
-    "https://www.googleapis.com/drive/v3/files?pageSize=1&fields=files(id)&q=mimeType%3D'application/vnd.google-apps.document'",
-  ] as const;
 
   protected readonly config = CONFIG;
 }

--- a/src/services/google/drive.ts
+++ b/src/services/google/drive.ts
@@ -17,7 +17,6 @@ export class GoogleDrive extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-drive" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-
   protected readonly config = CONFIG;
 }
 

--- a/src/services/google/drive.ts
+++ b/src/services/google/drive.ts
@@ -17,9 +17,6 @@ export class GoogleDrive extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-drive" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-  readonly credentialCheckCurlArguments = [
-    'https://www.googleapis.com/drive/v3/about?fields=user',
-  ] as const;
 
   protected readonly config = CONFIG;
 }

--- a/src/services/google/gmail.ts
+++ b/src/services/google/gmail.ts
@@ -19,9 +19,6 @@ export class GoogleGmail extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-gmail" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-  readonly credentialCheckCurlArguments = [
-    'https://gmail.googleapis.com/gmail/v1/users/me/profile',
-  ] as const;
 
   protected readonly config = CONFIG;
 }

--- a/src/services/google/gmail.ts
+++ b/src/services/google/gmail.ts
@@ -19,7 +19,6 @@ export class GoogleGmail extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-gmail" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-
   protected readonly config = CONFIG;
 }
 

--- a/src/services/google/people.ts
+++ b/src/services/google/people.ts
@@ -17,9 +17,6 @@ export class GooglePeople extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-people" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-  readonly credentialCheckCurlArguments = [
-    'https://people.googleapis.com/v1/people/me?personFields=names',
-  ] as const;
 
   protected readonly config = CONFIG;
 }

--- a/src/services/google/people.ts
+++ b/src/services/google/people.ts
@@ -17,7 +17,6 @@ export class GooglePeople extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-people" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-
   protected readonly config = CONFIG;
 }
 

--- a/src/services/google/sheets.ts
+++ b/src/services/google/sheets.ts
@@ -24,7 +24,6 @@ export class GoogleSheets extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-sheets" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-
   protected readonly config = CONFIG;
 }
 

--- a/src/services/google/sheets.ts
+++ b/src/services/google/sheets.ts
@@ -24,9 +24,6 @@ export class GoogleSheets extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-sheets" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-  readonly credentialCheckCurlArguments = [
-    "https://www.googleapis.com/drive/v3/files?pageSize=1&fields=files(id)&q=mimeType%3D'application/vnd.google-apps.spreadsheet'",
-  ] as const;
 
   protected readonly config = CONFIG;
 }

--- a/src/services/google/slides.ts
+++ b/src/services/google/slides.ts
@@ -24,7 +24,6 @@ export class GoogleSlides extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-slides" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-
   protected readonly config = CONFIG;
 }
 

--- a/src/services/google/slides.ts
+++ b/src/services/google/slides.ts
@@ -24,9 +24,6 @@ export class GoogleSlides extends GoogleService {
     'If needed, run "latchkey auth browser-prepare google-slides" to create an OAuth client first. ' +
     'It may take a few minutes before the OAuth client is ready to use.';
 
-  readonly credentialCheckCurlArguments = [
-    "https://www.googleapis.com/drive/v3/files?pageSize=1&fields=files(id)&q=mimeType%3D'application/vnd.google-apps.presentation'",
-  ] as const;
 
   protected readonly config = CONFIG;
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -7,7 +7,6 @@ export {
   ServiceSession,
   SimpleServiceSession,
   BrowserFollowupServiceSession,
-  type CredentialCheck,
   type LoginResult,
 } from './core/base.js';
 export {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -7,6 +7,8 @@ export {
   ServiceSession,
   SimpleServiceSession,
   BrowserFollowupServiceSession,
+  type CredentialCheck,
+  type LoginResult,
 } from './core/base.js';
 export {
   LoginCancelledError,

--- a/src/services/linear.ts
+++ b/src/services/linear.ts
@@ -9,8 +9,8 @@ import {
   Service,
   BrowserFollowupServiceSession,
   LoginFailedError,
-  tryParseJson,
 } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 

--- a/src/services/linear.ts
+++ b/src/services/linear.ts
@@ -5,7 +5,12 @@
 import type { Response, BrowserContext } from 'playwright';
 import { ApiCredentials, AuthorizationBare } from '../apiCredentials/base.js';
 import { typeLikeHuman } from '../playwrightUtils.js';
-import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
+import {
+  Service,
+  BrowserFollowupServiceSession,
+  LoginFailedError,
+  tryParseJson,
+} from './core/base.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 
@@ -103,12 +108,19 @@ export class Linear extends Service {
     '-H',
     'Content-Type: application/json',
     '-d',
-    '{"query": "{ viewer { id } }"}',
+    '{"query": "{ viewer { id email } }"}',
     'https://api.linear.app/graphql',
   ] as const;
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: <token>"`;
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    const data = tryParseJson(responseBody) as {
+      data?: { viewer?: { email?: string; id?: string } };
+    } | null;
+    return data?.data?.viewer?.email ?? data?.data?.viewer?.id ?? null;
   }
 
   override getSession(appNamePrefix: string): LinearServiceSession {

--- a/src/services/linear.ts
+++ b/src/services/linear.ts
@@ -6,7 +6,7 @@ import type { Response, BrowserContext } from 'playwright';
 import { ApiCredentials, AuthorizationBare } from '../apiCredentials/base.js';
 import { typeLikeHuman } from '../playwrightUtils.js';
 import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 
@@ -112,11 +112,17 @@ export class Linear extends Service {
     return `latchkey auth set ${serviceName} -H "Authorization: <token>"`;
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    const data = tryParseJson(responseBody) as {
-      data?: { viewer?: { email?: string; id?: string } };
-    } | null;
-    return data?.data?.viewer?.email ?? data?.data?.viewer?.id ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as {
+          data?: { viewer?: { email?: string; id?: string } };
+        } | null;
+        return data?.data?.viewer?.email ?? data?.data?.viewer?.id ?? null;
+      }
+    );
   }
 
   override getSession(appNamePrefix: string): LinearServiceSession {

--- a/src/services/linear.ts
+++ b/src/services/linear.ts
@@ -5,11 +5,7 @@
 import type { Response, BrowserContext } from 'playwright';
 import { ApiCredentials, AuthorizationBare } from '../apiCredentials/base.js';
 import { typeLikeHuman } from '../playwrightUtils.js';
-import {
-  Service,
-  BrowserFollowupServiceSession,
-  LoginFailedError,
-} from './core/base.js';
+import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
 import { tryParseJson } from '../apiCredentials/account.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;

--- a/src/services/mailchimp.ts
+++ b/src/services/mailchimp.ts
@@ -1,4 +1,5 @@
-import { Service, tryParseJson } from './core/base.js';
+import { Service } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 export class Mailchimp extends Service {
   readonly name = 'mailchimp';

--- a/src/services/mailchimp.ts
+++ b/src/services/mailchimp.ts
@@ -1,4 +1,4 @@
-import { Service } from './core/base.js';
+import { Service, tryParseJson } from './core/base.js';
 
 export class Mailchimp extends Service {
   readonly name = 'mailchimp';
@@ -14,6 +14,14 @@ export class Mailchimp extends Service {
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    const data = tryParseJson(responseBody) as {
+      login?: { email?: string; login_email?: string };
+      accountname?: string;
+    } | null;
+    return data?.login?.email ?? data?.login?.login_email ?? data?.accountname ?? null;
   }
 }
 

--- a/src/services/mailchimp.ts
+++ b/src/services/mailchimp.ts
@@ -1,5 +1,6 @@
+import type { ApiCredentials } from '../apiCredentials/base.js';
 import { Service } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 export class Mailchimp extends Service {
   readonly name = 'mailchimp';
@@ -17,12 +18,18 @@ export class Mailchimp extends Service {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    const data = tryParseJson(responseBody) as {
-      login?: { email?: string; login_email?: string };
-      accountname?: string;
-    } | null;
-    return data?.login?.email ?? data?.login?.login_email ?? data?.accountname ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as {
+          login?: { email?: string; login_email?: string };
+          accountname?: string;
+        } | null;
+        return data?.login?.email ?? data?.login?.login_email ?? data?.accountname ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/notion-mcp.ts
+++ b/src/services/notion-mcp.ts
@@ -8,6 +8,7 @@
 import { z } from 'zod';
 import type { Browser, BrowserContext, Response } from 'playwright';
 import { type ApiCredentials, OAuthCredentials } from '../apiCredentials/base.js';
+import { DEFAULT_ACCOUNT } from '../apiCredentials/account.js';
 import { runCaptured } from '../curl.js';
 import {
   exchangeCodeForTokens,
@@ -19,6 +20,7 @@ import {
 import {
   Service,
   ServiceSession,
+  type LoginResult,
   LoginFailedError,
   LoginCancelledError,
   buildPreparedCredentials,
@@ -108,7 +110,7 @@ class NotionMcpSession extends ServiceSession {
     encryptedStorage: import('../encryptedStorage.js').EncryptedStorage,
     launchOptions: import('../playwrightUtils.js').BrowserLaunchOptions = {},
     oldCredentials?: ApiCredentials
-  ): Promise<ApiCredentials> {
+  ): Promise<LoginResult> {
     const { withTempBrowserContext } = await import('../playwrightUtils.js');
 
     return withTempBrowserContext(encryptedStorage, launchOptions, async ({ context }) => {
@@ -169,13 +171,18 @@ class NotionMcpSession extends ServiceSession {
 
         await page.close();
 
-        return new OAuthCredentials(
-          clientId,
-          '', // public client
-          tokens.access_token,
-          tokens.refresh_token,
-          accessTokenExpiresAt
-        );
+        // The account is not yet determined for Notion MCP; it defaults to the
+        // unnamed account. (See determineAccount for the general mechanism.)
+        return {
+          credentials: new OAuthCredentials(
+            clientId,
+            '', // public client
+            tokens.access_token,
+            tokens.refresh_token,
+            accessTokenExpiresAt
+          ),
+          account: DEFAULT_ACCOUNT,
+        };
       } catch (error: unknown) {
         if (error instanceof Error && isBrowserClosedError(error)) {
           throw new LoginCancelledError();

--- a/src/services/notion-mcp.ts
+++ b/src/services/notion-mcp.ts
@@ -87,6 +87,26 @@ function registerClient(redirectUri: string, clientName: string): RegistrationRe
   }
 }
 
+/**
+ * Derive the account from the token-exchange response. Notion's MCP token
+ * endpoint reports `user_id`, `workspace_id` and `email_domain` (but not the
+ * full e-mail or the workspace name), and MCP-audienced tokens cannot call the
+ * classic REST API to look up anything richer. Credentials are unique per
+ * (user, workspace), so both parts go into the account key, with the e-mail
+ * domain as the human-readable half.
+ */
+function parseAccountFromTokenResponse(tokens: {
+  user_id?: string;
+  workspace_id?: string;
+  email_domain?: string;
+}): string {
+  const workspacePart = tokens.email_domain ?? tokens.workspace_id;
+  if (tokens.user_id !== undefined && workspacePart !== undefined) {
+    return `${tokens.user_id}@${workspacePart}`;
+  }
+  return tokens.user_id ?? tokens.workspace_id ?? DEFAULT_ACCOUNT;
+}
+
 class NotionMcpSession extends ServiceSession {
   onResponse(_response: Response): void {
     // Not used — login detection is via OAuth callback, not response inspection.
@@ -157,7 +177,9 @@ class NotionMcpSession extends ServiceSession {
         // 5. Wait for user to authorize and callback to receive code
         const code = await codePromise;
 
-        // 6. Exchange code for tokens
+        // 6. Exchange code for tokens. Besides the tokens, Notion's MCP token
+        // endpoint reports who authorized: user_id, workspace_id and
+        // email_domain ride along in the same response.
         const tokens = exchangeCodeForTokens(
           TOKEN_ENDPOINT,
           code,
@@ -165,14 +187,16 @@ class NotionMcpSession extends ServiceSession {
           '', // public client, no secret
           redirectUri,
           codeVerifier
-        );
+        ) as ReturnType<typeof exchangeCodeForTokens> & {
+          user_id?: string;
+          workspace_id?: string;
+          email_domain?: string;
+        };
 
         const accessTokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString();
 
         await page.close();
 
-        // The account is not yet determined for Notion MCP; it defaults to the
-        // unnamed account. (See determineAccount for the general mechanism.)
         return {
           credentials: new OAuthCredentials(
             clientId,
@@ -181,7 +205,7 @@ class NotionMcpSession extends ServiceSession {
             tokens.refresh_token,
             accessTokenExpiresAt
           ),
-          account: DEFAULT_ACCOUNT,
+          account: parseAccountFromTokenResponse(tokens),
         };
       } catch (error: unknown) {
         if (error instanceof Error && isBrowserClosedError(error)) {

--- a/src/services/notion-mcp.ts
+++ b/src/services/notion-mcp.ts
@@ -265,6 +265,15 @@ export class NotionMcp extends Service {
     );
   }
 
+  // MCP-audienced tokens cannot call the classic REST API, and the MCP
+  // endpoint itself reveals no identity. The account is only reported by the
+  // token endpoint during the login code exchange (user_id / workspace_id /
+  // email_domain riding along in the token response), so the login flow
+  // derives it there and stored credentials cannot be re-attributed later.
+  getAccount(): Promise<string | null> {
+    return Promise.resolve(null);
+  }
+
   override getSession(appNamePrefix: string): NotionMcpSession {
     return new NotionMcpSession(this, appNamePrefix);
   }

--- a/src/services/notion-mcp.ts
+++ b/src/services/notion-mcp.ts
@@ -8,7 +8,11 @@
 import { z } from 'zod';
 import type { Browser, BrowserContext, Response } from 'playwright';
 import { type ApiCredentials, OAuthCredentials } from '../apiCredentials/base.js';
-import { DEFAULT_ACCOUNT } from '../apiCredentials/account.js';
+import {
+  DEFAULT_ACCOUNT,
+  fetchAccountFromEndpoint,
+  tryParseJson,
+} from '../apiCredentials/account.js';
 import { runCaptured } from '../curl.js';
 import {
   exchangeCodeForTokens,
@@ -41,6 +45,7 @@ export const NotionMcpPrepareInputSchema = z
 
 export type NotionMcpPrepareInput = z.infer<typeof NotionMcpPrepareInputSchema>;
 
+const MCP_ENDPOINT = 'https://mcp.notion.com/mcp';
 const TOKEN_ENDPOINT = 'https://mcp.notion.com/token';
 const REGISTRATION_ENDPOINT = 'https://mcp.notion.com/register';
 const AUTHORIZATION_ENDPOINT = 'https://mcp.notion.com/authorize';
@@ -88,12 +93,11 @@ function registerClient(redirectUri: string, clientName: string): RegistrationRe
 }
 
 /**
- * Derive the account from the token-exchange response. Notion's MCP token
- * endpoint reports `user_id`, `workspace_id` and `email_domain` (but not the
- * full e-mail or the workspace name), and MCP-audienced tokens cannot call the
- * classic REST API to look up anything richer. Credentials are unique per
- * (user, workspace), so both parts go into the account key, with the e-mail
- * domain as the human-readable half.
+ * Fallback account derivation from the token-exchange response, used when the
+ * MCP `get-users` lookup fails. Notion's MCP token endpoint reports `user_id`,
+ * `workspace_id` and `email_domain` (but not the full e-mail or the workspace
+ * name), so the best it can offer is the opaque user id combined with the
+ * e-mail domain.
  */
 function parseAccountFromTokenResponse(tokens: {
   user_id?: string;
@@ -105,6 +109,80 @@ function parseAccountFromTokenResponse(tokens: {
     return `${tokens.user_id}@${workspacePart}`;
   }
   return tokens.user_id ?? tokens.workspace_id ?? DEFAULT_ACCOUNT;
+}
+
+/**
+ * A single stateless `tools/call` asking the `notion-get-users` tool for the
+ * current user. Notion's MCP server does not require the initialize handshake
+ * or a session id for this, so one POST is enough.
+ */
+const GET_SELF_CURL_ARGUMENTS = [
+  '-X',
+  'POST',
+  '-H',
+  'Content-Type: application/json',
+  '-H',
+  'Accept: application/json, text/event-stream',
+  '-d',
+  JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'tools/call',
+    params: { name: 'notion-get-users', arguments: { user_id: 'self' } },
+  }),
+  MCP_ENDPOINT,
+] as const;
+
+/**
+ * Parse an MCP Streamable HTTP response body: either a plain JSON-RPC message
+ * or an SSE stream whose `data:` lines carry JSON-RPC messages (the last
+ * parseable one wins, which is the response to our request).
+ */
+function parseMcpResponseBody(body: string): unknown {
+  const trimmed = body.trim();
+  if (trimmed.startsWith('data:') || trimmed.startsWith('event:') || trimmed.startsWith(':')) {
+    let lastParsedMessage: unknown = null;
+    for (const line of trimmed.split('\n')) {
+      if (line.startsWith('data:')) {
+        const parsed = tryParseJson(line.slice('data:'.length).trim());
+        if (parsed !== null) {
+          lastParsedMessage = parsed;
+        }
+      }
+    }
+    return lastParsedMessage;
+  }
+  return tryParseJson(trimmed);
+}
+
+/**
+ * Extract the current user from a `notion-get-users` tool response. The tool
+ * result rides as JSON text inside the MCP content parts, e.g.
+ * `{"results":[{"type":"person","id":"...","name":"Hynek Urban","email":
+ * "hynek@imbue.com"}],"has_more":false}`. Prefers the e-mail; falls back to
+ * the name (bots have no e-mail).
+ */
+function parseAccountFromGetUsersResponse(responseBody: string): string | null {
+  const message = parseMcpResponseBody(responseBody) as {
+    result?: { content?: readonly { type?: string; text?: string }[] };
+  } | null;
+  const content = message?.result?.content;
+  if (!Array.isArray(content)) {
+    return null;
+  }
+  for (const part of content as readonly { type?: string; text?: string }[]) {
+    if (part.type !== 'text' || typeof part.text !== 'string') {
+      continue;
+    }
+    const toolResult = tryParseJson(part.text) as {
+      results?: readonly { email?: string; name?: string }[];
+    } | null;
+    const self = toolResult?.results?.[0];
+    if (self !== undefined) {
+      return self.email ?? self.name ?? null;
+    }
+  }
+  return null;
 }
 
 class NotionMcpSession extends ServiceSession {
@@ -197,15 +275,20 @@ class NotionMcpSession extends ServiceSession {
 
         await page.close();
 
+        const credentials = new OAuthCredentials(
+          clientId,
+          '', // public client
+          tokens.access_token,
+          tokens.refresh_token,
+          accessTokenExpiresAt
+        );
+
         return {
-          credentials: new OAuthCredentials(
-            clientId,
-            '', // public client
-            tokens.access_token,
-            tokens.refresh_token,
-            accessTokenExpiresAt
-          ),
-          account: parseAccountFromTokenResponse(tokens),
+          credentials,
+          // Prefer the full e-mail resolved via the MCP get-users tool; fall
+          // back to the coarser identity riding along in the token response.
+          account:
+            (await this.service.getAccount(credentials)) ?? parseAccountFromTokenResponse(tokens),
         };
       } catch (error: unknown) {
         if (error instanceof Error && isBrowserClosedError(error)) {
@@ -265,13 +348,15 @@ export class NotionMcp extends Service {
     );
   }
 
-  // MCP-audienced tokens cannot call the classic REST API, and the MCP
-  // endpoint itself reveals no identity. The account is only reported by the
-  // token endpoint during the login code exchange (user_id / workspace_id /
-  // email_domain riding along in the token response), so the login flow
-  // derives it there and stored credentials cannot be re-attributed later.
-  getAccount(): Promise<string | null> {
-    return Promise.resolve(null);
+  // MCP-audienced tokens cannot call the classic REST API, but the MCP
+  // endpoint itself can reveal the identity: the `get-users` tool returns the
+  // current user's name and e-mail when asked for `self`.
+  getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      GET_SELF_CURL_ARGUMENTS,
+      parseAccountFromGetUsersResponse
+    );
   }
 
   override getSession(appNamePrefix: string): NotionMcpSession {

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -5,7 +5,8 @@
  * (e.g. by creating an internal integration at the loginUrl below).
  */
 
-import { Service, tryParseJson } from './core/base.js';
+import { Service } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 const NOTION_INTEGRATIONS_URL =
   'https://www.notion.so/profile/integrations/internal/form/new-integration';

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -5,7 +5,7 @@
  * (e.g. by creating an internal integration at the loginUrl below).
  */
 
-import { Service } from './core/base.js';
+import { Service, tryParseJson } from './core/base.js';
 
 const NOTION_INTEGRATIONS_URL =
   'https://www.notion.so/profile/integrations/internal/form/new-integration';
@@ -27,6 +27,25 @@ export class Notion extends Service {
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    // Internal-integration tokens authenticate as a bot user; the workspace
+    // name distinguishes tokens for different workspaces better than the
+    // per-integration bot name alone.
+    const data = tryParseJson(responseBody) as {
+      name?: string;
+      id?: string;
+      bot?: { workspace_name?: string };
+    } | null;
+    if (data === null) {
+      return null;
+    }
+    const workspaceName = data.bot?.workspace_name;
+    if (data.name !== undefined && workspaceName !== undefined) {
+      return `${data.name}@${workspaceName}`;
+    }
+    return data.name ?? workspaceName ?? data.id ?? null;
   }
 }
 

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -5,8 +5,9 @@
  * (e.g. by creating an internal integration at the loginUrl below).
  */
 
+import type { ApiCredentials } from '../apiCredentials/base.js';
 import { Service } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 const NOTION_INTEGRATIONS_URL =
   'https://www.notion.so/profile/integrations/internal/form/new-integration';
@@ -30,23 +31,29 @@ export class Notion extends Service {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    // Internal-integration tokens authenticate as a bot user; the workspace
-    // name distinguishes tokens for different workspaces better than the
-    // per-integration bot name alone.
-    const data = tryParseJson(responseBody) as {
-      name?: string;
-      id?: string;
-      bot?: { workspace_name?: string };
-    } | null;
-    if (data === null) {
-      return null;
-    }
-    const workspaceName = data.bot?.workspace_name;
-    if (data.name !== undefined && workspaceName !== undefined) {
-      return `${data.name}@${workspaceName}`;
-    }
-    return data.name ?? workspaceName ?? data.id ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        // Internal-integration tokens authenticate as a bot user; the workspace
+        // name distinguishes tokens for different workspaces better than the
+        // per-integration bot name alone.
+        const data = tryParseJson(responseBody) as {
+          name?: string;
+          id?: string;
+          bot?: { workspace_name?: string };
+        } | null;
+        if (data === null) {
+          return null;
+        }
+        const workspaceName = data.bot?.workspace_name;
+        if (data.name !== undefined && workspaceName !== undefined) {
+          return `${data.name}@${workspaceName}`;
+        }
+        return data.name ?? workspaceName ?? data.id ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/ramp.ts
+++ b/src/services/ramp.ts
@@ -14,8 +14,8 @@
 
 import { randomUUID } from 'node:crypto';
 import type { Browser, BrowserContext, Response } from 'playwright';
-import { ApiCredentials, ApiCredentialStatus, OAuthCredentials } from '../apiCredentials/base.js';
-import { DEFAULT_ACCOUNT, fetchAccountFromEndpoint } from '../apiCredentials/account.js';
+import { ApiCredentials, OAuthCredentials } from '../apiCredentials/base.js';
+import { DEFAULT_ACCOUNT, fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 import {
   exchangeCodeForTokens,
   generateCodeChallenge,
@@ -24,7 +24,6 @@ import {
   startOAuthCallbackServer,
 } from '../oauthUtils.js';
 import {
-  type CredentialCheck,
   isBrowserClosedError,
   type LoginResult,
   LoginCancelledError,
@@ -179,8 +178,8 @@ class RampOAuthServiceSession extends ServiceSession {
           tokens.refresh_token,
           accessTokenExpiresAt
         );
-        const credentialCheck = await this.service.checkApiCredentials(credentials);
-        return { credentials, account: credentialCheck.account ?? DEFAULT_ACCOUNT };
+        const account = (await this.service.getAccount(credentials)) ?? DEFAULT_ACCOUNT;
+        return { credentials, account };
       } catch (error: unknown) {
         if (error instanceof Error && isBrowserClosedError(error)) {
           throw new LoginCancelledError();
@@ -223,15 +222,15 @@ export class Ramp extends Service {
   }
 
   /**
-   * The check first asks `get-simplified-user-detail` — the agent-tools
-   * endpoint that returns the caller's user — whose response both proves the
-   * token valid and reveals the account. It needs the `users:read` scope
-   * (requested during login, but granted only if the signed-in user is
-   * entitled to it), so when it reveals nothing the check falls back to the
-   * scope-less help-center endpoint, which carries no identity.
+   * The account comes from `get-simplified-user-detail` — the agent-tools
+   * endpoint that returns the caller's user — rather than the scope-less
+   * help-center endpoint used by the credential check, which carries no
+   * identity. It needs the `users:read` scope (requested during login, but
+   * granted only if the signed-in user is entitled to it), so the account may
+   * stay undetermined.
    */
-  override async checkApiCredentials(apiCredentials: ApiCredentials): Promise<CredentialCheck> {
-    const account = await fetchAccountFromEndpoint(
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
       apiCredentials,
       [
         '-X',
@@ -242,18 +241,14 @@ export class Ramp extends Service {
         '{"rationale":"latchkey determines which account these credentials belong to"}',
         'https://api.ramp.com/developer/v1/agent-tools/get-simplified-user-detail',
       ],
-      (responseData) => {
-        const data = responseData as {
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as {
           users?: readonly { email?: string; id?: string }[];
         } | null;
         const user = data?.users?.[0];
         return user?.email ?? user?.id ?? null;
       }
     );
-    if (account !== null) {
-      return { status: ApiCredentialStatus.Valid, account };
-    }
-    return super.checkApiCredentials(apiCredentials);
   }
 
   /**

--- a/src/services/ramp.ts
+++ b/src/services/ramp.ts
@@ -16,11 +16,10 @@ import { randomUUID } from 'node:crypto';
 import type { Browser, BrowserContext, Response } from 'playwright';
 import {
   ApiCredentials,
-  ApiCredentialsUsageError,
+  ApiCredentialStatus,
   OAuthCredentials,
 } from '../apiCredentials/base.js';
-import { DEFAULT_ACCOUNT } from '../apiCredentials/account.js';
-import { runCaptured } from '../curl.js';
+import { DEFAULT_ACCOUNT, fetchAccountFromEndpoint } from '../apiCredentials/account.js';
 import {
   exchangeCodeForTokens,
   generateCodeChallenge,
@@ -29,12 +28,12 @@ import {
   startOAuthCallbackServer,
 } from '../oauthUtils.js';
 import {
+  type CredentialCheck,
   isBrowserClosedError,
   type LoginResult,
   LoginCancelledError,
   Service,
   ServiceSession,
-  tryParseJson,
 } from './core/base.js';
 
 /** Ramp's public OAuth client (PKCE, no secret), from ramp-cli. */
@@ -184,8 +183,8 @@ class RampOAuthServiceSession extends ServiceSession {
           tokens.refresh_token,
           accessTokenExpiresAt
         );
-        const account = (await this.service.determineAccount(credentials)) ?? DEFAULT_ACCOUNT;
-        return { credentials, account };
+        const credentialCheck = await this.service.checkApiCredentials(credentials);
+        return { credentials, account: credentialCheck.account ?? DEFAULT_ACCOUNT };
       } catch (error: unknown) {
         if (error instanceof Error && isBrowserClosedError(error)) {
           throw new LoginCancelledError();
@@ -228,17 +227,17 @@ export class Ramp extends Service {
   }
 
   /**
-   * The credential-check endpoint carries no identity, so the account comes
-   * from a separate call to `get-simplified-user-detail` — the agent-tools
-   * endpoint that returns the caller's user. Best-effort: it needs the
-   * `users:read` scope (requested during login, but granted only if the
-   * signed-in user is entitled to it).
+   * The check first asks `get-simplified-user-detail` — the agent-tools
+   * endpoint that returns the caller's user — whose response both proves the
+   * token valid and reveals the account. It needs the `users:read` scope
+   * (requested during login, but granted only if the signed-in user is
+   * entitled to it), so when it reveals nothing the check falls back to the
+   * scope-less help-center endpoint, which carries no identity.
    */
-  override async determineAccount(apiCredentials: ApiCredentials): Promise<string | null> {
-    let curlArguments: readonly string[];
-    try {
-      curlArguments = await apiCredentials.injectIntoCurlCall([
-        '-s',
+  override async checkApiCredentials(apiCredentials: ApiCredentials): Promise<CredentialCheck> {
+    const account = await fetchAccountFromEndpoint(
+      apiCredentials,
+      [
         '-X',
         'POST',
         '-H',
@@ -246,19 +245,19 @@ export class Ramp extends Service {
         '-d',
         '{"rationale":"latchkey determines which account these credentials belong to"}',
         'https://api.ramp.com/developer/v1/agent-tools/get-simplified-user-detail',
-      ]);
-    } catch (error) {
-      if (error instanceof ApiCredentialsUsageError) {
-        return null;
+      ],
+      (responseData) => {
+        const data = responseData as {
+          users?: readonly { email?: string; id?: string }[];
+        } | null;
+        const user = data?.users?.[0];
+        return user?.email ?? user?.id ?? null;
       }
-      throw error;
+    );
+    if (account !== null) {
+      return { status: ApiCredentialStatus.Valid, account };
     }
-    const result = runCaptured(curlArguments, 10);
-    const data = tryParseJson(result.stdout) as {
-      users?: readonly { email?: string; id?: string }[];
-    } | null;
-    const user = data?.users?.[0];
-    return user?.email ?? user?.id ?? null;
+    return super.checkApiCredentials(apiCredentials);
   }
 
   /**

--- a/src/services/ramp.ts
+++ b/src/services/ramp.ts
@@ -14,11 +14,7 @@
 
 import { randomUUID } from 'node:crypto';
 import type { Browser, BrowserContext, Response } from 'playwright';
-import {
-  ApiCredentials,
-  ApiCredentialStatus,
-  OAuthCredentials,
-} from '../apiCredentials/base.js';
+import { ApiCredentials, ApiCredentialStatus, OAuthCredentials } from '../apiCredentials/base.js';
 import { DEFAULT_ACCOUNT, fetchAccountFromEndpoint } from '../apiCredentials/account.js';
 import {
   exchangeCodeForTokens,

--- a/src/services/ramp.ts
+++ b/src/services/ramp.ts
@@ -14,8 +14,13 @@
 
 import { randomUUID } from 'node:crypto';
 import type { Browser, BrowserContext, Response } from 'playwright';
-import { ApiCredentials, OAuthCredentials } from '../apiCredentials/base.js';
+import {
+  ApiCredentials,
+  ApiCredentialsUsageError,
+  OAuthCredentials,
+} from '../apiCredentials/base.js';
 import { DEFAULT_ACCOUNT } from '../apiCredentials/account.js';
+import { runCaptured } from '../curl.js';
 import {
   exchangeCodeForTokens,
   generateCodeChallenge,
@@ -29,6 +34,7 @@ import {
   LoginCancelledError,
   Service,
   ServiceSession,
+  tryParseJson,
 } from './core/base.js';
 
 /** Ramp's public OAuth client (PKCE, no secret), from ramp-cli. */
@@ -171,17 +177,15 @@ class RampOAuthServiceSession extends ServiceSession {
         await page.close();
 
         // Public client: clientSecret is stored as '' so refresh sends client_id only.
-        // The account defaults to the unnamed account for now.
-        return {
-          credentials: new OAuthCredentials(
-            clientId,
-            '',
-            tokens.access_token,
-            tokens.refresh_token,
-            accessTokenExpiresAt
-          ),
-          account: DEFAULT_ACCOUNT,
-        };
+        const credentials = new OAuthCredentials(
+          clientId,
+          '',
+          tokens.access_token,
+          tokens.refresh_token,
+          accessTokenExpiresAt
+        );
+        const account = (await this.service.determineAccount(credentials)) ?? DEFAULT_ACCOUNT;
+        return { credentials, account };
       } catch (error: unknown) {
         if (error instanceof Error && isBrowserClosedError(error)) {
           throw new LoginCancelledError();
@@ -221,6 +225,40 @@ export class Ramp extends Service {
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth browser ${serviceName}`;
+  }
+
+  /**
+   * The credential-check endpoint carries no identity, so the account comes
+   * from a separate call to `get-simplified-user-detail` — the agent-tools
+   * endpoint that returns the caller's user. Best-effort: it needs the
+   * `users:read` scope (requested during login, but granted only if the
+   * signed-in user is entitled to it).
+   */
+  override async determineAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    let curlArguments: readonly string[];
+    try {
+      curlArguments = await apiCredentials.injectIntoCurlCall([
+        '-s',
+        '-X',
+        'POST',
+        '-H',
+        'Content-Type: application/json',
+        '-d',
+        '{"rationale":"latchkey determines which account these credentials belong to"}',
+        'https://api.ramp.com/developer/v1/agent-tools/get-simplified-user-detail',
+      ]);
+    } catch (error) {
+      if (error instanceof ApiCredentialsUsageError) {
+        return null;
+      }
+      throw error;
+    }
+    const result = runCaptured(curlArguments, 10);
+    const data = tryParseJson(result.stdout) as {
+      users?: readonly { email?: string; id?: string }[];
+    } | null;
+    const user = data?.users?.[0];
+    return user?.email ?? user?.id ?? null;
   }
 
   /**

--- a/src/services/ramp.ts
+++ b/src/services/ramp.ts
@@ -15,7 +15,11 @@
 import { randomUUID } from 'node:crypto';
 import type { Browser, BrowserContext, Response } from 'playwright';
 import { ApiCredentials, OAuthCredentials } from '../apiCredentials/base.js';
-import { DEFAULT_ACCOUNT, fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
+import {
+  DEFAULT_ACCOUNT,
+  fetchAccountFromEndpoint,
+  tryParseJson,
+} from '../apiCredentials/account.js';
 import {
   exchangeCodeForTokens,
   generateCodeChallenge,

--- a/src/services/ramp.ts
+++ b/src/services/ramp.ts
@@ -15,6 +15,7 @@
 import { randomUUID } from 'node:crypto';
 import type { Browser, BrowserContext, Response } from 'playwright';
 import { ApiCredentials, OAuthCredentials } from '../apiCredentials/base.js';
+import { DEFAULT_ACCOUNT } from '../apiCredentials/account.js';
 import {
   exchangeCodeForTokens,
   generateCodeChallenge,
@@ -22,7 +23,13 @@ import {
   refreshAccessToken,
   startOAuthCallbackServer,
 } from '../oauthUtils.js';
-import { isBrowserClosedError, LoginCancelledError, Service, ServiceSession } from './core/base.js';
+import {
+  isBrowserClosedError,
+  type LoginResult,
+  LoginCancelledError,
+  Service,
+  ServiceSession,
+} from './core/base.js';
 
 /** Ramp's public OAuth client (PKCE, no secret), from ramp-cli. */
 const RAMP_OAUTH_CLIENT_ID = 'ramp_id_6pKvd0IR3d8Kuzp82SV6YgpVCZOlz68Px6s3wVsr';
@@ -105,7 +112,7 @@ class RampOAuthServiceSession extends ServiceSession {
     encryptedStorage: import('../encryptedStorage.js').EncryptedStorage,
     launchOptions: import('../playwrightUtils.js').BrowserLaunchOptions = {},
     _oldCredentials?: ApiCredentials
-  ): Promise<ApiCredentials> {
+  ): Promise<LoginResult> {
     const { withTempBrowserContext } = await import('../playwrightUtils.js');
     const clientId = RAMP_OAUTH_CLIENT_ID;
 
@@ -164,13 +171,17 @@ class RampOAuthServiceSession extends ServiceSession {
         await page.close();
 
         // Public client: clientSecret is stored as '' so refresh sends client_id only.
-        return new OAuthCredentials(
-          clientId,
-          '',
-          tokens.access_token,
-          tokens.refresh_token,
-          accessTokenExpiresAt
-        );
+        // The account defaults to the unnamed account for now.
+        return {
+          credentials: new OAuthCredentials(
+            clientId,
+            '',
+            tokens.access_token,
+            tokens.refresh_token,
+            accessTokenExpiresAt
+          ),
+          account: DEFAULT_ACCOUNT,
+        };
       } catch (error: unknown) {
         if (error instanceof Error && isBrowserClosedError(error)) {
           throw new LoginCancelledError();

--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -1,5 +1,6 @@
+import type { ApiCredentials } from '../apiCredentials/base.js';
 import { Service } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 export class Sentry extends Service {
   readonly name = 'sentry';
@@ -28,11 +29,17 @@ export class Sentry extends Service {
     return data?.user !== undefined && data.user !== null && data.user !== false;
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    const data = tryParseJson(responseBody) as {
-      user?: { email?: string; username?: string; id?: string };
-    } | null;
-    return data?.user?.email ?? data?.user?.username ?? data?.user?.id ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as {
+          user?: { email?: string; username?: string; id?: string };
+        } | null;
+        return data?.user?.email ?? data?.user?.username ?? data?.user?.id ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -1,4 +1,5 @@
-import { Service, tryParseJson } from './core/base.js';
+import { Service } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 export class Sentry extends Service {
   readonly name = 'sentry';

--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -1,10 +1,4 @@
-import {
-  ApiCredentialStatus,
-  type ApiCredentials,
-  ApiCredentialsUsageError,
-} from '../apiCredentials/base.js';
-import { runCaptured } from '../curl.js';
-import { Service } from './core/base.js';
+import { Service, tryParseJson } from './core/base.js';
 
 export class Sentry extends Service {
   readonly name = 'sentry';
@@ -23,31 +17,21 @@ export class Sentry extends Service {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
   }
 
-  override async checkApiCredentials(apiCredentials: ApiCredentials): Promise<ApiCredentialStatus> {
-    let allCurlArgs: readonly string[];
-    try {
-      allCurlArgs = await apiCredentials.injectIntoCurlCall([
-        '-s',
-        ...this.credentialCheckCurlArguments,
-      ]);
-    } catch (error) {
-      if (error instanceof ApiCredentialsUsageError) {
-        return ApiCredentialStatus.Missing;
-      }
-      throw error;
-    }
+  // The root API endpoint responds HTTP 200 even without valid credentials;
+  // authenticated requests are recognizable by the `user` field in the body.
+  protected override isCredentialCheckResponseValid(
+    _httpStatusCode: string,
+    responseBody: string
+  ): boolean {
+    const data = tryParseJson(responseBody) as { user?: unknown } | null;
+    return data?.user !== undefined && data.user !== null && data.user !== false;
+  }
 
-    const result = runCaptured(allCurlArgs, 10);
-
-    try {
-      const data = JSON.parse(result.stdout) as { user?: unknown };
-      if (data.user) {
-        return ApiCredentialStatus.Valid;
-      }
-      return ApiCredentialStatus.Invalid;
-    } catch {
-      return ApiCredentialStatus.Invalid;
-    }
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    const data = tryParseJson(responseBody) as {
+      user?: { email?: string; username?: string; id?: string };
+    } | null;
+    return data?.user?.email ?? data?.user?.username ?? data?.user?.id ?? null;
   }
 }
 

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -4,9 +4,8 @@
 
 import type { Response } from 'playwright';
 import { z } from 'zod';
-import { ApiCredentialStatus, type ApiCredentials } from '../apiCredentials/base.js';
-import { runCaptured } from '../curl.js';
-import { Service, SimpleServiceSession } from './core/base.js';
+import type { ApiCredentials } from '../apiCredentials/base.js';
+import { Service, SimpleServiceSession, tryParseJson } from './core/base.js';
 
 /**
  * Slack-specific credentials (token + d cookie).
@@ -117,21 +116,31 @@ export class Slack extends Service {
     return new SlackServiceSession(this, appNamePrefix);
   }
 
-  override async checkApiCredentials(apiCredentials: ApiCredentials): Promise<ApiCredentialStatus> {
-    const result = runCaptured(
-      await apiCredentials.injectIntoCurlCall(['-s', ...this.credentialCheckCurlArguments]),
-      10
-    );
+  // auth.test reports authentication failures as HTTP 200 with `ok: false`,
+  // so validity comes from the body rather than the status code.
+  protected override isCredentialCheckResponseValid(
+    _httpStatusCode: string,
+    responseBody: string
+  ): boolean {
+    const data = tryParseJson(responseBody) as { ok?: boolean } | null;
+    return data?.ok === true;
+  }
 
-    try {
-      const data = JSON.parse(result.stdout) as { ok?: boolean };
-      if (data.ok) {
-        return ApiCredentialStatus.Valid;
-      }
-      return ApiCredentialStatus.Invalid;
-    } catch {
-      return ApiCredentialStatus.Invalid;
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    const data = tryParseJson(responseBody) as {
+      user?: string;
+      team?: string;
+      url?: string;
+    } | null;
+    if (data?.user === undefined) {
+      return null;
     }
+    // The same user can be signed in to several workspaces, so the account
+    // includes the workspace: prefer the stable subdomain from the workspace
+    // URL, falling back to the display name.
+    const workspaceMatch = data.url === undefined ? null : /^https:\/\/([^./]+)\./.exec(data.url);
+    const workspace = workspaceMatch?.[1] ?? data.team;
+    return workspace === undefined ? data.user : `${data.user}@${workspace}`;
   }
 }
 

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -6,7 +6,7 @@ import type { Response } from 'playwright';
 import { z } from 'zod';
 import type { ApiCredentials } from '../apiCredentials/base.js';
 import { Service, SimpleServiceSession } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 /**
  * Slack-specific credentials (token + d cookie).
@@ -127,21 +127,28 @@ export class Slack extends Service {
     return data?.ok === true;
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    const data = tryParseJson(responseBody) as {
-      user?: string;
-      team?: string;
-      url?: string;
-    } | null;
-    if (data?.user === undefined) {
-      return null;
-    }
-    // The same user can be signed in to several workspaces, so the account
-    // includes the workspace: prefer the stable subdomain from the workspace
-    // URL, falling back to the display name.
-    const workspaceMatch = data.url === undefined ? null : /^https:\/\/([^./]+)\./.exec(data.url);
-    const workspace = workspaceMatch?.[1] ?? data.team;
-    return workspace === undefined ? data.user : `${data.user}@${workspace}`;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as {
+          user?: string;
+          team?: string;
+          url?: string;
+        } | null;
+        if (data?.user === undefined) {
+          return null;
+        }
+        // The same user can be signed in to several workspaces, so the account
+        // includes the workspace: prefer the stable subdomain from the workspace
+        // URL, falling back to the display name.
+        const workspaceMatch =
+          data.url === undefined ? null : /^https:\/\/([^./]+)\./.exec(data.url);
+        const workspace = workspaceMatch?.[1] ?? data.team;
+        return workspace === undefined ? data.user : `${data.user}@${workspace}`;
+      }
+    );
   }
 }
 

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -5,7 +5,8 @@
 import type { Response } from 'playwright';
 import { z } from 'zod';
 import type { ApiCredentials } from '../apiCredentials/base.js';
-import { Service, SimpleServiceSession, tryParseJson } from './core/base.js';
+import { Service, SimpleServiceSession } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 /**
  * Slack-specific credentials (token + d cookie).

--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -1,4 +1,9 @@
-import { Service } from './core/base.js';
+import {
+  type ApiCredentials,
+  ApiCredentialsUsageError,
+} from '../apiCredentials/base.js';
+import { runCaptured } from '../curl.js';
+import { Service, tryParseJson } from './core/base.js';
 
 export class Stripe extends Service {
   readonly name = 'stripe';
@@ -11,6 +16,37 @@ export class Stripe extends Service {
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  /**
+   * The balance endpoint used for the credential check works with restricted
+   * keys but carries no identity, so the account is fetched separately from
+   * /v1/account — best-effort, because restricted keys may not be allowed to
+   * read the account.
+   */
+  override async determineAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    let curlArguments: readonly string[];
+    try {
+      curlArguments = await apiCredentials.injectIntoCurlCall([
+        '-s',
+        'https://api.stripe.com/v1/account',
+      ]);
+    } catch (error) {
+      if (error instanceof ApiCredentialsUsageError) {
+        return null;
+      }
+      throw error;
+    }
+    const result = runCaptured(curlArguments, 10);
+    const data = tryParseJson(result.stdout) as {
+      email?: string | null;
+      id?: string;
+      error?: unknown;
+    } | null;
+    if (data === null || data.error !== undefined) {
+      return null;
+    }
+    return data.email ?? data.id ?? null;
   }
 }
 

--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -1,6 +1,6 @@
-import { type ApiCredentials, ApiCredentialStatus } from '../apiCredentials/base.js';
-import { fetchAccountFromEndpoint } from '../apiCredentials/account.js';
-import { type CredentialCheck, Service } from './core/base.js';
+import type { ApiCredentials } from '../apiCredentials/base.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
+import { Service } from './core/base.js';
 
 export class Stripe extends Service {
   readonly name = 'stripe';
@@ -16,18 +16,16 @@ export class Stripe extends Service {
   }
 
   /**
-   * The check first asks /v1/account, whose response both proves the key
-   * valid and reveals the account. Restricted keys may not be allowed to read
-   * the account, so when that reveals nothing the check falls back to the
-   * balance endpoint (which works with restricted keys but carries no
-   * identity).
+   * The account comes from /v1/account rather than the balance endpoint used
+   * by the credential check, which carries no identity. Restricted keys may
+   * not be allowed to read the account, in which case it stays undetermined.
    */
-  override async checkApiCredentials(apiCredentials: ApiCredentials): Promise<CredentialCheck> {
-    const account = await fetchAccountFromEndpoint(
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
       apiCredentials,
       ['https://api.stripe.com/v1/account'],
-      (responseData) => {
-        const data = responseData as {
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as {
           email?: string | null;
           id?: string;
           error?: unknown;
@@ -38,10 +36,6 @@ export class Stripe extends Service {
         return data.email ?? data.id ?? null;
       }
     );
-    if (account !== null) {
-      return { status: ApiCredentialStatus.Valid, account };
-    }
-    return super.checkApiCredentials(apiCredentials);
   }
 }
 

--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -1,9 +1,6 @@
-import {
-  type ApiCredentials,
-  ApiCredentialsUsageError,
-} from '../apiCredentials/base.js';
-import { runCaptured } from '../curl.js';
-import { Service, tryParseJson } from './core/base.js';
+import { type ApiCredentials, ApiCredentialStatus } from '../apiCredentials/base.js';
+import { fetchAccountFromEndpoint } from '../apiCredentials/account.js';
+import { type CredentialCheck, Service } from './core/base.js';
 
 export class Stripe extends Service {
   readonly name = 'stripe';
@@ -19,34 +16,32 @@ export class Stripe extends Service {
   }
 
   /**
-   * The balance endpoint used for the credential check works with restricted
-   * keys but carries no identity, so the account is fetched separately from
-   * /v1/account — best-effort, because restricted keys may not be allowed to
-   * read the account.
+   * The check first asks /v1/account, whose response both proves the key
+   * valid and reveals the account. Restricted keys may not be allowed to read
+   * the account, so when that reveals nothing the check falls back to the
+   * balance endpoint (which works with restricted keys but carries no
+   * identity).
    */
-  override async determineAccount(apiCredentials: ApiCredentials): Promise<string | null> {
-    let curlArguments: readonly string[];
-    try {
-      curlArguments = await apiCredentials.injectIntoCurlCall([
-        '-s',
-        'https://api.stripe.com/v1/account',
-      ]);
-    } catch (error) {
-      if (error instanceof ApiCredentialsUsageError) {
-        return null;
+  override async checkApiCredentials(apiCredentials: ApiCredentials): Promise<CredentialCheck> {
+    const account = await fetchAccountFromEndpoint(
+      apiCredentials,
+      ['https://api.stripe.com/v1/account'],
+      (responseData) => {
+        const data = responseData as {
+          email?: string | null;
+          id?: string;
+          error?: unknown;
+        } | null;
+        if (data === null || data.error !== undefined) {
+          return null;
+        }
+        return data.email ?? data.id ?? null;
       }
-      throw error;
+    );
+    if (account !== null) {
+      return { status: ApiCredentialStatus.Valid, account };
     }
-    const result = runCaptured(curlArguments, 10);
-    const data = tryParseJson(result.stdout) as {
-      email?: string | null;
-      id?: string;
-      error?: unknown;
-    } | null;
-    if (data === null || data.error !== undefined) {
-      return null;
-    }
-    return data.email ?? data.id ?? null;
+    return super.checkApiCredentials(apiCredentials);
   }
 }
 

--- a/src/services/telegram.ts
+++ b/src/services/telegram.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { type ApiCredentials } from '../apiCredentials/base.js';
 import { extractUrlFromCurlArguments } from '../curl.js';
 import { NoCurlCredentialsNotSupportedError, Service } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 const BASE_API_URL = 'https://api.telegram.org/';
 
@@ -87,11 +87,17 @@ export class Telegram extends Service {
     return new TelegramBotCredentials(token);
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    const data = tryParseJson(responseBody) as {
-      result?: { username?: string; id?: number };
-    } | null;
-    return data?.result?.username ?? data?.result?.id?.toString() ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as {
+          result?: { username?: string; id?: number };
+        } | null;
+        return data?.result?.username ?? data?.result?.id?.toString() ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/telegram.ts
+++ b/src/services/telegram.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 import { type ApiCredentials } from '../apiCredentials/base.js';
 import { extractUrlFromCurlArguments } from '../curl.js';
-import { NoCurlCredentialsNotSupportedError, Service, tryParseJson } from './core/base.js';
+import { NoCurlCredentialsNotSupportedError, Service } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 const BASE_API_URL = 'https://api.telegram.org/';
 

--- a/src/services/telegram.ts
+++ b/src/services/telegram.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { type ApiCredentials } from '../apiCredentials/base.js';
 import { extractUrlFromCurlArguments } from '../curl.js';
-import { NoCurlCredentialsNotSupportedError, Service } from './core/base.js';
+import { NoCurlCredentialsNotSupportedError, Service, tryParseJson } from './core/base.js';
 
 const BASE_API_URL = 'https://api.telegram.org/';
 
@@ -84,6 +84,13 @@ export class Telegram extends Service {
       );
     }
     return new TelegramBotCredentials(token);
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    const data = tryParseJson(responseBody) as {
+      result?: { username?: string; id?: number };
+    } | null;
+    return data?.result?.username ?? data?.result?.id?.toString() ?? null;
   }
 }
 

--- a/src/services/todoist.ts
+++ b/src/services/todoist.ts
@@ -4,7 +4,12 @@
 
 import type { Response, BrowserContext } from 'playwright';
 import { ApiCredentials, AuthorizationBearer } from '../apiCredentials/base.js';
-import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
+import {
+  Service,
+  BrowserFollowupServiceSession,
+  LoginFailedError,
+  tryParseJson,
+} from './core/base.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 
@@ -81,10 +86,20 @@ export class Todoist extends Service {
     'https://developer.todoist.com/api/v1. ' +
     'The personal API token is read from Settings → Integrations → Developer during login.';
 
-  readonly credentialCheckCurlArguments = ['https://api.todoist.com/api/v1/projects'] as const;
+  // /user both validates the token and identifies the account.
+  readonly credentialCheckCurlArguments = ['https://api.todoist.com/api/v1/user'] as const;
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    const data = tryParseJson(responseBody) as {
+      email?: string;
+      full_name?: string;
+      id?: string;
+    } | null;
+    return data?.email ?? data?.full_name ?? data?.id ?? null;
   }
 
   override getSession(appNamePrefix: string): TodoistServiceSession {

--- a/src/services/todoist.ts
+++ b/src/services/todoist.ts
@@ -5,7 +5,7 @@
 import type { Response, BrowserContext } from 'playwright';
 import { ApiCredentials, AuthorizationBearer } from '../apiCredentials/base.js';
 import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 
@@ -89,13 +89,19 @@ export class Todoist extends Service {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    const data = tryParseJson(responseBody) as {
-      email?: string;
-      full_name?: string;
-      id?: string;
-    } | null;
-    return data?.email ?? data?.full_name ?? data?.id ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as {
+          email?: string;
+          full_name?: string;
+          id?: string;
+        } | null;
+        return data?.email ?? data?.full_name ?? data?.id ?? null;
+      }
+    );
   }
 
   override getSession(appNamePrefix: string): TodoistServiceSession {

--- a/src/services/todoist.ts
+++ b/src/services/todoist.ts
@@ -8,8 +8,8 @@ import {
   Service,
   BrowserFollowupServiceSession,
   LoginFailedError,
-  tryParseJson,
 } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 

--- a/src/services/todoist.ts
+++ b/src/services/todoist.ts
@@ -4,11 +4,7 @@
 
 import type { Response, BrowserContext } from 'playwright';
 import { ApiCredentials, AuthorizationBearer } from '../apiCredentials/base.js';
-import {
-  Service,
-  BrowserFollowupServiceSession,
-  LoginFailedError,
-} from './core/base.js';
+import { Service, BrowserFollowupServiceSession, LoginFailedError } from './core/base.js';
 import { tryParseJson } from '../apiCredentials/account.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;

--- a/src/services/umami.ts
+++ b/src/services/umami.ts
@@ -1,4 +1,5 @@
-import { Service, tryParseJson } from './core/base.js';
+import { Service } from './core/base.js';
+import { tryParseJson } from '../apiCredentials/account.js';
 
 export class Umami extends Service {
   readonly name = 'umami';

--- a/src/services/umami.ts
+++ b/src/services/umami.ts
@@ -1,5 +1,6 @@
+import type { ApiCredentials } from '../apiCredentials/base.js';
 import { Service } from './core/base.js';
-import { tryParseJson } from '../apiCredentials/account.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
 
 export class Umami extends Service {
   readonly name = 'umami';
@@ -16,12 +17,18 @@ export class Umami extends Service {
     return `latchkey auth set ${serviceName} -H "x-umami-api-key: <api-key>"`;
   }
 
-  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
-    // On Umami Cloud the username is the account e-mail.
-    const data = tryParseJson(responseBody) as {
-      user?: { username?: string; id?: string };
-    } | null;
-    return data?.user?.username ?? data?.user?.id ?? null;
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        // On Umami Cloud the username is the account e-mail.
+        const data = tryParseJson(responseBody) as {
+          user?: { username?: string; id?: string };
+        } | null;
+        return data?.user?.username ?? data?.user?.id ?? null;
+      }
+    );
   }
 }
 

--- a/src/services/umami.ts
+++ b/src/services/umami.ts
@@ -1,4 +1,4 @@
-import { Service } from './core/base.js';
+import { Service, tryParseJson } from './core/base.js';
 
 export class Umami extends Service {
   readonly name = 'umami';
@@ -7,10 +7,20 @@ export class Umami extends Service {
   readonly loginUrl = 'https://cloud.umami.is/login';
   readonly info = 'https://umami.is/docs/api.';
 
-  readonly credentialCheckCurlArguments = ['https://api.umami.is/v1/websites'] as const;
+  // /v1/me both validates the API key and identifies the account (it is one of
+  // the few endpoints allowed for API-key authentication).
+  readonly credentialCheckCurlArguments = ['https://api.umami.is/v1/me'] as const;
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "x-umami-api-key: <api-key>"`;
+  }
+
+  protected override parseAccountFromCredentialCheckBody(responseBody: string): string | null {
+    // On Umami Cloud the username is the account e-mail.
+    const data = tryParseJson(responseBody) as {
+      user?: { username?: string; id?: string };
+    } | null;
+    return data?.user?.username ?? data?.user?.id ?? null;
   }
 }
 

--- a/src/services/yelp.ts
+++ b/src/services/yelp.ts
@@ -14,6 +14,12 @@ export class Yelp extends Service {
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
   }
+
+  // Yelp API keys are app-scoped and the Fusion API has no endpoint that
+  // reveals the account behind them.
+  getAccount(): Promise<string | null> {
+    return Promise.resolve(null);
+  }
 }
 
 export const YELP = new Yelp();

--- a/src/services/zoom.ts
+++ b/src/services/zoom.ts
@@ -1,6 +1,6 @@
-import { type ApiCredentials, ApiCredentialStatus } from '../apiCredentials/base.js';
-import { fetchAccountFromEndpoint } from '../apiCredentials/account.js';
-import { type CredentialCheck, Service } from './core/base.js';
+import type { ApiCredentials } from '../apiCredentials/base.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
+import { Service } from './core/base.js';
 
 export class Zoom extends Service {
   readonly name = 'zoom';
@@ -20,18 +20,17 @@ export class Zoom extends Service {
   }
 
   /**
-   * The check first asks /users/me, whose response both proves the token
-   * valid and reveals the account. Server-to-server tokens have no user
-   * context and error on /users/me, so when that reveals nothing the check
-   * falls back to the user-list endpoint (which works for them but carries no
-   * identity).
+   * The account comes from /users/me rather than the user-list endpoint used
+   * by the credential check, which carries no identity. Server-to-server
+   * tokens have no user context and error on /users/me, in which case the
+   * account stays undetermined.
    */
-  override async checkApiCredentials(apiCredentials: ApiCredentials): Promise<CredentialCheck> {
-    const account = await fetchAccountFromEndpoint(
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
       apiCredentials,
       ['https://api.zoom.us/v2/users/me'],
-      (responseData) => {
-        const data = responseData as {
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as {
           email?: string;
           id?: string;
           code?: number;
@@ -42,10 +41,6 @@ export class Zoom extends Service {
         return data.email ?? data.id ?? null;
       }
     );
-    if (account !== null) {
-      return { status: ApiCredentialStatus.Valid, account };
-    }
-    return super.checkApiCredentials(apiCredentials);
   }
 }
 

--- a/src/services/zoom.ts
+++ b/src/services/zoom.ts
@@ -1,9 +1,6 @@
-import {
-  type ApiCredentials,
-  ApiCredentialsUsageError,
-} from '../apiCredentials/base.js';
-import { runCaptured } from '../curl.js';
-import { Service, tryParseJson } from './core/base.js';
+import { type ApiCredentials, ApiCredentialStatus } from '../apiCredentials/base.js';
+import { fetchAccountFromEndpoint } from '../apiCredentials/account.js';
+import { type CredentialCheck, Service } from './core/base.js';
 
 export class Zoom extends Service {
   readonly name = 'zoom';
@@ -23,34 +20,32 @@ export class Zoom extends Service {
   }
 
   /**
-   * The credential check must stay on the user-list endpoint because
-   * server-to-server tokens have no user context and error on /users/me. The
-   * account is instead determined by a separate best-effort call to /users/me,
-   * which works for user-level tokens.
+   * The check first asks /users/me, whose response both proves the token
+   * valid and reveals the account. Server-to-server tokens have no user
+   * context and error on /users/me, so when that reveals nothing the check
+   * falls back to the user-list endpoint (which works for them but carries no
+   * identity).
    */
-  override async determineAccount(apiCredentials: ApiCredentials): Promise<string | null> {
-    let curlArguments: readonly string[];
-    try {
-      curlArguments = await apiCredentials.injectIntoCurlCall([
-        '-s',
-        'https://api.zoom.us/v2/users/me',
-      ]);
-    } catch (error) {
-      if (error instanceof ApiCredentialsUsageError) {
-        return null;
+  override async checkApiCredentials(apiCredentials: ApiCredentials): Promise<CredentialCheck> {
+    const account = await fetchAccountFromEndpoint(
+      apiCredentials,
+      ['https://api.zoom.us/v2/users/me'],
+      (responseData) => {
+        const data = responseData as {
+          email?: string;
+          id?: string;
+          code?: number;
+        } | null;
+        if (data === null || data.code !== undefined) {
+          return null;
+        }
+        return data.email ?? data.id ?? null;
       }
-      throw error;
+    );
+    if (account !== null) {
+      return { status: ApiCredentialStatus.Valid, account };
     }
-    const result = runCaptured(curlArguments, 10);
-    const data = tryParseJson(result.stdout) as {
-      email?: string;
-      id?: string;
-      code?: number;
-    } | null;
-    if (data === null || data.code !== undefined) {
-      return null;
-    }
-    return data.email ?? data.id ?? null;
+    return super.checkApiCredentials(apiCredentials);
   }
 }
 

--- a/src/services/zoom.ts
+++ b/src/services/zoom.ts
@@ -1,4 +1,9 @@
-import { Service } from './core/base.js';
+import {
+  type ApiCredentials,
+  ApiCredentialsUsageError,
+} from '../apiCredentials/base.js';
+import { runCaptured } from '../curl.js';
+import { Service, tryParseJson } from './core/base.js';
 
 export class Zoom extends Service {
   readonly name = 'zoom';
@@ -15,6 +20,37 @@ export class Zoom extends Service {
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  /**
+   * The credential check must stay on the user-list endpoint because
+   * server-to-server tokens have no user context and error on /users/me. The
+   * account is instead determined by a separate best-effort call to /users/me,
+   * which works for user-level tokens.
+   */
+  override async determineAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    let curlArguments: readonly string[];
+    try {
+      curlArguments = await apiCredentials.injectIntoCurlCall([
+        '-s',
+        'https://api.zoom.us/v2/users/me',
+      ]);
+    } catch (error) {
+      if (error instanceof ApiCredentialsUsageError) {
+        return null;
+      }
+      throw error;
+    }
+    const result = runCaptured(curlArguments, 10);
+    const data = tryParseJson(result.stdout) as {
+      email?: string;
+      id?: string;
+      code?: number;
+    } | null;
+    if (data === null || data.code !== undefined) {
+      return null;
+    }
+    return data.email ?? data.id ?? null;
   }
 }
 

--- a/src/sharedOperations.ts
+++ b/src/sharedOperations.ts
@@ -312,9 +312,9 @@ export async function authBrowserPrepare(
 
   const launchOptions = getBrowserLaunchOptions(config);
 
-  let credentials;
+  let credentials: ApiCredentials;
   try {
-    ({ credentials } = await session.prepare(encryptedStorage, launchOptions));
+    credentials = await session.prepare(encryptedStorage, launchOptions);
   } catch (error: unknown) {
     // Closing the browser window during preparation should be reported to
     // the user as a clean cancellation rather than a stack trace. Doing

--- a/src/sharedOperations.ts
+++ b/src/sharedOperations.ts
@@ -306,10 +306,9 @@ export async function authBrowserPrepare(
     return { alreadyPrepared: true };
   }
 
-  if (apiCredentialStore.getPreparation(service.name) !== null) {
-    return { alreadyPrepared: true };
-  }
-
+  // A preparation may already exist, but we still run the flow again: the
+  // multi-account flow relies on people being able to prepare repeatedly to
+  // create different OAuth clients. The new preparation overwrites the old one.
   const launchOptions = getBrowserLaunchOptions(config);
 
   let credentials: ApiCredentials;

--- a/src/sharedOperations.ts
+++ b/src/sharedOperations.ts
@@ -7,7 +7,7 @@
  */
 
 import { ApiCredentialStatus } from './apiCredentials/base.js';
-import type { ApiCredentialStore } from './apiCredentials/store.js';
+import { DEFAULT_ACCOUNT, type ApiCredentialStore } from './apiCredentials/store.js';
 import { getCredentialStatus } from './apiCredentials/utils.js';
 import type { Config } from './config.js';
 import { loadBrowserConfig } from './configDataStore.js';
@@ -129,20 +129,22 @@ export async function servicesInfo(
   apiCredentialStore: ApiCredentialStore,
   config: Config,
   serviceName: string,
-  offline = false
+  offline = false,
+  account?: string
 ): Promise<ServicesInfoResult> {
   const service = lookupService(registry, serviceName);
 
   const supportsBrowser = service.getSession !== undefined && !config.browserDisabled;
   const authOptions = supportsBrowser ? ['browser', 'set'] : ['set'];
 
-  const apiCredentials = apiCredentialStore.get(serviceName);
+  const apiCredentials = apiCredentialStore.get(serviceName, account);
   const credentialStatus = await getCredentialStatus(
     service,
     apiCredentials,
     apiCredentialStore,
     config.credentialsRefreshDisabled,
-    offline
+    offline,
+    account
   );
 
   const serviceType = service instanceof RegisteredService ? 'user-registered' : 'built-in';
@@ -164,9 +166,24 @@ export async function authList(
 ): Promise<Record<string, { credentialType: string; credentialStatus: ApiCredentialStatus }>> {
   const allCredentials = apiCredentialStore.getAll();
 
-  const statusChecks = Array.from(
-    allCredentials,
-    async ([serviceName, credentials]): Promise<
+  // Flatten the service -> account -> credentials structure into a list of
+  // (key, credentials, account) triples. The default account keeps the plain
+  // service name as its key for backwards compatibility; named accounts are
+  // reported as "service (account)".
+  const entries = Array.from(allCredentials).flatMap(([serviceName, accountMap]) =>
+    Array.from(accountMap, ([account, credentials]) => {
+      const key = account === DEFAULT_ACCOUNT ? serviceName : `${serviceName} (${account})`;
+      return { key, serviceName, account, credentials };
+    })
+  );
+
+  const statusChecks = entries.map(
+    async ({
+      key,
+      serviceName,
+      account,
+      credentials,
+    }): Promise<
       readonly [string, { credentialType: string; credentialStatus: ApiCredentialStatus }]
     > => {
       const service = registry.getByName(serviceName);
@@ -176,11 +193,13 @@ export async function authList(
               service,
               credentials,
               apiCredentialStore,
-              config.credentialsRefreshDisabled
+              config.credentialsRefreshDisabled,
+              false,
+              account
             )
           : ApiCredentialStatus.Valid;
 
-      return [serviceName, { credentialType: credentials.objectType, credentialStatus }];
+      return [key, { credentialType: credentials.objectType, credentialStatus }];
     }
   );
 
@@ -192,7 +211,8 @@ export async function authBrowser(
   apiCredentialStore: ApiCredentialStore,
   encryptedStorage: EncryptedStorage,
   config: Config,
-  serviceName: string
+  serviceName: string,
+  account?: string
 ): Promise<void> {
   const service = lookupService(registry, serviceName);
 
@@ -201,7 +221,7 @@ export async function authBrowser(
     throw new BrowserFlowsNotSupportedError(serviceName);
   }
 
-  const oldCredentials = apiCredentialStore.get(service.name);
+  const oldCredentials = apiCredentialStore.get(service.name, account);
   if (session.prepare && oldCredentials === null) {
     throw new PreparationRequiredError(serviceName);
   }
@@ -213,7 +233,7 @@ export async function authBrowser(
     launchOptions,
     oldCredentials ?? undefined
   );
-  apiCredentialStore.save(service.name, apiCredentials);
+  apiCredentialStore.save(service.name, apiCredentials, account);
 }
 
 export interface AuthBrowserPrepareResult {
@@ -225,7 +245,8 @@ export async function authBrowserPrepare(
   apiCredentialStore: ApiCredentialStore,
   encryptedStorage: EncryptedStorage,
   config: Config,
-  serviceName: string
+  serviceName: string,
+  account?: string
 ): Promise<AuthBrowserPrepareResult> {
   const service = lookupService(registry, serviceName);
 
@@ -234,7 +255,7 @@ export async function authBrowserPrepare(
     return { alreadyPrepared: true };
   }
 
-  const existingCredentials = apiCredentialStore.get(service.name);
+  const existingCredentials = apiCredentialStore.get(service.name, account);
   if (existingCredentials !== null) {
     return { alreadyPrepared: true };
   }
@@ -254,7 +275,7 @@ export async function authBrowserPrepare(
     }
     throw error;
   }
-  apiCredentialStore.save(service.name, apiCredentials);
+  apiCredentialStore.save(service.name, apiCredentials, account);
   return { alreadyPrepared: false };
 }
 
@@ -273,7 +294,8 @@ export function prepareService(
   registry: ServiceRegistry,
   apiCredentialStore: ApiCredentialStore,
   serviceName: string,
-  json: string
+  json: string,
+  account?: string
 ): PrepareServiceResult {
   const service = lookupService(registry, serviceName);
 
@@ -297,6 +319,6 @@ export function prepareService(
   // PrepareInputInvalidError on any mismatch, so a store only happens once the
   // input is fully valid.
   const credentials = service.prepareFromJson(parsedJson);
-  apiCredentialStore.save(service.name, credentials);
+  apiCredentialStore.save(service.name, credentials, account);
   return { serviceName: service.name, credentialType: credentials.objectType };
 }

--- a/src/sharedOperations.ts
+++ b/src/sharedOperations.ts
@@ -6,8 +6,8 @@
  * rather than writing to stdout or calling process.exit.
  */
 
-import { ApiCredentialStatus } from './apiCredentials/base.js';
-import { DEFAULT_ACCOUNT, type ApiCredentialStore } from './apiCredentials/store.js';
+import { ApiCredentialStatus, type ApiCredentials } from './apiCredentials/base.js';
+import type { ApiCredentialStore } from './apiCredentials/store.js';
 import { getCredentialStatus } from './apiCredentials/utils.js';
 import type { Config } from './config.js';
 import { loadBrowserConfig } from './configDataStore.js';
@@ -115,11 +115,54 @@ export function servicesList(
   return services.map((service) => service.name).sort();
 }
 
+/**
+ * Status of a single stored credential, keyed by account in the various
+ * listings. Shared between `auth list` and `services info`.
+ */
+export interface CredentialStatusEntry {
+  readonly credentialType: string;
+  readonly credentialStatus: ApiCredentialStatus;
+}
+
+/**
+ * A service's stored credentials keyed by account. The default account is
+ * keyed by the empty string.
+ */
+export type AccountCredentialStatuses = Record<string, CredentialStatusEntry>;
+
+async function computeAccountStatuses(
+  registry: ServiceRegistry,
+  apiCredentialStore: ApiCredentialStore,
+  config: Config,
+  serviceName: string,
+  accountMap: ReadonlyMap<string, ApiCredentials> | undefined,
+  offline: boolean
+): Promise<AccountCredentialStatuses> {
+  const service = registry.getByName(serviceName);
+  const entries = await Promise.all(
+    Array.from(accountMap ?? [], async ([account, credentials]) => {
+      const credentialStatus =
+        service !== null
+          ? await getCredentialStatus(
+              service,
+              credentials,
+              apiCredentialStore,
+              config.credentialsRefreshDisabled,
+              offline,
+              account
+            )
+          : ApiCredentialStatus.Valid;
+      return [account, { credentialType: credentials.objectType, credentialStatus }] as const;
+    })
+  );
+  return Object.fromEntries(entries);
+}
+
 export interface ServicesInfoResult {
   readonly type: 'built-in' | 'user-registered';
   readonly baseApiUrls: readonly (string | RegExp)[];
   readonly authOptions: readonly string[];
-  readonly credentialStatus: ApiCredentialStatus;
+  readonly credentials: AccountCredentialStatuses;
   readonly setCredentialsExample: string;
   readonly developerNotes: string;
 }
@@ -129,22 +172,21 @@ export async function servicesInfo(
   apiCredentialStore: ApiCredentialStore,
   config: Config,
   serviceName: string,
-  offline = false,
-  account?: string
+  offline = false
 ): Promise<ServicesInfoResult> {
   const service = lookupService(registry, serviceName);
 
   const supportsBrowser = service.getSession !== undefined && !config.browserDisabled;
   const authOptions = supportsBrowser ? ['browser', 'set'] : ['set'];
 
-  const apiCredentials = apiCredentialStore.get(serviceName, account);
-  const credentialStatus = await getCredentialStatus(
-    service,
-    apiCredentials,
+  const accountMap = apiCredentialStore.getAll().get(serviceName);
+  const credentials = await computeAccountStatuses(
+    registry,
     apiCredentialStore,
-    config.credentialsRefreshDisabled,
-    offline,
-    account
+    config,
+    serviceName,
+    accountMap,
+    offline
   );
 
   const serviceType = service instanceof RegisteredService ? 'user-registered' : 'built-in';
@@ -153,7 +195,7 @@ export async function servicesInfo(
     type: serviceType,
     baseApiUrls: service.baseApiUrls,
     authOptions,
-    credentialStatus,
+    credentials,
     setCredentialsExample: service.setCredentialsExample(serviceName),
     developerNotes: service.info,
   };
@@ -163,47 +205,28 @@ export async function authList(
   registry: ServiceRegistry,
   apiCredentialStore: ApiCredentialStore,
   config: Config
-): Promise<Record<string, { credentialType: string; credentialStatus: ApiCredentialStatus }>> {
+): Promise<Record<string, AccountCredentialStatuses>> {
   const allCredentials = apiCredentialStore.getAll();
 
-  // Flatten the service -> account -> credentials structure into a list of
-  // (key, credentials, account) triples. The default account keeps the plain
-  // service name as its key for backwards compatibility; named accounts are
-  // reported as "service (account)".
-  const entries = Array.from(allCredentials).flatMap(([serviceName, accountMap]) =>
-    Array.from(accountMap, ([account, credentials]) => {
-      const key = account === DEFAULT_ACCOUNT ? serviceName : `${serviceName} (${account})`;
-      return { key, serviceName, account, credentials };
+  const entries = await Promise.all(
+    Array.from(allCredentials, async ([serviceName, accountMap]) => {
+      const statuses = await computeAccountStatuses(
+        registry,
+        apiCredentialStore,
+        config,
+        serviceName,
+        accountMap,
+        false
+      );
+      return [serviceName, statuses] as const;
     })
   );
 
-  const statusChecks = entries.map(
-    async ({
-      key,
-      serviceName,
-      account,
-      credentials,
-    }): Promise<
-      readonly [string, { credentialType: string; credentialStatus: ApiCredentialStatus }]
-    > => {
-      const service = registry.getByName(serviceName);
-      const credentialStatus =
-        service !== null
-          ? await getCredentialStatus(
-              service,
-              credentials,
-              apiCredentialStore,
-              config.credentialsRefreshDisabled,
-              false,
-              account
-            )
-          : ApiCredentialStatus.Valid;
+  return Object.fromEntries(entries);
+}
 
-      return [key, { credentialType: credentials.objectType, credentialStatus }];
-    }
-  );
-
-  return Object.fromEntries(await Promise.all(statusChecks));
+export interface AuthBrowserResult {
+  readonly account: string;
 }
 
 export async function authBrowser(
@@ -211,9 +234,8 @@ export async function authBrowser(
   apiCredentialStore: ApiCredentialStore,
   encryptedStorage: EncryptedStorage,
   config: Config,
-  serviceName: string,
-  account?: string
-): Promise<void> {
+  serviceName: string
+): Promise<AuthBrowserResult> {
   const service = lookupService(registry, serviceName);
 
   const session = service.getSession?.(config.appNamePrefix);
@@ -221,23 +243,27 @@ export async function authBrowser(
     throw new BrowserFlowsNotSupportedError(serviceName);
   }
 
-  const oldCredentials = apiCredentialStore.get(service.name, account);
+  const oldCredentials = apiCredentialStore.get(service.name);
   if (session.prepare && oldCredentials === null) {
     throw new PreparationRequiredError(serviceName);
   }
 
   const launchOptions = getBrowserLaunchOptions(config);
 
-  const apiCredentials = await session.login(
+  // The browser flow reports which account the user logged in as, so the
+  // credentials are stored under that account.
+  const { credentials, account } = await session.login(
     encryptedStorage,
     launchOptions,
     oldCredentials ?? undefined
   );
-  apiCredentialStore.save(service.name, apiCredentials, account);
+  apiCredentialStore.save(service.name, credentials, account);
+  return { account };
 }
 
 export interface AuthBrowserPrepareResult {
   readonly alreadyPrepared: boolean;
+  readonly account?: string;
 }
 
 export async function authBrowserPrepare(
@@ -245,8 +271,7 @@ export async function authBrowserPrepare(
   apiCredentialStore: ApiCredentialStore,
   encryptedStorage: EncryptedStorage,
   config: Config,
-  serviceName: string,
-  account?: string
+  serviceName: string
 ): Promise<AuthBrowserPrepareResult> {
   const service = lookupService(registry, serviceName);
 
@@ -255,16 +280,17 @@ export async function authBrowserPrepare(
     return { alreadyPrepared: true };
   }
 
-  const existingCredentials = apiCredentialStore.get(service.name, account);
+  const existingCredentials = apiCredentialStore.get(service.name);
   if (existingCredentials !== null) {
     return { alreadyPrepared: true };
   }
 
   const launchOptions = getBrowserLaunchOptions(config);
 
-  let apiCredentials;
+  let credentials;
+  let account: string;
   try {
-    apiCredentials = await session.prepare(encryptedStorage, launchOptions);
+    ({ credentials, account } = await session.prepare(encryptedStorage, launchOptions));
   } catch (error: unknown) {
     // Closing the browser window during preparation should be reported to
     // the user as a clean cancellation rather than a stack trace. Doing
@@ -275,8 +301,8 @@ export async function authBrowserPrepare(
     }
     throw error;
   }
-  apiCredentialStore.save(service.name, apiCredentials, account);
-  return { alreadyPrepared: false };
+  apiCredentialStore.save(service.name, credentials, account);
+  return { alreadyPrepared: false, account };
 }
 
 export interface PrepareServiceResult {

--- a/src/sharedOperations.ts
+++ b/src/sharedOperations.ts
@@ -6,7 +6,12 @@
  * rather than writing to stdout or calling process.exit.
  */
 
-import { ApiCredentialStatus, type ApiCredentials } from './apiCredentials/base.js';
+import { DEFAULT_ACCOUNT } from './apiCredentials/account.js';
+import {
+  ApiCredentialStatus,
+  OAuthCredentials,
+  type ApiCredentials,
+} from './apiCredentials/base.js';
 import type { ApiCredentialStore } from './apiCredentials/store.js';
 import { getCredentialStatus } from './apiCredentials/utils.js';
 import type { Config } from './config.js';
@@ -243,7 +248,17 @@ export async function authBrowser(
     throw new BrowserFlowsNotSupportedError(serviceName);
   }
 
-  const oldCredentials = apiCredentialStore.get(service.name);
+  // Login reuses stored credentials only for service-level artifacts (e.g.
+  // the OAuth client created by browser-prepare), which all of a service's
+  // accounts share — so logging in to an additional account can borrow any
+  // stored account's credentials. Prefer the default account, where
+  // browser-prepare places the client before the first login.
+  const storedAccounts = apiCredentialStore.listAccounts(service.name);
+  const reusableAccount = storedAccounts.includes(DEFAULT_ACCOUNT)
+    ? DEFAULT_ACCOUNT
+    : storedAccounts[0];
+  const oldCredentials =
+    reusableAccount === undefined ? null : apiCredentialStore.get(service.name, reusableAccount);
   if (session.prepare && oldCredentials === null) {
     throw new PreparationRequiredError(serviceName);
   }
@@ -258,7 +273,33 @@ export async function authBrowser(
     oldCredentials ?? undefined
   );
   apiCredentialStore.save(service.name, credentials, account);
+  removeObsoletePreparedCredentials(apiCredentialStore, service.name, account);
   return { account };
+}
+
+/**
+ * After a login stores credentials under a real account, drop a leftover
+ * token-less entry under the default account — the placeholder created by
+ * `auth browser-prepare`. Its purpose (carrying the OAuth client to the first
+ * login) is served, and the client lives on inside every logged-in account's
+ * credentials; keeping the placeholder would only make account resolution
+ * ambiguous. Complete credentials under the default account are left alone.
+ */
+function removeObsoletePreparedCredentials(
+  apiCredentialStore: ApiCredentialStore,
+  serviceName: string,
+  savedAccount: string
+): void {
+  if (savedAccount === DEFAULT_ACCOUNT) {
+    return;
+  }
+  const defaultAccountCredentials = apiCredentialStore.get(serviceName, DEFAULT_ACCOUNT);
+  if (
+    defaultAccountCredentials instanceof OAuthCredentials &&
+    defaultAccountCredentials.accessToken === undefined
+  ) {
+    apiCredentialStore.delete(serviceName, DEFAULT_ACCOUNT);
+  }
 }
 
 export interface AuthBrowserPrepareResult {

--- a/src/sharedOperations.ts
+++ b/src/sharedOperations.ts
@@ -6,12 +6,7 @@
  * rather than writing to stdout or calling process.exit.
  */
 
-import { DEFAULT_ACCOUNT } from './apiCredentials/account.js';
-import {
-  ApiCredentialStatus,
-  OAuthCredentials,
-  type ApiCredentials,
-} from './apiCredentials/base.js';
+import { ApiCredentialStatus, type ApiCredentials } from './apiCredentials/base.js';
 import type { ApiCredentialStore } from './apiCredentials/store.js';
 import { getCredentialStatus } from './apiCredentials/utils.js';
 import type { Config } from './config.js';
@@ -55,9 +50,20 @@ export class PreparationRequiredError extends Error {
   constructor(serviceName: string) {
     super(
       `Service ${serviceName} requires preparation first. ` +
-        `Run 'latchkey auth browser-prepare ${serviceName}' before logging in.`
+        `Run 'latchkey auth browser-prepare ${serviceName}' before logging in, ` +
+        `or pass --account to reuse the client stored with an existing account's credentials.`
     );
     this.name = 'PreparationRequiredError';
+  }
+}
+
+/**
+ * Thrown when an explicitly named account has no stored credentials.
+ */
+export class AccountNotFoundError extends Error {
+  constructor(serviceName: string, account: string) {
+    super(`No credentials stored for account '${account}' of service '${serviceName}'.`);
+    this.name = 'AccountNotFoundError';
   }
 }
 
@@ -239,7 +245,8 @@ export async function authBrowser(
   apiCredentialStore: ApiCredentialStore,
   encryptedStorage: EncryptedStorage,
   config: Config,
-  serviceName: string
+  serviceName: string,
+  account?: string
 ): Promise<AuthBrowserResult> {
   const service = lookupService(registry, serviceName);
 
@@ -248,17 +255,22 @@ export async function authBrowser(
     throw new BrowserFlowsNotSupportedError(serviceName);
   }
 
-  // Login reuses stored credentials only for service-level artifacts (e.g.
-  // the OAuth client created by browser-prepare), which all of a service's
-  // accounts share — so logging in to an additional account can borrow any
-  // stored account's credentials. Prefer the default account, where
-  // browser-prepare places the client before the first login.
-  const storedAccounts = apiCredentialStore.listAccounts(service.name);
-  const reusableAccount = storedAccounts.includes(DEFAULT_ACCOUNT)
-    ? DEFAULT_ACCOUNT
-    : storedAccounts[0];
-  const oldCredentials =
-    reusableAccount === undefined ? null : apiCredentialStore.get(service.name, reusableAccount);
+  // Login reuses previously stored credentials only for service-level
+  // artifacts (e.g. an OAuth client), which all of a service's accounts can
+  // share. By default the service's preparation (created by `auth prepare` or
+  // `auth browser-prepare`) is used; with an explicit account, that account's
+  // stored credentials carry the client instead. Either way the login may
+  // still end up stored under a different account — whichever the user logs
+  // in as.
+  let oldCredentials: ApiCredentials | null;
+  if (account !== undefined) {
+    oldCredentials = apiCredentialStore.get(service.name, account);
+    if (oldCredentials === null) {
+      throw new AccountNotFoundError(serviceName, account);
+    }
+  } else {
+    oldCredentials = apiCredentialStore.getPreparation(service.name);
+  }
   if (session.prepare && oldCredentials === null) {
     throw new PreparationRequiredError(serviceName);
   }
@@ -267,44 +279,17 @@ export async function authBrowser(
 
   // The browser flow reports which account the user logged in as, so the
   // credentials are stored under that account.
-  const { credentials, account } = await session.login(
+  const { credentials, account: loggedInAccount } = await session.login(
     encryptedStorage,
     launchOptions,
     oldCredentials ?? undefined
   );
-  apiCredentialStore.save(service.name, credentials, account);
-  removeObsoletePreparedCredentials(apiCredentialStore, service.name, account);
-  return { account };
-}
-
-/**
- * After a login stores credentials under a real account, drop a leftover
- * token-less entry under the default account — the placeholder created by
- * `auth browser-prepare`. Its purpose (carrying the OAuth client to the first
- * login) is served, and the client lives on inside every logged-in account's
- * credentials; keeping the placeholder would only make account resolution
- * ambiguous. Complete credentials under the default account are left alone.
- */
-function removeObsoletePreparedCredentials(
-  apiCredentialStore: ApiCredentialStore,
-  serviceName: string,
-  savedAccount: string
-): void {
-  if (savedAccount === DEFAULT_ACCOUNT) {
-    return;
-  }
-  const defaultAccountCredentials = apiCredentialStore.get(serviceName, DEFAULT_ACCOUNT);
-  if (
-    defaultAccountCredentials instanceof OAuthCredentials &&
-    defaultAccountCredentials.accessToken === undefined
-  ) {
-    apiCredentialStore.delete(serviceName, DEFAULT_ACCOUNT);
-  }
+  apiCredentialStore.save(service.name, credentials, loggedInAccount);
+  return { account: loggedInAccount };
 }
 
 export interface AuthBrowserPrepareResult {
   readonly alreadyPrepared: boolean;
-  readonly account?: string;
 }
 
 export async function authBrowserPrepare(
@@ -321,17 +306,15 @@ export async function authBrowserPrepare(
     return { alreadyPrepared: true };
   }
 
-  const existingCredentials = apiCredentialStore.get(service.name);
-  if (existingCredentials !== null) {
+  if (apiCredentialStore.getPreparation(service.name) !== null) {
     return { alreadyPrepared: true };
   }
 
   const launchOptions = getBrowserLaunchOptions(config);
 
   let credentials;
-  let account: string;
   try {
-    ({ credentials, account } = await session.prepare(encryptedStorage, launchOptions));
+    ({ credentials } = await session.prepare(encryptedStorage, launchOptions));
   } catch (error: unknown) {
     // Closing the browser window during preparation should be reported to
     // the user as a clean cancellation rather than a stack trace. Doing
@@ -342,8 +325,8 @@ export async function authBrowserPrepare(
     }
     throw error;
   }
-  apiCredentialStore.save(service.name, credentials, account);
-  return { alreadyPrepared: false, account };
+  apiCredentialStore.savePreparation(service.name, credentials);
+  return { alreadyPrepared: false };
 }
 
 export interface PrepareServiceResult {
@@ -352,17 +335,17 @@ export interface PrepareServiceResult {
 }
 
 /**
- * Store credentials for a service from a validated JSON payload
- * (`latchkey auth prepare <service> <json>`). The whole operation is rejected — and
- * nothing is stored — if the JSON is malformed, fails the service's schema, or
- * the service does not support prepare.
+ * Store a service's preparation from a validated JSON payload
+ * (`latchkey auth prepare <service> <json>`), overwriting any previous
+ * preparation. The whole operation is rejected — and nothing is stored — if
+ * the JSON is malformed, fails the service's schema, or the service does not
+ * support prepare.
  */
 export function prepareService(
   registry: ServiceRegistry,
   apiCredentialStore: ApiCredentialStore,
   serviceName: string,
-  json: string,
-  account?: string
+  json: string
 ): PrepareServiceResult {
   const service = lookupService(registry, serviceName);
 
@@ -386,6 +369,6 @@ export function prepareService(
   // PrepareInputInvalidError on any mismatch, so a store only happens once the
   // input is fully valid.
   const credentials = service.prepareFromJson(parsedJson);
-  apiCredentialStore.save(service.name, credentials, account);
+  apiCredentialStore.savePreparation(service.name, credentials);
   return { serviceName: service.name, credentialType: credentials.objectType };
 }

--- a/tests/apiCredentialStore.test.ts
+++ b/tests/apiCredentialStore.test.ts
@@ -3,7 +3,11 @@ import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { AmbiguousAccountError, ApiCredentialStore } from '../src/apiCredentials/store.js';
-import { AuthorizationBearer, AuthorizationBare } from '../src/apiCredentials/base.js';
+import {
+  AuthorizationBearer,
+  AuthorizationBare,
+  OAuthCredentials,
+} from '../src/apiCredentials/base.js';
 import { SlackApiCredentials } from '../src/services/slack.js';
 import { EncryptedStorage } from '../src/encryptedStorage.js';
 import { generateKey } from '../src/encryption.js';
@@ -131,6 +135,77 @@ describe('ApiCredentialStore', () => {
 
       expect(store.get('github')).toBeNull();
       expect(store.get('discord')).not.toBeNull();
+    });
+  });
+
+  describe('preparations', () => {
+    it('should return null when no preparation is stored', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      expect(store.getPreparation('google-gmail')).toBeNull();
+    });
+
+    it('should store and retrieve a preparation per service', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
+
+      const retrieved = store.getPreparation('google-gmail');
+      expect(retrieved).toBeInstanceOf(OAuthCredentials);
+      expect((retrieved as OAuthCredentials).clientId).toBe('client-id');
+      expect(store.getPreparation('google-docs')).toBeNull();
+    });
+
+    it('should overwrite a previous preparation for the same service', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      store.savePreparation('google-gmail', new OAuthCredentials('old-id', 'old-secret'));
+      store.savePreparation('google-gmail', new OAuthCredentials('new-id', 'new-secret'));
+
+      expect((store.getPreparation('google-gmail') as OAuthCredentials).clientId).toBe('new-id');
+    });
+
+    it('should keep preparations separate from credentials', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
+
+      expect(store.get('google-gmail')).toBeNull();
+      expect(store.listAccounts('google-gmail')).toEqual([]);
+      expect(store.getAll().has('google-gmail')).toBe(false);
+    });
+
+    it('delete without an account also removes the preparation', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
+      store.save('google-gmail', new AuthorizationBearer('token'), 'user@example.com');
+
+      expect(store.delete('google-gmail')).toBe(true);
+      expect(store.get('google-gmail', 'user@example.com')).toBeNull();
+      expect(store.getPreparation('google-gmail')).toBeNull();
+    });
+
+    it('delete without an account removes a preparation-only service', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
+
+      expect(store.delete('google-gmail')).toBe(true);
+      expect(store.getPreparation('google-gmail')).toBeNull();
+    });
+
+    it('delete with an explicit account keeps the preparation', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
+      store.save('google-gmail', new AuthorizationBearer('token'), 'user@example.com');
+
+      expect(store.delete('google-gmail', 'user@example.com')).toBe(true);
+      expect(store.getPreparation('google-gmail')).not.toBeNull();
+    });
+
+    it('delete without an account still throws on account ambiguity, keeping the preparation', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
+      store.save('google-gmail', new AuthorizationBearer('a'), 'a@example.com');
+      store.save('google-gmail', new AuthorizationBearer('b'), 'b@example.com');
+
+      expect(() => store.delete('google-gmail')).toThrow(AmbiguousAccountError);
+      expect(store.getPreparation('google-gmail')).not.toBeNull();
     });
   });
 

--- a/tests/apiCredentialStore.test.ts
+++ b/tests/apiCredentialStore.test.ts
@@ -171,41 +171,44 @@ describe('ApiCredentialStore', () => {
       expect(store.getAll().has('google-gmail')).toBe(false);
     });
 
-    it('delete without an account also removes the preparation', () => {
+    it('delete never removes the preparation', () => {
       const store = new ApiCredentialStore(storePath, encryptedStorage);
       store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
       store.save('google-gmail', new AuthorizationBearer('token'), 'user@example.com');
 
       expect(store.delete('google-gmail')).toBe(true);
       expect(store.get('google-gmail', 'user@example.com')).toBeNull();
-      expect(store.getPreparation('google-gmail')).toBeNull();
-    });
+      expect(store.getPreparation('google-gmail')).not.toBeNull();
 
-    it('delete without an account removes a preparation-only service', () => {
-      const store = new ApiCredentialStore(storePath, encryptedStorage);
-      store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
-
-      expect(store.delete('google-gmail')).toBe(true);
-      expect(store.getPreparation('google-gmail')).toBeNull();
-    });
-
-    it('delete with an explicit account keeps the preparation', () => {
-      const store = new ApiCredentialStore(storePath, encryptedStorage);
-      store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
-      store.save('google-gmail', new AuthorizationBearer('token'), 'user@example.com');
-
-      expect(store.delete('google-gmail', 'user@example.com')).toBe(true);
+      expect(store.delete('google-gmail')).toBe(false);
       expect(store.getPreparation('google-gmail')).not.toBeNull();
     });
 
-    it('delete without an account still throws on account ambiguity, keeping the preparation', () => {
+    it('deleteAll removes all accounts and the preparation', () => {
       const store = new ApiCredentialStore(storePath, encryptedStorage);
       store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
       store.save('google-gmail', new AuthorizationBearer('a'), 'a@example.com');
       store.save('google-gmail', new AuthorizationBearer('b'), 'b@example.com');
 
-      expect(() => store.delete('google-gmail')).toThrow(AmbiguousAccountError);
-      expect(store.getPreparation('google-gmail')).not.toBeNull();
+      expect(store.deleteAll('google-gmail')).toBe(true);
+      expect(store.listAccounts('google-gmail')).toEqual([]);
+      expect(store.getPreparation('google-gmail')).toBeNull();
+    });
+
+    it('deleteAll removes a preparation-only service', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
+
+      expect(store.deleteAll('google-gmail')).toBe(true);
+      expect(store.getPreparation('google-gmail')).toBeNull();
+    });
+
+    it('deleteAll returns false when the service has nothing stored', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      store.save('slack', new AuthorizationBearer('token'));
+
+      expect(store.deleteAll('google-gmail')).toBe(false);
+      expect(store.get('slack')).not.toBeNull();
     });
   });
 

--- a/tests/apiCredentialStore.test.ts
+++ b/tests/apiCredentialStore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { ApiCredentialStore } from '../src/apiCredentials/store.js';
+import { AmbiguousAccountError, ApiCredentialStore } from '../src/apiCredentials/store.js';
 import { AuthorizationBearer, AuthorizationBare } from '../src/apiCredentials/base.js';
 import { SlackApiCredentials } from '../src/services/slack.js';
 import { EncryptedStorage } from '../src/encryptedStorage.js';
@@ -131,6 +131,126 @@ describe('ApiCredentialStore', () => {
 
       expect(store.get('github')).toBeNull();
       expect(store.get('discord')).not.toBeNull();
+    });
+  });
+
+  describe('accounts', () => {
+    it('should store and retrieve credentials per account', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      store.save('github', new AuthorizationBearer('default-token'));
+      store.save('github', new AuthorizationBearer('work-token'), 'work@example.com');
+
+      expect((store.get('github', '') as AuthorizationBearer).token).toBe('default-token');
+      expect((store.get('github', 'work@example.com') as AuthorizationBearer).token).toBe(
+        'work-token'
+      );
+      expect(store.get('github', 'missing@example.com')).toBeNull();
+    });
+
+    it('should list the accounts stored for a service', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      expect(store.listAccounts('github')).toEqual([]);
+
+      store.save('github', new AuthorizationBearer('default-token'));
+      store.save('github', new AuthorizationBearer('work-token'), 'work@example.com');
+
+      expect([...store.listAccounts('github')].sort()).toEqual(['', 'work@example.com']);
+    });
+
+    describe('implicit account resolution', () => {
+      it('get returns the single account when no account is requested', () => {
+        const store = new ApiCredentialStore(storePath, encryptedStorage);
+        store.save('github', new AuthorizationBearer('token'), 'only@example.com');
+        expect((store.get('github') as AuthorizationBearer).token).toBe('token');
+      });
+
+      it('get throws AmbiguousAccountError when several accounts exist and none is requested', () => {
+        const store = new ApiCredentialStore(storePath, encryptedStorage);
+        store.save('github', new AuthorizationBearer('a'), 'a@example.com');
+        store.save('github', new AuthorizationBearer('b'), 'b@example.com');
+        expect(() => store.get('github')).toThrow(AmbiguousAccountError);
+      });
+
+      it('save without an account updates the single existing account', () => {
+        const store = new ApiCredentialStore(storePath, encryptedStorage);
+        store.save('github', new AuthorizationBearer('old'), 'only@example.com');
+        store.save('github', new AuthorizationBearer('new'));
+
+        expect(store.listAccounts('github')).toEqual(['only@example.com']);
+        expect((store.get('github', 'only@example.com') as AuthorizationBearer).token).toBe('new');
+      });
+
+      it('save without an account creates the default account for a new service', () => {
+        const store = new ApiCredentialStore(storePath, encryptedStorage);
+        store.save('github', new AuthorizationBearer('token'));
+        expect(store.listAccounts('github')).toEqual(['']);
+      });
+
+      it('save without an account throws AmbiguousAccountError when several accounts exist', () => {
+        const store = new ApiCredentialStore(storePath, encryptedStorage);
+        store.save('github', new AuthorizationBearer('a'), 'a@example.com');
+        store.save('github', new AuthorizationBearer('b'), 'b@example.com');
+        expect(() => {
+          store.save('github', new AuthorizationBearer('c'));
+        }).toThrow(AmbiguousAccountError);
+      });
+    });
+
+    describe('delete', () => {
+      it('should delete a single account and keep the others', () => {
+        const store = new ApiCredentialStore(storePath, encryptedStorage);
+        store.save('github', new AuthorizationBearer('a'), 'a@example.com');
+        store.save('github', new AuthorizationBearer('b'), 'b@example.com');
+
+        expect(store.delete('github', 'a@example.com')).toBe(true);
+        expect(store.get('github', 'a@example.com')).toBeNull();
+        expect(store.get('github', 'b@example.com')).not.toBeNull();
+      });
+
+      it('should remove the service entry when its last account is deleted', () => {
+        const store = new ApiCredentialStore(storePath, encryptedStorage);
+        store.save('github', new AuthorizationBearer('a'), 'a@example.com');
+
+        expect(store.delete('github', 'a@example.com')).toBe(true);
+        expect(store.listAccounts('github')).toEqual([]);
+      });
+
+      it('should delete the single account when none is specified', () => {
+        const store = new ApiCredentialStore(storePath, encryptedStorage);
+        store.save('github', new AuthorizationBearer('a'), 'a@example.com');
+
+        expect(store.delete('github')).toBe(true);
+        expect(store.listAccounts('github')).toEqual([]);
+      });
+
+      it('should throw AmbiguousAccountError when deleting without an account and several exist', () => {
+        const store = new ApiCredentialStore(storePath, encryptedStorage);
+        store.save('github', new AuthorizationBearer('a'), 'a@example.com');
+        store.save('github', new AuthorizationBearer('b'), 'b@example.com');
+        expect(() => store.delete('github')).toThrow(AmbiguousAccountError);
+      });
+
+      it('should return false when deleting a missing account', () => {
+        const store = new ApiCredentialStore(storePath, encryptedStorage);
+        store.save('github', new AuthorizationBearer('a'), 'a@example.com');
+        expect(store.delete('github', 'missing@example.com')).toBe(false);
+      });
+    });
+
+    describe('getAll', () => {
+      it('should return credentials grouped by service and account', () => {
+        const store = new ApiCredentialStore(storePath, encryptedStorage);
+        store.save('github', new AuthorizationBearer('default'));
+        store.save('github', new AuthorizationBearer('work'), 'work@example.com');
+        store.save('discord', new AuthorizationBare('discord-token'));
+
+        const all = store.getAll();
+        expect([...all.keys()].sort()).toEqual(['discord', 'github']);
+        expect([...all.get('github')!.keys()].sort()).toEqual(['', 'work@example.com']);
+        expect((all.get('github')!.get('work@example.com') as AuthorizationBearer).token).toBe(
+          'work'
+        );
+      });
     });
   });
 });

--- a/tests/apiCredentialsUtils.test.ts
+++ b/tests/apiCredentialsUtils.test.ts
@@ -27,7 +27,7 @@ describe('maybeRefreshCredentials', () => {
     const result = await maybeRefreshCredentials(service, expired, store, false);
 
     expect(refreshCredentials).toHaveBeenCalledOnce();
-    expect(save).toHaveBeenCalledWith('demo', refreshed);
+    expect(save).toHaveBeenCalledWith('demo', refreshed, undefined);
     expect(result).toBe(refreshed);
   });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -731,7 +731,7 @@ describe('CLI commands with dependency injection', () => {
       expect(info.type).toBe('built-in');
       expect(info.baseApiUrls).toEqual(['https://slack.com/api/']);
       expect(info.authOptions).toEqual(['browser', 'set']);
-      expect(info.credentialStatus).toBe('missing');
+      expect(info.credentials).toEqual({});
       expect(info.setCredentialsExample).toBe(
         'latchkey auth set slack -H "Authorization: Bearer xoxb-your-token"'
       );
@@ -794,7 +794,32 @@ describe('CLI commands with dependency injection', () => {
       await runCommand(['services', 'info', 'slack'], deps);
 
       const info = JSON.parse(logs[0] ?? '') as Record<string, unknown>;
-      expect(info.credentialStatus).toBe('valid');
+      expect(info.credentials).toEqual({
+        '': { credentialType: 'slack', credentialStatus: 'valid' },
+      });
+    });
+
+    it('should list credentials for each account', async () => {
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(
+        storePath,
+        JSON.stringify({
+          slack: {
+            '': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: default'] },
+            'work@example.com': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: work'] },
+          },
+        })
+      );
+
+      const deps = createMockDependencies();
+
+      await runCommand(['services', 'info', 'slack'], deps);
+
+      const info = JSON.parse(logs[0] ?? '') as Record<string, unknown>;
+      expect(info.credentials).toEqual({
+        '': { credentialType: 'rawCurl', credentialStatus: 'valid' },
+        'work@example.com': { credentialType: 'rawCurl', credentialStatus: 'valid' },
+      });
     });
 
     it('should return error for unknown service', async () => {
@@ -963,6 +988,35 @@ describe('CLI commands with dependency injection', () => {
       expect(capturedArgs).toEqual([]);
     });
 
+    it('auth prepare stores the client under the given account', async () => {
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(storePath, '{}');
+
+      const deps = createMockDependencies({
+        registry: new ServiceRegistry([GOOGLE_GMAIL]),
+      });
+      await runCommand(
+        [
+          '--account',
+          'work@example.com',
+          'auth',
+          'prepare',
+          'google-gmail',
+          '{"clientId":"cid","clientSecret":"csecret"}',
+        ],
+        deps
+      );
+
+      expect(logs).toContain('Done');
+      const store = readStore(storePath);
+      expect(store['google-gmail']?.['work@example.com']).toEqual({
+        objectType: 'oauth',
+        clientId: 'cid',
+        clientSecret: 'csecret',
+      });
+      expect(store['google-gmail']?.['']).toBeUndefined();
+    });
+
     it('auth clear removes only the requested account', async () => {
       const storePath = writeMultiAccountStore({
         'a@example.com': 'a',
@@ -997,6 +1051,20 @@ describe('CLI commands with dependency injection', () => {
       expect(exitCode).toBeNull();
       expect(logs.join('\n')).toContain('No API credentials found for slack.');
     });
+
+    it.each([
+      ['services', 'info', 'slack'],
+      ['auth', 'browser', 'slack'],
+      ['auth', 'browser-prepare', 'slack'],
+      ['auth', 'list'],
+      ['services', 'list'],
+    ])('rejects --account for the unsupported command: %s %s', async (...commandArgs) => {
+      const deps = createMockDependencies();
+      await runCommand(['--account', 'hola@jola.com', ...commandArgs], deps);
+
+      expect(exitCode).toBe(1);
+      expect(errorLogs.join('\n')).toContain('--account option is not supported');
+    });
   });
 
   describe('auth list command', () => {
@@ -1015,8 +1083,29 @@ describe('CLI commands with dependency injection', () => {
       expect(logs).toHaveLength(1);
       const entries = JSON.parse(logs[0] ?? '') as Record<string, unknown>;
       expect(entries.slack).toEqual({
-        credentialType: 'slack',
-        credentialStatus: 'valid',
+        '': { credentialType: 'slack', credentialStatus: 'valid' },
+      });
+    });
+
+    it('should key each service by account', async () => {
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(
+        storePath,
+        JSON.stringify({
+          slack: {
+            '': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: default'] },
+            'work@example.com': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: work'] },
+          },
+        })
+      );
+
+      const deps = createMockDependencies();
+      await runCommand(['auth', 'list'], deps);
+
+      const entries = JSON.parse(logs[0] ?? '') as Record<string, unknown>;
+      expect(entries.slack).toEqual({
+        '': { credentialType: 'rawCurl', credentialStatus: 'valid' },
+        'work@example.com': { credentialType: 'rawCurl', credentialStatus: 'valid' },
       });
     });
 
@@ -1047,8 +1136,7 @@ describe('CLI commands with dependency injection', () => {
       expect(logs).toHaveLength(1);
       const entries = JSON.parse(logs[0] ?? '') as Record<string, unknown>;
       expect(entries.unknown).toEqual({
-        credentialType: 'rawCurl',
-        credentialStatus: 'valid',
+        '': { credentialType: 'rawCurl', credentialStatus: 'valid' },
       });
     });
   });
@@ -2782,6 +2870,19 @@ describe('CLI commands with dependency injection', () => {
         params: { serviceName: 'slack' },
       });
       expect(logs).toContain('Done');
+    });
+
+    it('reports the account returned by the gateway for `auth browser`', async () => {
+      makeFetchMock(
+        new Response(JSON.stringify({ result: { account: 'user@example.com' } }), { status: 200 })
+      );
+      const deps = createMockDependencies({
+        config: createMockConfig({ gatewayUrl: GATEWAY_URL }),
+      });
+
+      await runCommand(['auth', 'browser', 'slack'], deps);
+
+      expect(logs).toContain("Done. Stored credentials for account 'user@example.com'.");
     });
 
     it('forwards `auth browser-prepare` and reports `Already prepared.` when the gateway says so', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -45,6 +45,24 @@ function readSecureFile(path: string): string | null {
   return storage.readFile(path);
 }
 
+// Wrap a flat { service: credentials } map into the account-keyed on-disk
+// layout, storing everything under the default account.
+function nestAccounts(
+  flat: Record<string, unknown>
+): Record<string, Record<string, unknown>> {
+  return Object.fromEntries(Object.entries(flat).map(([service, creds]) => [service, { '': creds }]));
+}
+
+// Read the raw account-keyed credential store contents.
+function readStore(path: string): Record<string, Record<string, unknown>> {
+  return JSON.parse(readSecureFile(path) ?? '{}') as Record<string, Record<string, unknown>>;
+}
+
+// Read a single service's default-account credentials from the store.
+function readDefaultCredentials(path: string, service: string): unknown {
+  return readStore(path)[service]?.[''];
+}
+
 interface CliResult {
   exitCode: number | null;
   stdout: string;
@@ -492,9 +510,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies();
@@ -610,9 +628,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        })
+        }))
       );
 
       const originalPlatform = process.platform;
@@ -648,9 +666,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies({
@@ -667,12 +685,12 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           'my-gitlab': {
             objectType: 'rawCurl',
             curlArguments: ['-H', 'PRIVATE-TOKEN: token'],
           },
-        })
+        }))
       );
 
       // Ensure a graphical environment is available so browser auth is considered viable
@@ -766,9 +784,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies();
@@ -807,9 +825,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies();
@@ -833,20 +851,20 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'slack-token', dCookie: 'slack-cookie' },
           discord: { objectType: 'authorizationBare', token: 'discord-token' },
-        })
+        }))
       );
 
       const deps = createMockDependencies();
 
       await runCommand(['auth', 'clear', 'slack'], deps);
 
-      const storedData = JSON.parse(readSecureFile(storePath) ?? '{}') as StoredCredentials;
+      const storedData = readStore(storePath);
       expect(storedData.slack).toBeUndefined();
       expect(storedData.discord).toBeDefined();
-      expect(storedData.discord?.token).toBe('discord-token');
+      expect((storedData.discord?.[''] as { token: string }).token).toBe('discord-token');
     });
 
     it('should delete both store and browser state with -y flag', async () => {
@@ -854,7 +872,7 @@ describe('CLI commands with dependency injection', () => {
       const browserStatePath = join(tempDir, 'browser_state.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({ slack: { objectType: 'slack', token: 'test', dCookie: 'test' } })
+        JSON.stringify(nestAccounts({ slack: { objectType: 'slack', token: 'test', dCookie: 'test' } }))
       );
       writeSecureFile(browserStatePath, '{}');
 
@@ -867,14 +885,128 @@ describe('CLI commands with dependency injection', () => {
     });
   });
 
+  describe('--account option', () => {
+    const rawCurl = (token: string) => ({
+      objectType: 'rawCurl',
+      curlArguments: ['-H', `X-Token: ${token}`],
+    });
+
+    function writeMultiAccountStore(accounts: Record<string, string>): string {
+      const storePath = join(tempDir, 'credentials.json');
+      const slackAccounts = Object.fromEntries(
+        Object.entries(accounts).map(([account, token]) => [account, rawCurl(token)])
+      );
+      writeSecureFile(storePath, JSON.stringify({ slack: slackAccounts }));
+      return storePath;
+    }
+
+    it('auth set stores credentials under the given account', async () => {
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(storePath, '{}');
+
+      const deps = createMockDependencies();
+      await runCommand(
+        ['--account', 'work@example.com', 'auth', 'set', 'slack', '-H', 'X-Token: secret'],
+        deps
+      );
+
+      expect(logs).toContain('Credentials stored.');
+      const store = readStore(storePath);
+      expect(store.slack?.['work@example.com']).toEqual(rawCurl('secret'));
+      expect(store.slack?.['']).toBeUndefined();
+    });
+
+    it('curl injects credentials for the requested account', async () => {
+      writeMultiAccountStore({ '': 'default', 'work@example.com': 'work' });
+
+      const deps = createMockDependencies();
+      await runCommand(
+        ['--account', 'work@example.com', 'curl', 'https://slack.com/api/test'],
+        deps
+      );
+
+      expect(exitCode).toBe(0);
+      expect(capturedArgs).toEqual(['-H', 'X-Token: work', 'https://slack.com/api/test']);
+    });
+
+    it('curl uses the single stored account without requiring --account', async () => {
+      writeMultiAccountStore({ 'only@example.com': 'solo' });
+
+      const deps = createMockDependencies();
+      await runCommand(['curl', 'https://slack.com/api/test'], deps);
+
+      expect(exitCode).toBe(0);
+      expect(capturedArgs).toEqual(['-H', 'X-Token: solo', 'https://slack.com/api/test']);
+    });
+
+    it('curl requires --account when multiple accounts exist', async () => {
+      writeMultiAccountStore({ 'a@example.com': 'a', 'b@example.com': 'b' });
+
+      const deps = createMockDependencies();
+      await runCommand(['curl', 'https://slack.com/api/test'], deps);
+
+      expect(exitCode).toBe(1);
+      expect(errorLogs.join('\n')).toContain('--account');
+    });
+
+    it('curl fails gracefully for a non-existing account', async () => {
+      writeMultiAccountStore({ '': 'default' });
+
+      const deps = createMockDependencies();
+      await runCommand(
+        ['--account', 'missing@example.com', 'curl', 'https://slack.com/api/test'],
+        deps
+      );
+
+      // A missing account is treated as "no credentials for this service".
+      expect(exitCode).toBe(1);
+      expect(capturedArgs).toEqual([]);
+    });
+
+    it('auth clear removes only the requested account', async () => {
+      const storePath = writeMultiAccountStore({
+        'a@example.com': 'a',
+        'b@example.com': 'b',
+      });
+
+      const deps = createMockDependencies();
+      await runCommand(['--account', 'a@example.com', 'auth', 'clear', 'slack'], deps);
+
+      const store = readStore(storePath);
+      expect(store.slack?.['a@example.com']).toBeUndefined();
+      expect(store.slack?.['b@example.com']).toBeDefined();
+    });
+
+    it('auth clear requires --account when multiple accounts exist', async () => {
+      writeMultiAccountStore({ 'a@example.com': 'a', 'b@example.com': 'b' });
+
+      const deps = createMockDependencies();
+      await runCommand(['auth', 'clear', 'slack'], deps);
+
+      expect(exitCode).toBe(1);
+      expect(errorLogs.join('\n')).toContain('--account');
+    });
+
+    it('auth clear fails gracefully for a non-existing account', async () => {
+      writeMultiAccountStore({ '': 'default' });
+
+      const deps = createMockDependencies();
+      await runCommand(['--account', 'missing@example.com', 'auth', 'clear', 'slack'], deps);
+
+      // Clearing a missing account is a no-op rather than an error.
+      expect(exitCode).toBeNull();
+      expect(logs.join('\n')).toContain('No API credentials found for slack.');
+    });
+  });
+
   describe('auth list command', () => {
     it('should list stored credentials with their status', async () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies();
@@ -904,9 +1036,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           unknown: { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: secret'] },
-        })
+        }))
       );
 
       const deps = createMockDependencies();
@@ -935,8 +1067,7 @@ describe('CLI commands with dependency injection', () => {
 
       expect(logs).toContain('Credentials stored.');
 
-      const storedData = JSON.parse(readSecureFile(storePath) ?? '{}') as Record<string, unknown>;
-      expect(storedData.slack).toEqual({
+      expect(readDefaultCredentials(storePath, 'slack')).toEqual({
         objectType: 'rawCurl',
         curlArguments: ['-H', 'X-Token: secret', '-H', 'X-Other: value'],
       });
@@ -970,9 +1101,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'old-token', dCookie: 'old-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies();
@@ -981,8 +1112,7 @@ describe('CLI commands with dependency injection', () => {
 
       expect(logs).toContain('Credentials stored.');
 
-      const storedData = JSON.parse(readSecureFile(storePath) ?? '{}') as Record<string, unknown>;
-      expect(storedData.slack).toEqual({
+      expect(readDefaultCredentials(storePath, 'slack')).toEqual({
         objectType: 'rawCurl',
         curlArguments: ['-H', 'X-Token: new-secret'],
       });
@@ -995,7 +1125,14 @@ describe('CLI commands with dependency injection', () => {
 
     function readWithKey(path: string, key: string): Record<string, unknown> {
       const storage = new EncryptedStorage(key);
-      return JSON.parse(storage.readFile(path) ?? '{}') as Record<string, unknown>;
+      const raw = JSON.parse(storage.readFile(path) ?? '{}') as Record<
+        string,
+        Record<string, unknown>
+      >;
+      // Unwrap the default account so assertions can compare flat credentials.
+      return Object.fromEntries(
+        Object.entries(raw).map(([service, accounts]) => [service, accounts['']])
+      );
     }
 
     function withStdinKey(key: string, overrides: Partial<CliDependencies> = {}): CliDependencies {
@@ -1006,7 +1143,7 @@ describe('CLI commands with dependency injection', () => {
     const STORE_FILENAME = 'credentials.json';
 
     function writeStore(contents: Record<string, unknown>): void {
-      writeSecureFile(join(tempDir, STORE_FILENAME), JSON.stringify(contents));
+      writeSecureFile(join(tempDir, STORE_FILENAME), JSON.stringify(nestAccounts(contents)));
     }
 
     it('re-encrypts all stored credentials with the new key', async () => {
@@ -1153,8 +1290,7 @@ describe('CLI commands with dependency injection', () => {
 
       expect(logs).toContain('Credentials stored.');
 
-      const storedData = JSON.parse(readSecureFile(storePath) ?? '{}') as Record<string, unknown>;
-      expect(storedData.telegram).toEqual({
+      expect(readDefaultCredentials(storePath, 'telegram')).toEqual({
         objectType: 'telegramBot',
         token: '123456:ABC-DEF',
       });
@@ -1212,8 +1348,7 @@ describe('CLI commands with dependency injection', () => {
       );
 
       expect(logs).toContain('Done');
-      const storedData = JSON.parse(readSecureFile(storePath) ?? '{}') as Record<string, unknown>;
-      expect(storedData['google-gmail']).toEqual({
+      expect(readDefaultCredentials(storePath, 'google-gmail')).toEqual({
         objectType: 'oauth',
         clientId: 'cid',
         clientSecret: 'csecret',
@@ -1272,9 +1407,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies();
@@ -1295,9 +1430,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'rawCurl', curlArguments: ['-H', 'X-Custom: header'] },
-        })
+        }))
       );
 
       const deps = createMockDependencies();
@@ -1312,9 +1447,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies();
@@ -1344,9 +1479,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies({
@@ -1378,9 +1513,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           'google-gmail': { objectType: 'oauth', clientId: 'cid', clientSecret: 'csecret' },
-        })
+        }))
       );
 
       const deps = createMockDependencies({
@@ -1397,14 +1532,14 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           'google-docs': {
             objectType: 'oauth',
             clientId: 'cid',
             clientSecret: 'csecret',
             accessToken: 'docs-token',
           },
-        })
+        }))
       );
 
       const deps = createMockDependencies({
@@ -1421,7 +1556,7 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           'google-drive': {
             objectType: 'oauth',
             clientId: 'cid',
@@ -1434,7 +1569,7 @@ describe('CLI commands with dependency injection', () => {
             clientSecret: 'csecret',
             accessToken: 'docs-token',
           },
-        })
+        }))
       );
 
       const deps = createMockDependencies({
@@ -1451,7 +1586,7 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           'google-drive': {
             objectType: 'oauth',
             clientId: 'cid',
@@ -1465,7 +1600,7 @@ describe('CLI commands with dependency injection', () => {
             clientSecret: 'csecret',
             accessToken: 'docs-token',
           },
-        })
+        }))
       );
 
       const deps = createMockDependencies({
@@ -1483,14 +1618,14 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           'google-docs': {
             objectType: 'oauth',
             clientId: 'cid',
             clientSecret: 'csecret',
             accessToken: 'docs-token',
           },
-        })
+        }))
       );
 
       const deps = createMockDependencies({
@@ -1534,9 +1669,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies({
@@ -1553,9 +1688,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        })
+        }))
       );
 
       const mockLogin = vi.fn();
@@ -1601,9 +1736,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           telegram: { objectType: 'telegramBot', token: '123456:ABC-DEF' },
-        })
+        }))
       );
 
       const deps = createMockDependencies({
@@ -1620,9 +1755,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           nologin: { objectType: 'rawCurl', curlArguments: ['-H', 'X-API-Key: secret'] },
-        })
+        }))
       );
 
       const noLoginService: Service = {
@@ -1657,9 +1792,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies({
@@ -1677,9 +1812,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        })
+        }))
       );
 
       const deps = createMockDependencies({
@@ -1696,9 +1831,9 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        })
+        }))
       );
 
       const { PermissionCheckError } = await import('../src/permissions.js');
@@ -2186,12 +2321,12 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           'my-api': {
             objectType: 'rawCurl',
             curlArguments: ['-H', 'Authorization: Bearer my-token'],
           },
-        })
+        }))
       );
 
       logs = [];
@@ -2265,12 +2400,12 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           'my-gitlab': {
             objectType: 'rawCurl',
             curlArguments: ['-H', 'PRIVATE-TOKEN: my-secret-token'],
           },
-        })
+        }))
       );
 
       logs = [];
@@ -2379,12 +2514,12 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           'my-gitlab': {
             objectType: 'rawCurl',
             curlArguments: ['-H', 'PRIVATE-TOKEN: my-secret-token'],
           },
-        })
+        }))
       );
 
       logs = [];
@@ -2424,12 +2559,12 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify({
+        JSON.stringify(nestAccounts({
           'my-gitlab': {
             objectType: 'rawCurl',
             curlArguments: ['-H', 'PRIVATE-TOKEN: my-secret-token'],
           },
-        })
+        }))
       );
 
       logs = [];

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -995,9 +995,16 @@ describe('CLI commands with dependency injection', () => {
         deps
       );
 
-      // A missing account is treated as "no credentials for this service".
+      // A missing account is treated as "no credentials for this service",
+      // and the suggested commands carry the requested account.
       expect(exitCode).toBe(1);
       expect(capturedArgs).toEqual([]);
+      expect(errorLogs.join('\n')).toContain(
+        "No credentials found for slack (account 'missing@example.com')"
+      );
+      expect(errorLogs.join('\n')).toContain(
+        'latchkey --account missing@example.com auth browser slack'
+      );
     });
 
     it('auth clear keeps the preparation without --all', async () => {
@@ -2690,8 +2697,52 @@ describe('CLI commands with dependency injection', () => {
       await runCommand(['services', 'deregister', 'my-gitlab'], deps);
 
       expect(exitCode).toBe(1);
-      expect(errorLogs[0]).toContain('Credentials still exist');
-      expect(errorLogs[0]).toContain('latchkey auth clear my-gitlab');
+      expect(errorLogs[0]).toContain('Credentials or a preparation still exist');
+      expect(errorLogs[0]).toContain('latchkey auth clear my-gitlab --all');
+
+      // Service should still be in config
+      const entries = loadRegisteredServices(deps.config.configPath);
+      expect(entries.get('my-gitlab')).toBeDefined();
+    });
+
+    it('should reject deregistering when only a preparation still exists', async () => {
+      const deps = createMockDependencies({
+        registry: new ServiceRegistry([GITLAB]),
+      });
+
+      await runCommand(
+        [
+          'services',
+          'register',
+          'my-gitlab',
+          '--base-api-url',
+          'https://gitlab.mycompany.com/api/',
+          '--service-family',
+          'gitlab',
+        ],
+        deps
+      );
+
+      // Store a preparation (but no credentials) for the service
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(
+        storePath,
+        JSON.stringify({
+          credentials: {},
+          preparations: {
+            'my-gitlab': { objectType: 'oauth', clientId: 'cid', clientSecret: 'csecret' },
+          },
+        })
+      );
+
+      logs = [];
+      errorLogs = [];
+      exitCode = null;
+      await runCommand(['services', 'deregister', 'my-gitlab'], deps);
+
+      expect(exitCode).toBe(1);
+      expect(errorLogs[0]).toContain('Credentials or a preparation still exist');
+      expect(errorLogs[0]).toContain('latchkey auth clear my-gitlab --all');
 
       // Service should still be in config
       const entries = loadRegisteredServices(deps.config.configPath);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -984,7 +984,7 @@ describe('CLI commands with dependency injection', () => {
       expect(capturedArgs).toEqual([]);
     });
 
-    it('auth clear without --account also removes the preparation', async () => {
+    it('auth clear keeps the preparation without --all', async () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
@@ -1000,7 +1000,48 @@ describe('CLI commands with dependency injection', () => {
       await runCommand(['auth', 'clear', 'slack'], deps);
 
       expect(readStore(storePath).slack).toBeUndefined();
+      expect(readPreparations(storePath).slack).toBeDefined();
+    });
+
+    it('auth clear --all removes all accounts and the preparation', async () => {
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(
+        storePath,
+        JSON.stringify({
+          credentials: { slack: { 'a@example.com': rawCurl('a'), 'b@example.com': rawCurl('b') } },
+          preparations: {
+            slack: { objectType: 'oauth', clientId: 'cid', clientSecret: 'csecret' },
+          },
+        })
+      );
+
+      const deps = createMockDependencies();
+      await runCommand(['auth', 'clear', 'slack', '--all'], deps);
+
+      expect(logs.join('\n')).toContain('API credentials for slack have been cleared.');
+      expect(readStore(storePath).slack).toBeUndefined();
       expect(readPreparations(storePath).slack).toBeUndefined();
+    });
+
+    it('auth clear --all rejects a missing service name', async () => {
+      const deps = createMockDependencies();
+      await runCommand(['auth', 'clear', '--all'], deps);
+
+      expect(exitCode).toBe(1);
+      expect(errorLogs.join('\n')).toContain('--all requires a service name');
+    });
+
+    it('auth clear --all rejects --account', async () => {
+      writeMultiAccountStore({ 'a@example.com': 'a' });
+
+      const deps = createMockDependencies();
+      await runCommand(
+        ['--account', 'a@example.com', 'auth', 'clear', 'slack', '--all'],
+        deps
+      );
+
+      expect(exitCode).toBe(1);
+      expect(errorLogs.join('\n')).toContain('--all cannot be combined with --account');
     });
 
     it('auth clear removes only the requested account', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -506,9 +506,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies();
@@ -623,9 +625,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
+          })
+        )
       );
 
       const originalPlatform = process.platform;
@@ -661,9 +665,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies({
@@ -680,12 +686,14 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          'my-gitlab': {
-            objectType: 'rawCurl',
-            curlArguments: ['-H', 'PRIVATE-TOKEN: token'],
-          },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            'my-gitlab': {
+              objectType: 'rawCurl',
+              curlArguments: ['-H', 'PRIVATE-TOKEN: token'],
+            },
+          })
+        )
       );
 
       // Ensure a graphical environment is available so browser auth is considered viable
@@ -778,9 +786,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies();
@@ -846,9 +856,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies();
@@ -872,10 +884,12 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'slack-token', dCookie: 'slack-cookie' },
-          discord: { objectType: 'authorizationBare', token: 'discord-token' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'slack-token', dCookie: 'slack-cookie' },
+            discord: { objectType: 'authorizationBare', token: 'discord-token' },
+          })
+        )
       );
 
       const deps = createMockDependencies();
@@ -893,7 +907,9 @@ describe('CLI commands with dependency injection', () => {
       const browserStatePath = join(tempDir, 'browser_state.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({ slack: { objectType: 'slack', token: 'test', dCookie: 'test' } }))
+        JSON.stringify(
+          nestAccounts({ slack: { objectType: 'slack', token: 'test', dCookie: 'test' } })
+        )
       );
       writeSecureFile(browserStatePath, '{}');
 
@@ -1035,10 +1051,7 @@ describe('CLI commands with dependency injection', () => {
       writeMultiAccountStore({ 'a@example.com': 'a' });
 
       const deps = createMockDependencies();
-      await runCommand(
-        ['--account', 'a@example.com', 'auth', 'clear', 'slack', '--all'],
-        deps
-      );
+      await runCommand(['--account', 'a@example.com', 'auth', 'clear', 'slack', '--all'], deps);
 
       expect(exitCode).toBe(1);
       expect(errorLogs.join('\n')).toContain('--all cannot be combined with --account');
@@ -1099,9 +1112,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies();
@@ -1154,9 +1169,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          unknown: { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: secret'] },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            unknown: { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: secret'] },
+          })
+        )
       );
 
       const deps = createMockDependencies();
@@ -1218,9 +1235,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'old-token', dCookie: 'old-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'old-token', dCookie: 'old-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies();
@@ -1524,9 +1543,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies();
@@ -1547,9 +1568,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'rawCurl', curlArguments: ['-H', 'X-Custom: header'] },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'rawCurl', curlArguments: ['-H', 'X-Custom: header'] },
+          })
+        )
       );
 
       const deps = createMockDependencies();
@@ -1564,9 +1587,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies();
@@ -1596,9 +1621,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies({
@@ -1630,9 +1657,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          'google-gmail': { objectType: 'oauth', clientId: 'cid', clientSecret: 'csecret' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            'google-gmail': { objectType: 'oauth', clientId: 'cid', clientSecret: 'csecret' },
+          })
+        )
       );
 
       const deps = createMockDependencies({
@@ -1649,14 +1678,16 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          'google-docs': {
-            objectType: 'oauth',
-            clientId: 'cid',
-            clientSecret: 'csecret',
-            accessToken: 'docs-token',
-          },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            'google-docs': {
+              objectType: 'oauth',
+              clientId: 'cid',
+              clientSecret: 'csecret',
+              accessToken: 'docs-token',
+            },
+          })
+        )
       );
 
       const deps = createMockDependencies({
@@ -1673,20 +1704,22 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          'google-drive': {
-            objectType: 'oauth',
-            clientId: 'cid',
-            clientSecret: 'csecret',
-            accessToken: 'drive-token',
-          },
-          'google-docs': {
-            objectType: 'oauth',
-            clientId: 'cid',
-            clientSecret: 'csecret',
-            accessToken: 'docs-token',
-          },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            'google-drive': {
+              objectType: 'oauth',
+              clientId: 'cid',
+              clientSecret: 'csecret',
+              accessToken: 'drive-token',
+            },
+            'google-docs': {
+              objectType: 'oauth',
+              clientId: 'cid',
+              clientSecret: 'csecret',
+              accessToken: 'docs-token',
+            },
+          })
+        )
       );
 
       const deps = createMockDependencies({
@@ -1703,21 +1736,23 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          'google-drive': {
-            objectType: 'oauth',
-            clientId: 'cid',
-            clientSecret: 'csecret',
-            accessToken: 'drive-token',
-            accessTokenExpiresAt: '2000-01-01T00:00:00.000Z',
-          },
-          'google-docs': {
-            objectType: 'oauth',
-            clientId: 'cid',
-            clientSecret: 'csecret',
-            accessToken: 'docs-token',
-          },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            'google-drive': {
+              objectType: 'oauth',
+              clientId: 'cid',
+              clientSecret: 'csecret',
+              accessToken: 'drive-token',
+              accessTokenExpiresAt: '2000-01-01T00:00:00.000Z',
+            },
+            'google-docs': {
+              objectType: 'oauth',
+              clientId: 'cid',
+              clientSecret: 'csecret',
+              accessToken: 'docs-token',
+            },
+          })
+        )
       );
 
       const deps = createMockDependencies({
@@ -1735,14 +1770,16 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          'google-docs': {
-            objectType: 'oauth',
-            clientId: 'cid',
-            clientSecret: 'csecret',
-            accessToken: 'docs-token',
-          },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            'google-docs': {
+              objectType: 'oauth',
+              clientId: 'cid',
+              clientSecret: 'csecret',
+              accessToken: 'docs-token',
+            },
+          })
+        )
       );
 
       const deps = createMockDependencies({
@@ -1786,9 +1823,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies({
@@ -1805,9 +1844,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
+          })
+        )
       );
 
       const mockLogin = vi.fn();
@@ -1842,9 +1883,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          telegram: { objectType: 'telegramBot', token: '123456:ABC-DEF' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            telegram: { objectType: 'telegramBot', token: '123456:ABC-DEF' },
+          })
+        )
       );
 
       const deps = createMockDependencies({
@@ -1861,9 +1904,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          nologin: { objectType: 'rawCurl', curlArguments: ['-H', 'X-API-Key: secret'] },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            nologin: { objectType: 'rawCurl', curlArguments: ['-H', 'X-API-Key: secret'] },
+          })
+        )
       );
 
       const noLoginService: Service = createMockService({
@@ -1897,9 +1942,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies({
@@ -1917,9 +1964,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
+          })
+        )
       );
 
       const deps = createMockDependencies({
@@ -1936,9 +1985,11 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'stored-token', dCookie: 'stored-cookie' },
+          })
+        )
       );
 
       const { PermissionCheckError } = await import('../src/permissions.js');
@@ -2426,12 +2477,14 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          'my-api': {
-            objectType: 'rawCurl',
-            curlArguments: ['-H', 'Authorization: Bearer my-token'],
-          },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            'my-api': {
+              objectType: 'rawCurl',
+              curlArguments: ['-H', 'Authorization: Bearer my-token'],
+            },
+          })
+        )
       );
 
       logs = [];
@@ -2505,12 +2558,14 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          'my-gitlab': {
-            objectType: 'rawCurl',
-            curlArguments: ['-H', 'PRIVATE-TOKEN: my-secret-token'],
-          },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            'my-gitlab': {
+              objectType: 'rawCurl',
+              curlArguments: ['-H', 'PRIVATE-TOKEN: my-secret-token'],
+            },
+          })
+        )
       );
 
       logs = [];
@@ -2619,12 +2674,14 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          'my-gitlab': {
-            objectType: 'rawCurl',
-            curlArguments: ['-H', 'PRIVATE-TOKEN: my-secret-token'],
-          },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            'my-gitlab': {
+              objectType: 'rawCurl',
+              curlArguments: ['-H', 'PRIVATE-TOKEN: my-secret-token'],
+            },
+          })
+        )
       );
 
       logs = [];
@@ -2664,12 +2721,14 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
         storePath,
-        JSON.stringify(nestAccounts({
-          'my-gitlab': {
-            objectType: 'rawCurl',
-            curlArguments: ['-H', 'PRIVATE-TOKEN: my-secret-token'],
-          },
-        }))
+        JSON.stringify(
+          nestAccounts({
+            'my-gitlab': {
+              objectType: 'rawCurl',
+              curlArguments: ['-H', 'PRIVATE-TOKEN: my-secret-token'],
+            },
+          })
+        )
       );
 
       logs = [];

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -11,8 +11,8 @@ import { EncryptedStorage } from '../src/encryptedStorage.js';
 import { Config } from '../src/config.js';
 import { ServiceRegistry } from '../src/serviceRegistry.js';
 import { ApiCredentialStatus } from '../src/apiCredentials/base.js';
-import { SlackApiCredentials } from '../src/services/slack.js';
-import { NoCurlCredentialsNotSupportedError, Service } from '../src/services/core/base.js';
+import { Service } from '../src/services/core/base.js';
+import { createMockService, MockService } from './mockService.js';
 import { RegisteredService } from '../src/services/core/registered.js';
 import { GITLAB } from '../src/services/gitlab.js';
 import { GITHUB } from '../src/services/github.js';
@@ -399,24 +399,7 @@ describe('CLI commands with dependency injection', () => {
   }
 
   function createMockDependencies(overrides: Partial<CliDependencies> = {}): CliDependencies {
-    const mockSlackService: Service = {
-      name: 'slack',
-      displayName: 'Slack',
-      baseApiUrls: ['https://slack.com/api/'],
-      loginUrl: 'https://slack.com/signin',
-      info: 'Test info for Slack service.',
-      credentialCheckCurlArguments: ['https://slack.com/api/auth.test'],
-      checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Valid),
-      setCredentialsExample(serviceName: string) {
-        return `latchkey auth set ${serviceName} -H "Authorization: Bearer xoxb-your-token"`;
-      },
-      getCredentialsNoCurl() {
-        throw new NoCurlCredentialsNotSupportedError('slack');
-      },
-      getSession: vi.fn().mockReturnValue({
-        login: vi.fn().mockResolvedValue(new SlackApiCredentials('xoxc-test-token', 'test-cookie')),
-      }),
-    };
+    const mockSlackService: Service = new MockService();
 
     const mockRegistry = new ServiceRegistry([mockSlackService]);
 
@@ -551,21 +534,20 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(storePath, '{}');
 
-      const noLoginService: Service = {
+      const noLoginService: Service = createMockService({
         name: 'nologin',
         displayName: 'No Login Service',
         baseApiUrls: ['https://nologin.example.com/api/'],
         loginUrl: 'https://nologin.example.com',
         info: 'A service without browser login support.',
         credentialCheckCurlArguments: [],
-        checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Missing),
-        setCredentialsExample(serviceName: string) {
-          return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
-        },
-        getCredentialsNoCurl() {
-          throw new NoCurlCredentialsNotSupportedError('nologin');
-        },
-      };
+        checkApiCredentials: vi
+          .fn()
+          .mockResolvedValue({ status: ApiCredentialStatus.Missing, account: null }),
+        setCredentialsExample: (serviceName: string) =>
+          `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`,
+        getSession: undefined,
+      });
 
       const deps = createMockDependencies({
         registry: new ServiceRegistry([noLoginService]),
@@ -742,21 +724,20 @@ describe('CLI commands with dependency injection', () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(storePath, '{}');
 
-      const noLoginService: Service = {
+      const noLoginService: Service = createMockService({
         name: 'nologin',
         displayName: 'No Login Service',
         baseApiUrls: ['https://nologin.example.com/api/'],
         loginUrl: 'https://nologin.example.com',
         info: 'A service without browser login support.',
         credentialCheckCurlArguments: [],
-        checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Missing),
-        setCredentialsExample(serviceName: string) {
-          return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
-        },
-        getCredentialsNoCurl() {
-          throw new NoCurlCredentialsNotSupportedError('nologin');
-        },
-      };
+        checkApiCredentials: vi
+          .fn()
+          .mockResolvedValue({ status: ApiCredentialStatus.Missing, account: null }),
+        setCredentialsExample: (serviceName: string) =>
+          `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`,
+        getSession: undefined,
+      });
 
       const deps = createMockDependencies({
         registry: new ServiceRegistry([noLoginService]),
@@ -1782,22 +1763,11 @@ describe('CLI commands with dependency injection', () => {
       );
 
       const mockLogin = vi.fn();
-      const mockSlackService: Service = {
-        name: 'slack',
-        displayName: 'Slack',
-        baseApiUrls: ['https://slack.com/api/'],
-        loginUrl: 'https://slack.com/signin',
-        info: 'Test info for Slack service.',
+      const mockSlackService: Service = createMockService({
         credentialCheckCurlArguments: [],
         checkApiCredentials: vi.fn(),
-        setCredentialsExample(serviceName: string) {
-          return `latchkey auth set ${serviceName} -H "Authorization: Bearer xoxb-your-token"`;
-        },
-        getCredentialsNoCurl() {
-          throw new NoCurlCredentialsNotSupportedError('slack');
-        },
         getSession: vi.fn().mockReturnValue({ login: mockLogin }),
-      };
+      });
 
       const deps = createMockDependencies({
         registry: new ServiceRegistry([mockSlackService]),
@@ -1848,22 +1818,21 @@ describe('CLI commands with dependency injection', () => {
         }))
       );
 
-      const noLoginService: Service = {
+      const noLoginService: Service = createMockService({
         name: 'nologin',
         displayName: 'No Login Service',
         baseApiUrls: ['https://nologin.example.com/api/'],
         loginUrl: 'https://nologin.example.com',
         info: 'A service without browser login support.',
         credentialCheckCurlArguments: [],
-        checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Valid),
-        setCredentialsExample(serviceName: string) {
-          return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
-        },
-        getCredentialsNoCurl() {
-          throw new NoCurlCredentialsNotSupportedError('nologin');
-        },
+        checkApiCredentials: vi
+          .fn()
+          .mockResolvedValue({ status: ApiCredentialStatus.Valid, account: null }),
+        setCredentialsExample: (serviceName: string) =>
+          `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`,
         // No getSession - service doesn't support browser login
-      };
+        getSession: undefined,
+      });
 
       const deps = createMockDependencies({
         registry: new ServiceRegistry([noLoginService]),
@@ -1941,7 +1910,7 @@ describe('CLI commands with dependency injection', () => {
 
   describe('auth browser command', () => {
     it('should return error when service does not support browser login', async () => {
-      const noLoginService: Service = {
+      const noLoginService: Service = createMockService({
         name: 'nologin',
         displayName: 'No Login Service',
         baseApiUrls: ['https://nologin.example.com/api/'],
@@ -1949,13 +1918,13 @@ describe('CLI commands with dependency injection', () => {
         info: 'A service without browser login support.',
         credentialCheckCurlArguments: [],
         checkApiCredentials: vi.fn(),
-        setCredentialsExample(serviceName: string) {
-          return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
-        },
+        setCredentialsExample: (serviceName: string) =>
+          `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`,
         // eslint-disable-next-line @typescript-eslint/unbound-method
         getCredentialsNoCurl: Service.prototype.getCredentialsNoCurl,
         // No getSession - service doesn't support browser login
-      };
+        getSession: undefined,
+      });
 
       const deps = createMockDependencies({
         registry: new ServiceRegistry([noLoginService]),
@@ -1999,7 +1968,7 @@ describe('CLI commands with dependency injection', () => {
     });
 
     it('should suggest set-nocurl when service supports nocurl credentials', async () => {
-      const nocurlService: Service = {
+      const nocurlService: Service = createMockService({
         name: 'nocurl-only',
         displayName: 'NoCurl Only Service',
         baseApiUrls: ['https://nocurl.example.com/api/'],
@@ -2007,9 +1976,8 @@ describe('CLI commands with dependency injection', () => {
         info: 'A service with nocurl credentials but no browser login.',
         credentialCheckCurlArguments: [],
         checkApiCredentials: vi.fn(),
-        setCredentialsExample(serviceName: string) {
-          return `latchkey auth set-nocurl ${serviceName} <some-arg>`;
-        },
+        setCredentialsExample: (serviceName: string) =>
+          `latchkey auth set-nocurl ${serviceName} <some-arg>`,
         getCredentialsNoCurl(arguments_: readonly string[]) {
           if (arguments_.length !== 1) {
             throw new Error('Expected exactly one argument');
@@ -2017,7 +1985,8 @@ describe('CLI commands with dependency injection', () => {
           return { objectType: 'test', injectIntoCurlCall: vi.fn(), isExpired: () => false };
         },
         // No getSession - service doesn't support browser login
-      };
+        getSession: undefined,
+      });
 
       const deps = createMockDependencies({
         registry: new ServiceRegistry([nocurlService]),

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -556,9 +556,7 @@ describe('CLI commands with dependency injection', () => {
         loginUrl: 'https://nologin.example.com',
         info: 'A service without browser login support.',
         credentialCheckCurlArguments: [],
-        checkApiCredentials: vi
-          .fn()
-          .mockResolvedValue({ status: ApiCredentialStatus.Missing, account: null }),
+        checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Missing),
         setCredentialsExample: (serviceName: string) =>
           `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`,
         getSession: undefined,
@@ -752,9 +750,7 @@ describe('CLI commands with dependency injection', () => {
         loginUrl: 'https://nologin.example.com',
         info: 'A service without browser login support.',
         credentialCheckCurlArguments: [],
-        checkApiCredentials: vi
-          .fn()
-          .mockResolvedValue({ status: ApiCredentialStatus.Missing, account: null }),
+        checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Missing),
         setCredentialsExample: (serviceName: string) =>
           `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`,
         getSession: undefined,
@@ -1925,9 +1921,7 @@ describe('CLI commands with dependency injection', () => {
         loginUrl: 'https://nologin.example.com',
         info: 'A service without browser login support.',
         credentialCheckCurlArguments: [],
-        checkApiCredentials: vi
-          .fn()
-          .mockResolvedValue({ status: ApiCredentialStatus.Valid, account: null }),
+        checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Valid),
         setCredentialsExample: (serviceName: string) =>
           `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`,
         // No getSession - service doesn't support browser login

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -45,17 +45,30 @@ function readSecureFile(path: string): string | null {
   return storage.readFile(path);
 }
 
-// Wrap a flat { service: credentials } map into the account-keyed on-disk
-// layout, storing everything under the default account.
-function nestAccounts(
-  flat: Record<string, unknown>
-): Record<string, Record<string, unknown>> {
-  return Object.fromEntries(Object.entries(flat).map(([service, creds]) => [service, { '': creds }]));
+// Wrap a flat { service: credentials } map into the on-disk layout, storing
+// everything as account-keyed credentials under the default account.
+function nestAccounts(flat: Record<string, unknown>): Record<string, unknown> {
+  return {
+    credentials: Object.fromEntries(
+      Object.entries(flat).map(([service, creds]) => [service, { '': creds }])
+    ),
+  };
 }
 
-// Read the raw account-keyed credential store contents.
+// Read the raw account-keyed credentials section of the store.
 function readStore(path: string): Record<string, Record<string, unknown>> {
-  return JSON.parse(readSecureFile(path) ?? '{}') as Record<string, Record<string, unknown>>;
+  const parsed = JSON.parse(readSecureFile(path) ?? '{}') as {
+    credentials?: Record<string, Record<string, unknown>>;
+  };
+  return parsed.credentials ?? {};
+}
+
+// Read the raw preparations section of the store.
+function readPreparations(path: string): Record<string, unknown> {
+  const parsed = JSON.parse(readSecureFile(path) ?? '{}') as {
+    preparations?: Record<string, unknown>;
+  };
+  return parsed.preparations ?? {};
 }
 
 // Read a single service's default-account credentials from the store.
@@ -785,9 +798,11 @@ describe('CLI commands with dependency injection', () => {
       writeSecureFile(
         storePath,
         JSON.stringify({
-          slack: {
-            '': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: default'] },
-            'work@example.com': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: work'] },
+          credentials: {
+            slack: {
+              '': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: default'] },
+              'work@example.com': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: work'] },
+            },
           },
         })
       );
@@ -902,7 +917,7 @@ describe('CLI commands with dependency injection', () => {
       const slackAccounts = Object.fromEntries(
         Object.entries(accounts).map(([account, token]) => [account, rawCurl(token)])
       );
-      writeSecureFile(storePath, JSON.stringify({ slack: slackAccounts }));
+      writeSecureFile(storePath, JSON.stringify({ credentials: { slack: slackAccounts } }));
       return storePath;
     }
 
@@ -969,33 +984,23 @@ describe('CLI commands with dependency injection', () => {
       expect(capturedArgs).toEqual([]);
     });
 
-    it('auth prepare stores the client under the given account', async () => {
+    it('auth clear without --account also removes the preparation', async () => {
       const storePath = join(tempDir, 'credentials.json');
-      writeSecureFile(storePath, '{}');
-
-      const deps = createMockDependencies({
-        registry: new ServiceRegistry([GOOGLE_GMAIL]),
-      });
-      await runCommand(
-        [
-          '--account',
-          'work@example.com',
-          'auth',
-          'prepare',
-          'google-gmail',
-          '{"clientId":"cid","clientSecret":"csecret"}',
-        ],
-        deps
+      writeSecureFile(
+        storePath,
+        JSON.stringify({
+          credentials: { slack: { 'a@example.com': rawCurl('a') } },
+          preparations: {
+            slack: { objectType: 'oauth', clientId: 'cid', clientSecret: 'csecret' },
+          },
+        })
       );
 
-      expect(logs).toContain('Done');
-      const store = readStore(storePath);
-      expect(store['google-gmail']?.['work@example.com']).toEqual({
-        objectType: 'oauth',
-        clientId: 'cid',
-        clientSecret: 'csecret',
-      });
-      expect(store['google-gmail']?.['']).toBeUndefined();
+      const deps = createMockDependencies();
+      await runCommand(['auth', 'clear', 'slack'], deps);
+
+      expect(readStore(storePath).slack).toBeUndefined();
+      expect(readPreparations(storePath).slack).toBeUndefined();
     });
 
     it('auth clear removes only the requested account', async () => {
@@ -1035,8 +1040,8 @@ describe('CLI commands with dependency injection', () => {
 
     it.each([
       ['services', 'info', 'slack'],
-      ['auth', 'browser', 'slack'],
       ['auth', 'browser-prepare', 'slack'],
+      ['auth', 'prepare', 'google-gmail', '{"clientId":"a","clientSecret":"b"}'],
       ['auth', 'list'],
       ['services', 'list'],
     ])('rejects --account for the unsupported command: %s %s', async (...commandArgs) => {
@@ -1073,9 +1078,11 @@ describe('CLI commands with dependency injection', () => {
       writeSecureFile(
         storePath,
         JSON.stringify({
-          slack: {
-            '': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: default'] },
-            'work@example.com': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: work'] },
+          credentials: {
+            slack: {
+              '': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: default'] },
+              'work@example.com': { objectType: 'rawCurl', curlArguments: ['-H', 'X-Token: work'] },
+            },
           },
         })
       );
@@ -1194,13 +1201,12 @@ describe('CLI commands with dependency injection', () => {
 
     function readWithKey(path: string, key: string): Record<string, unknown> {
       const storage = new EncryptedStorage(key);
-      const raw = JSON.parse(storage.readFile(path) ?? '{}') as Record<
-        string,
-        Record<string, unknown>
-      >;
+      const raw = JSON.parse(storage.readFile(path) ?? '{}') as {
+        credentials?: Record<string, Record<string, unknown>>;
+      };
       // Unwrap the default account so assertions can compare flat credentials.
       return Object.fromEntries(
-        Object.entries(raw).map(([service, accounts]) => [service, accounts['']])
+        Object.entries(raw.credentials ?? {}).map(([service, accounts]) => [service, accounts['']])
       );
     }
 
@@ -1403,7 +1409,7 @@ describe('CLI commands with dependency injection', () => {
   });
 
   describe('prepare command', () => {
-    it('stores an OAuth client for a Google service and reports success', async () => {
+    it("stores an OAuth client as the service's preparation and reports success", async () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(storePath, '{}');
 
@@ -1417,11 +1423,12 @@ describe('CLI commands with dependency injection', () => {
       );
 
       expect(logs).toContain('Done');
-      expect(readDefaultCredentials(storePath, 'google-gmail')).toEqual({
+      expect(readPreparations(storePath)['google-gmail']).toEqual({
         objectType: 'oauth',
         clientId: 'cid',
         clientSecret: 'csecret',
       });
+      expect(readDefaultCredentials(storePath, 'google-gmail')).toBeUndefined();
     });
 
     it('returns an error for an unknown service', async () => {

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -235,7 +235,11 @@ describe('gateway server', () => {
     configOverrides: Partial<Config> = {}
   ): Promise<GatewayServer> {
     const storePath = join(tempDir, 'credentials.json');
-    writeSecureFile(storePath, JSON.stringify(credentialsData));
+    // Store credentials under the default account, matching the on-disk layout.
+    const nestedCredentials = Object.fromEntries(
+      Object.entries(credentialsData).map(([service, creds]) => [service, { '': creds }])
+    );
+    writeSecureFile(storePath, JSON.stringify(nestedCredentials));
 
     const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
     const apiCredentialStore = new ApiCredentialStore(storePath, encryptedStorage);

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -228,7 +228,7 @@ describe('gateway server', () => {
     const nestedCredentials = Object.fromEntries(
       Object.entries(credentialsData).map(([service, creds]) => [service, { '': creds }])
     );
-    writeSecureFile(storePath, JSON.stringify(nestedCredentials));
+    writeSecureFile(storePath, JSON.stringify({ credentials: nestedCredentials }));
 
     const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
     const apiCredentialStore = new ApiCredentialStore(storePath, encryptedStorage);

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -21,8 +21,8 @@ import { EncryptedStorage } from '../src/encryptedStorage.js';
 import { ApiCredentialStore } from '../src/apiCredentials/store.js';
 import { Config } from '../src/config.js';
 import { ServiceRegistry } from '../src/serviceRegistry.js';
-import { ApiCredentialStatus } from '../src/apiCredentials/base.js';
-import { NoCurlCredentialsNotSupportedError, Service } from '../src/services/core/base.js';
+import { Service } from '../src/services/core/base.js';
+import { createMockService } from './mockService.js';
 
 const TEST_ENCRYPTION_KEY = 'dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleXRlc3Q=';
 
@@ -194,21 +194,10 @@ describe('gateway server', () => {
   let mockCurlHeaderDump: string;
   let mockPermissionResult: boolean;
 
-  const mockSlackService: Service = {
-    name: 'slack',
-    displayName: 'Slack',
-    baseApiUrls: ['https://slack.com/api/'],
-    loginUrl: 'https://slack.com/signin',
+  const mockSlackService: Service = createMockService({
     info: 'Test Slack service.',
-    credentialCheckCurlArguments: ['https://slack.com/api/auth.test'],
-    checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Valid),
-    setCredentialsExample(serviceName: string) {
-      return `latchkey auth set ${serviceName} -H "Authorization: Bearer xoxb-your-token"`;
-    },
-    getCredentialsNoCurl() {
-      throw new NoCurlCredentialsNotSupportedError('slack');
-    },
-  };
+    getSession: undefined,
+  });
 
   function createMockConfig(configOverrides: Partial<Config> = {}): Config {
     const base = new Config((name) => {

--- a/tests/latchkeyEndpoint.test.ts
+++ b/tests/latchkeyEndpoint.test.ts
@@ -153,7 +153,7 @@ describe('/latchkey/ endpoint', () => {
     const nestedCredentials = Object.fromEntries(
       Object.entries(credentialsData).map(([service, creds]) => [service, { '': creds }])
     );
-    writeSecureFile(storePath, JSON.stringify(nestedCredentials));
+    writeSecureFile(storePath, JSON.stringify({ credentials: nestedCredentials }));
 
     const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
     const apiCredentialStore = new ApiCredentialStore(storePath, encryptedStorage);

--- a/tests/latchkeyEndpoint.test.ts
+++ b/tests/latchkeyEndpoint.test.ts
@@ -6,7 +6,8 @@ import { EncryptedStorage } from '../src/encryptedStorage.js';
 import { derivePermissionsOverrideSigningKey } from '../src/gateway/permissionsOverride.js';
 import { ApiCredentialStore } from '../src/apiCredentials/store.js';
 import { ApiCredentialStatus } from '../src/apiCredentials/base.js';
-import { NoCurlCredentialsNotSupportedError, Service } from '../src/services/core/base.js';
+import { Service } from '../src/services/core/base.js';
+import { createMockService } from './mockService.js';
 import { GOOGLE_GMAIL } from '../src/services/google/gmail.js';
 import { ServiceRegistry } from '../src/serviceRegistry.js';
 import { Config } from '../src/config.js';
@@ -23,21 +24,10 @@ function writeSecureFile(path: string, content: string): void {
   storage.writeFile(path, content);
 }
 
-const mockSlackService: Service = {
-  name: 'slack',
-  displayName: 'Slack',
-  baseApiUrls: ['https://slack.com/api/'],
-  loginUrl: 'https://slack.com/signin',
+const mockSlackService: Service = createMockService({
   info: 'Test Slack service.',
-  credentialCheckCurlArguments: ['https://slack.com/api/auth.test'],
-  checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Valid),
-  setCredentialsExample(serviceName: string) {
-    return `latchkey auth set ${serviceName} -H "Authorization: Bearer xoxb-your-token"`;
-  },
-  getCredentialsNoCurl() {
-    throw new NoCurlCredentialsNotSupportedError('slack');
-  },
-};
+  getSession: undefined,
+});
 
 // ─── Schema validation tests ──────────────────────────────────────────────────
 
@@ -434,7 +424,8 @@ describe('/latchkey/ endpoint', () => {
     });
 
     it('should return error when browser is disabled', async () => {
-      const browserSlack: Service = Object.assign({}, mockSlackService, {
+      const browserSlack: Service = createMockService({
+        info: 'Test Slack service.',
         getSession: vi.fn().mockReturnValue({
           login: vi.fn(),
         }),
@@ -455,21 +446,20 @@ describe('/latchkey/ endpoint', () => {
     });
 
     it('should return error for service without browser support', async () => {
-      const noLoginService: Service = {
+      const noLoginService: Service = createMockService({
         name: 'nologin',
         displayName: 'No Login Service',
         baseApiUrls: ['https://nologin.example.com/api/'],
         loginUrl: 'https://nologin.example.com',
         info: 'No browser login support.',
         credentialCheckCurlArguments: [],
-        checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Missing),
-        setCredentialsExample(serviceName: string) {
-          return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
-        },
-        getCredentialsNoCurl() {
-          throw new NoCurlCredentialsNotSupportedError('nologin');
-        },
-      };
+        checkApiCredentials: vi
+          .fn()
+          .mockResolvedValue({ status: ApiCredentialStatus.Missing, account: null }),
+        setCredentialsExample: (serviceName: string) =>
+          `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`,
+        getSession: undefined,
+      });
 
       gateway = await createTestGateway({}, { registry: new ServiceRegistry([noLoginService]) });
       const response = await postLatchkey({

--- a/tests/latchkeyEndpoint.test.ts
+++ b/tests/latchkeyEndpoint.test.ts
@@ -159,7 +159,11 @@ describe('/latchkey/ endpoint', () => {
     configOverrides: Partial<Config> = {}
   ): Promise<GatewayServer> {
     const storePath = join(tempDir, 'credentials.json');
-    writeSecureFile(storePath, JSON.stringify(credentialsData));
+    // Store credentials under the default account, matching the on-disk layout.
+    const nestedCredentials = Object.fromEntries(
+      Object.entries(credentialsData).map(([service, creds]) => [service, { '': creds }])
+    );
+    writeSecureFile(storePath, JSON.stringify(nestedCredentials));
 
     const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
     const apiCredentialStore = new ApiCredentialStore(storePath, encryptedStorage);

--- a/tests/latchkeyEndpoint.test.ts
+++ b/tests/latchkeyEndpoint.test.ts
@@ -329,10 +329,10 @@ describe('/latchkey/ endpoint', () => {
 
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
-        result: { type: string; credentialStatus: string };
+        result: { type: string; credentials: Record<string, unknown> };
       };
       expect(body.result.type).toBe('built-in');
-      expect(body.result.credentialStatus).toBe('missing');
+      expect(body.result.credentials).toEqual({});
     });
 
     it('should return error for unknown service', async () => {
@@ -409,11 +409,13 @@ describe('/latchkey/ endpoint', () => {
 
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
-        result: Record<string, { credentialType: string; credentialStatus: string }>;
+        result: Record<string, Record<string, { credentialType: string; credentialStatus: string }>>;
       };
       expect(body.result.slack).toEqual({
-        credentialType: 'slack',
-        credentialStatus: 'valid',
+        '': {
+          credentialType: 'slack',
+          credentialStatus: 'valid',
+        },
       });
     });
   });

--- a/tests/latchkeyEndpoint.test.ts
+++ b/tests/latchkeyEndpoint.test.ts
@@ -456,9 +456,7 @@ describe('/latchkey/ endpoint', () => {
         loginUrl: 'https://nologin.example.com',
         info: 'No browser login support.',
         credentialCheckCurlArguments: [],
-        checkApiCredentials: vi
-          .fn()
-          .mockResolvedValue({ status: ApiCredentialStatus.Missing, account: null }),
+        checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Missing),
         setCredentialsExample: (serviceName: string) =>
           `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`,
         getSession: undefined,

--- a/tests/latchkeyEndpoint.test.ts
+++ b/tests/latchkeyEndpoint.test.ts
@@ -399,7 +399,10 @@ describe('/latchkey/ endpoint', () => {
 
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
-        result: Record<string, Record<string, { credentialType: string; credentialStatus: string }>>;
+        result: Record<
+          string,
+          Record<string, { credentialType: string; credentialStatus: string }>
+        >;
       };
       expect(body.result.slack).toEqual({
         '': {

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -89,17 +89,19 @@ describe('migrations', () => {
   });
 
   describe('runMigrations', () => {
-    it('should skip migrations on first installation (no directory)', async () => {
+    it('should skip migrations but stamp the version on first installation (no directory)', async () => {
       const freshConfig = createTestConfig(join(tempDir, 'nonexistent'));
       await runMigrations(freshConfig, encryptedStorage, inconclusiveResolver);
-      // Should not throw and should not create any files
-      expect(existsSync(join(tempDir, 'nonexistent', 'data-format-version'))).toBe(false);
+      // A fresh installation starts in the newest format; the version stamp
+      // prevents future runs from "migrating" a store created in that format.
+      expect(readDataFormatVersion(freshConfig)).toBe(LATEST_VERSION);
+      expect(existsSync(join(tempDir, 'nonexistent', 'credentials.json'))).toBe(false);
     });
 
-    it('should skip migrations on first installation (directory exists but no credentials)', async () => {
+    it('should skip migrations but stamp the version on first installation (directory exists but no credentials)', async () => {
       // tempDir exists but has no credentials file
       await runMigrations(config, encryptedStorage, inconclusiveResolver);
-      expect(existsSync(join(tempDir, 'data-format-version'))).toBe(false);
+      expect(readDataFormatVersion(config)).toBe(LATEST_VERSION);
     });
 
     it('should run migrations when credentials exist and version is 0', async () => {
@@ -157,20 +159,34 @@ describe('migrations', () => {
       await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
-      const store = JSON.parse(content) as Record<string, unknown>;
+      const store = JSON.parse(content) as {
+        credentials: Record<string, unknown>;
+        preparations: Record<string, unknown>;
+      };
 
       // The account migration additionally wraps each entry under the default
-      // account (the empty string).
-      expect(store).not.toHaveProperty('google');
-      expect(store['google-gmail']).toEqual({ '': googleCredentials });
-      expect(store['google-calendar']).toEqual({ '': googleCredentials });
-      expect(store['google-drive']).toEqual({ '': googleCredentials });
-      expect(store['google-sheets']).toEqual({ '': googleCredentials });
-      expect(store['google-docs']).toEqual({ '': googleCredentials });
-      expect(store['google-people']).toEqual({ '': googleCredentials });
+      // account (the empty string), and the preparations migration derives a
+      // token-less OAuth client for each Google service.
+      const expectedPreparation = {
+        objectType: 'oauth',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+      };
+      expect(store.credentials).not.toHaveProperty('google');
+      for (const serviceName of [
+        'google-gmail',
+        'google-calendar',
+        'google-drive',
+        'google-sheets',
+        'google-docs',
+        'google-people',
+      ]) {
+        expect(store.credentials[serviceName]).toEqual({ '': googleCredentials });
+        expect(store.preparations[serviceName]).toEqual(expectedPreparation);
+      }
       // analytics and maps should NOT be created
-      expect(store).not.toHaveProperty('google-analytics');
-      expect(store).not.toHaveProperty('google-directions');
+      expect(store.credentials).not.toHaveProperty('google-analytics');
+      expect(store.credentials).not.toHaveProperty('google-directions');
     });
 
     it('should not overwrite existing individual service credentials', async () => {
@@ -198,10 +214,16 @@ describe('migrations', () => {
       await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
-      const store = JSON.parse(content) as Record<string, unknown>;
+      const store = JSON.parse(content) as {
+        credentials: Record<string, unknown>;
+        preparations: Record<string, unknown>;
+      };
 
-      expect(store['google-drive']).toEqual({ '': existingDriveCredentials });
-      expect(store['google-gmail']).toEqual({ '': googleCredentials });
+      expect(store.credentials['google-drive']).toEqual({ '': existingDriveCredentials });
+      // The old shared "google" credentials carry no tokens, so the
+      // preparations migration treats them as prepared placeholders.
+      expect(store.credentials['google-gmail']).toBeUndefined();
+      expect(store.preparations['google-gmail']).toEqual(googleCredentials);
     });
 
     it('should preserve non-google credentials', async () => {
@@ -223,9 +245,9 @@ describe('migrations', () => {
       await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
-      const store = JSON.parse(content) as Record<string, unknown>;
+      const store = JSON.parse(content) as { credentials: Record<string, unknown> };
 
-      expect(store.slack).toEqual({ '': slackCredentials });
+      expect(store.credentials.slack).toEqual({ '': slackCredentials });
     });
 
     it('should be a no-op when there is no "google" entry', async () => {
@@ -239,10 +261,10 @@ describe('migrations', () => {
       await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
-      const store = JSON.parse(content) as Record<string, unknown>;
+      const store = JSON.parse(content) as { credentials: Record<string, unknown> };
 
-      expect(store.slack).toEqual({ '': slackCredentials });
-      expect(Object.keys(store)).toEqual(['slack']);
+      expect(store.credentials.slack).toEqual({ '': slackCredentials });
+      expect(Object.keys(store.credentials)).toEqual(['slack']);
     });
 
     it('should update the version file after migration', async () => {
@@ -271,10 +293,10 @@ describe('migrations', () => {
       await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
-      const store = JSON.parse(content) as Record<string, unknown>;
+      const store = JSON.parse(content) as { credentials: Record<string, unknown> };
 
-      expect(store.slack).toEqual({ '': slackCredentials });
-      expect(store.discord).toEqual({ '': discordCredentials });
+      expect(store.credentials.slack).toEqual({ '': slackCredentials });
+      expect(store.credentials.discord).toEqual({ '': discordCredentials });
     });
 
     it('should produce an empty store for an empty store', async () => {
@@ -283,7 +305,7 @@ describe('migrations', () => {
       await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
-      expect(JSON.parse(content)).toEqual({});
+      expect(JSON.parse(content)).toEqual({ credentials: {}, preparations: {} });
     });
 
     it('should key valid credentials by their resolved account', async () => {
@@ -304,9 +326,9 @@ describe('migrations', () => {
 
       const store = JSON.parse(
         encryptedStorage.readFile(config.credentialStorePath)!
-      ) as Record<string, unknown>;
+      ) as { credentials: Record<string, unknown> };
 
-      expect(store.slack).toEqual({ 'user@example.com': slackCredentials });
+      expect(store.credentials.slack).toEqual({ 'user@example.com': slackCredentials });
     });
 
     it('should keep valid credentials under the default account when the account is unknown', async () => {
@@ -325,9 +347,9 @@ describe('migrations', () => {
 
       const store = JSON.parse(
         encryptedStorage.readFile(config.credentialStorePath)!
-      ) as Record<string, unknown>;
+      ) as { credentials: Record<string, unknown> };
 
-      expect(store.slack).toEqual({ '': slackCredentials });
+      expect(store.credentials.slack).toEqual({ '': slackCredentials });
     });
 
     it('should drop invalid credentials', async () => {
@@ -350,10 +372,10 @@ describe('migrations', () => {
 
       const store = JSON.parse(
         encryptedStorage.readFile(config.credentialStorePath)!
-      ) as Record<string, unknown>;
+      ) as { credentials: Record<string, unknown> };
 
-      expect(store).not.toHaveProperty('slack');
-      expect(store.discord).toEqual({ 'me#1234': discordCredentials });
+      expect(store.credentials).not.toHaveProperty('slack');
+      expect(store.credentials.discord).toEqual({ 'me#1234': discordCredentials });
     });
 
     it('should key google credentials by the account from determineAccount()', async () => {
@@ -395,9 +417,16 @@ describe('migrations', () => {
 
       const store = JSON.parse(
         encryptedStorage.readFile(config.credentialStorePath)!
-      ) as Record<string, unknown>;
+      ) as { credentials: Record<string, unknown>; preparations: Record<string, unknown> };
 
-      expect(store['google-gmail']).toEqual({ 'alice@example.com': gmailCredentials });
+      expect(store.credentials['google-gmail']).toEqual({
+        'alice@example.com': gmailCredentials,
+      });
+      expect(store.preparations['google-gmail']).toEqual({
+        objectType: 'oauth',
+        clientId: 'client',
+        clientSecret: 'secret',
+      });
     });
 
     it('should leave credentials under the default account on inconclusive checks', async () => {
@@ -416,9 +445,99 @@ describe('migrations', () => {
 
       const store = JSON.parse(
         encryptedStorage.readFile(config.credentialStorePath)!
-      ) as Record<string, unknown>;
+      ) as { credentials: Record<string, unknown> };
 
-      expect(store.slack).toEqual({ '': slackCredentials });
+      expect(store.credentials.slack).toEqual({ '': slackCredentials });
+    });
+  });
+
+  describe('migration 3: separate preparations', () => {
+    async function runPreparationsMigrationOn(
+      store: Record<string, Record<string, unknown>>
+    ): Promise<{ credentials: Record<string, unknown>; preparations: Record<string, unknown> }> {
+      encryptedStorage.writeFile(config.credentialStorePath, JSON.stringify(store));
+      // Skip migrations 1 and 2: the input is already account-keyed.
+      writeFileSync(join(tempDir, 'data-format-version'), '2', 'utf-8');
+      await runMigrations(config, encryptedStorage, inconclusiveResolver);
+      return JSON.parse(encryptedStorage.readFile(config.credentialStorePath)!) as {
+        credentials: Record<string, unknown>;
+        preparations: Record<string, unknown>;
+      };
+    }
+
+    it('moves a token-less default-account OAuth client into preparations', async () => {
+      const preparedClient = { objectType: 'oauth', clientId: 'cid', clientSecret: 'csecret' };
+
+      const store = await runPreparationsMigrationOn({ 'google-gmail': { '': preparedClient } });
+
+      expect(store.credentials).not.toHaveProperty('google-gmail');
+      expect(store.preparations['google-gmail']).toEqual(preparedClient);
+    });
+
+    it('derives a token-less preparation from complete OAuth credentials', async () => {
+      const fullCredentials = {
+        objectType: 'oauth',
+        clientId: 'cid',
+        clientSecret: 'csecret',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      };
+
+      const store = await runPreparationsMigrationOn({
+        'google-docs': { 'user@example.com': fullCredentials },
+      });
+
+      expect(store.credentials['google-docs']).toEqual({ 'user@example.com': fullCredentials });
+      expect(store.preparations['google-docs']).toEqual({
+        objectType: 'oauth',
+        clientId: 'cid',
+        clientSecret: 'csecret',
+      });
+    });
+
+    it("prefers the default account's client when deriving a preparation", async () => {
+      const defaultCredentials = {
+        objectType: 'oauth',
+        clientId: 'default-cid',
+        clientSecret: 'default-csecret',
+        accessToken: 'access-token',
+      };
+      const namedCredentials = {
+        objectType: 'oauth',
+        clientId: 'named-cid',
+        clientSecret: 'named-csecret',
+        accessToken: 'access-token',
+      };
+
+      const store = await runPreparationsMigrationOn({
+        'google-gmail': { 'user@example.com': namedCredentials, '': defaultCredentials },
+      });
+
+      expect(store.preparations['google-gmail']).toEqual({
+        objectType: 'oauth',
+        clientId: 'default-cid',
+        clientSecret: 'default-csecret',
+      });
+    });
+
+    it('creates no preparation for non-OAuth credentials', async () => {
+      const slackCredentials = { objectType: 'slack', token: 't', dCookie: 'd' };
+
+      const store = await runPreparationsMigrationOn({ slack: { '': slackCredentials } });
+
+      expect(store.credentials.slack).toEqual({ '': slackCredentials });
+      expect(store.preparations).toEqual({});
+    });
+
+    it('keeps a token-less OAuth client stored under a named account as credentials', async () => {
+      const namedClient = { objectType: 'oauth', clientId: 'cid', clientSecret: 'csecret' };
+
+      const store = await runPreparationsMigrationOn({
+        'notion-mcp': { 'user@workspace': namedClient },
+      });
+
+      expect(store.credentials['notion-mcp']).toEqual({ 'user@workspace': namedClient });
+      expect(store.preparations['notion-mcp']).toEqual(namedClient);
     });
   });
 });

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -133,13 +133,15 @@ describe('migrations', () => {
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
       const store = JSON.parse(content) as Record<string, unknown>;
 
+      // The account migration additionally wraps each entry under the default
+      // account (the empty string).
       expect(store).not.toHaveProperty('google');
-      expect(store['google-gmail']).toEqual(googleCredentials);
-      expect(store['google-calendar']).toEqual(googleCredentials);
-      expect(store['google-drive']).toEqual(googleCredentials);
-      expect(store['google-sheets']).toEqual(googleCredentials);
-      expect(store['google-docs']).toEqual(googleCredentials);
-      expect(store['google-people']).toEqual(googleCredentials);
+      expect(store['google-gmail']).toEqual({ '': googleCredentials });
+      expect(store['google-calendar']).toEqual({ '': googleCredentials });
+      expect(store['google-drive']).toEqual({ '': googleCredentials });
+      expect(store['google-sheets']).toEqual({ '': googleCredentials });
+      expect(store['google-docs']).toEqual({ '': googleCredentials });
+      expect(store['google-people']).toEqual({ '': googleCredentials });
       // analytics and maps should NOT be created
       expect(store).not.toHaveProperty('google-analytics');
       expect(store).not.toHaveProperty('google-directions');
@@ -172,8 +174,8 @@ describe('migrations', () => {
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
       const store = JSON.parse(content) as Record<string, unknown>;
 
-      expect(store['google-drive']).toEqual(existingDriveCredentials);
-      expect(store['google-gmail']).toEqual(googleCredentials);
+      expect(store['google-drive']).toEqual({ '': existingDriveCredentials });
+      expect(store['google-gmail']).toEqual({ '': googleCredentials });
     });
 
     it('should preserve non-google credentials', () => {
@@ -197,7 +199,7 @@ describe('migrations', () => {
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
       const store = JSON.parse(content) as Record<string, unknown>;
 
-      expect(store.slack).toEqual(slackCredentials);
+      expect(store.slack).toEqual({ '': slackCredentials });
     });
 
     it('should be a no-op when there is no "google" entry', () => {
@@ -213,7 +215,7 @@ describe('migrations', () => {
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
       const store = JSON.parse(content) as Record<string, unknown>;
 
-      expect(store.slack).toEqual(slackCredentials);
+      expect(store.slack).toEqual({ '': slackCredentials });
       expect(Object.keys(store)).toEqual(['slack']);
     });
 
@@ -227,6 +229,35 @@ describe('migrations', () => {
 
       const versionContent = readFileSync(join(tempDir, 'data-format-version'), 'utf-8');
       expect(versionContent).toBe(String(LATEST_VERSION));
+    });
+  });
+
+  describe('migration 2: introduce accounts', () => {
+    it('should wrap each service credential under the default account', () => {
+      const slackCredentials = { objectType: 'slack', token: 't', dCookie: 'd' };
+      const discordCredentials = { objectType: 'authorizationBare', token: 'discord' };
+
+      encryptedStorage.writeFile(
+        config.credentialStorePath,
+        JSON.stringify({ slack: slackCredentials, discord: discordCredentials })
+      );
+
+      runMigrations(config, encryptedStorage);
+
+      const content = encryptedStorage.readFile(config.credentialStorePath)!;
+      const store = JSON.parse(content) as Record<string, unknown>;
+
+      expect(store.slack).toEqual({ '': slackCredentials });
+      expect(store.discord).toEqual({ '': discordCredentials });
+    });
+
+    it('should produce an empty store for an empty store', () => {
+      encryptedStorage.writeFile(config.credentialStorePath, JSON.stringify({}));
+
+      runMigrations(config, encryptedStorage);
+
+      const content = encryptedStorage.readFile(config.credentialStorePath)!;
+      expect(JSON.parse(content)).toEqual({});
     });
   });
 });

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -164,9 +164,9 @@ describe('migrations', () => {
         preparations: Record<string, unknown>;
       };
 
-      // The account migration additionally wraps each entry under the default
-      // account (the empty string), and the preparations migration derives a
-      // token-less OAuth client for each Google service.
+      // The accounts-and-preparations migration additionally wraps each entry
+      // under the default account (the empty string) and derives a token-less
+      // OAuth client preparation for each Google service.
       const expectedPreparation = {
         objectType: 'oauth',
         clientId: 'test-client-id',
@@ -221,7 +221,8 @@ describe('migrations', () => {
 
       expect(store.credentials['google-drive']).toEqual({ '': existingDriveCredentials });
       // The old shared "google" credentials carry no tokens, so the
-      // preparations migration treats them as prepared placeholders.
+      // accounts-and-preparations migration treats them as prepared
+      // placeholders.
       expect(store.credentials['google-gmail']).toBeUndefined();
       expect(store.preparations['google-gmail']).toEqual(googleCredentials);
     });
@@ -280,7 +281,7 @@ describe('migrations', () => {
     });
   });
 
-  describe('migration 2: introduce accounts', () => {
+  describe('migration 2: introduce accounts and separate preparations', () => {
     it('should wrap each service credential under the default account', async () => {
       const slackCredentials = { objectType: 'slack', token: 't', dCookie: 'd' };
       const discordCredentials = { objectType: 'authorizationBare', token: 'discord' };
@@ -350,6 +351,40 @@ describe('migrations', () => {
       ) as { credentials: Record<string, unknown> };
 
       expect(store.credentials.slack).toEqual({ '': slackCredentials });
+    });
+
+    it('should preserve the OAuth client of dropped invalid credentials as a preparation', async () => {
+      const gmailCredentials = {
+        objectType: 'oauth',
+        clientId: 'client',
+        clientSecret: 'secret',
+        accessToken: 'expired-access-token',
+        refreshToken: 'expired-refresh-token',
+      };
+
+      encryptedStorage.writeFile(
+        config.credentialStorePath,
+        JSON.stringify({ 'google-gmail': gmailCredentials })
+      );
+
+      await runMigrations(
+        config,
+        encryptedStorage,
+        resolverFromMap({
+          'google-gmail': { status: ApiCredentialStatus.Invalid, account: null },
+        })
+      );
+
+      const store = JSON.parse(
+        encryptedStorage.readFile(config.credentialStorePath)!
+      ) as { credentials: Record<string, unknown>; preparations: Record<string, unknown> };
+
+      expect(store.credentials).not.toHaveProperty('google-gmail');
+      expect(store.preparations['google-gmail']).toEqual({
+        objectType: 'oauth',
+        clientId: 'client',
+        clientSecret: 'secret',
+      });
     });
 
     it('should drop invalid credentials', async () => {
@@ -449,13 +484,11 @@ describe('migrations', () => {
     });
   });
 
-  describe('migration 3: separate preparations', () => {
-    async function runPreparationsMigrationOn(
-      store: Record<string, Record<string, unknown>>
+  describe('migration 2: preparations', () => {
+    async function runMigrationOn(
+      store: Record<string, unknown>
     ): Promise<{ credentials: Record<string, unknown>; preparations: Record<string, unknown> }> {
       encryptedStorage.writeFile(config.credentialStorePath, JSON.stringify(store));
-      // Skip migrations 1 and 2: the input is already account-keyed.
-      writeFileSync(join(tempDir, 'data-format-version'), '2', 'utf-8');
       await runMigrations(config, encryptedStorage, inconclusiveResolver);
       return JSON.parse(encryptedStorage.readFile(config.credentialStorePath)!) as {
         credentials: Record<string, unknown>;
@@ -463,10 +496,10 @@ describe('migrations', () => {
       };
     }
 
-    it('moves a token-less default-account OAuth client into preparations', async () => {
+    it('moves a token-less OAuth client (a prepared placeholder) into preparations', async () => {
       const preparedClient = { objectType: 'oauth', clientId: 'cid', clientSecret: 'csecret' };
 
-      const store = await runPreparationsMigrationOn({ 'google-gmail': { '': preparedClient } });
+      const store = await runMigrationOn({ 'google-gmail': preparedClient });
 
       expect(store.credentials).not.toHaveProperty('google-gmail');
       expect(store.preparations['google-gmail']).toEqual(preparedClient);
@@ -481,11 +514,9 @@ describe('migrations', () => {
         refreshToken: 'refresh-token',
       };
 
-      const store = await runPreparationsMigrationOn({
-        'google-docs': { 'user@example.com': fullCredentials },
-      });
+      const store = await runMigrationOn({ 'google-docs': fullCredentials });
 
-      expect(store.credentials['google-docs']).toEqual({ 'user@example.com': fullCredentials });
+      expect(store.credentials['google-docs']).toEqual({ '': fullCredentials });
       expect(store.preparations['google-docs']).toEqual({
         objectType: 'oauth',
         clientId: 'cid',
@@ -493,49 +524,13 @@ describe('migrations', () => {
       });
     });
 
-    it("prefers the default account's client when deriving a preparation", async () => {
-      const defaultCredentials = {
-        objectType: 'oauth',
-        clientId: 'default-cid',
-        clientSecret: 'default-csecret',
-        accessToken: 'access-token',
-      };
-      const namedCredentials = {
-        objectType: 'oauth',
-        clientId: 'named-cid',
-        clientSecret: 'named-csecret',
-        accessToken: 'access-token',
-      };
-
-      const store = await runPreparationsMigrationOn({
-        'google-gmail': { 'user@example.com': namedCredentials, '': defaultCredentials },
-      });
-
-      expect(store.preparations['google-gmail']).toEqual({
-        objectType: 'oauth',
-        clientId: 'default-cid',
-        clientSecret: 'default-csecret',
-      });
-    });
-
     it('creates no preparation for non-OAuth credentials', async () => {
       const slackCredentials = { objectType: 'slack', token: 't', dCookie: 'd' };
 
-      const store = await runPreparationsMigrationOn({ slack: { '': slackCredentials } });
+      const store = await runMigrationOn({ slack: slackCredentials });
 
       expect(store.credentials.slack).toEqual({ '': slackCredentials });
       expect(store.preparations).toEqual({});
-    });
-
-    it('keeps a token-less OAuth client stored under a named account as credentials', async () => {
-      const namedClient = { objectType: 'oauth', clientId: 'cid', clientSecret: 'csecret' };
-
-      const store = await runPreparationsMigrationOn({
-        'notion-mcp': { 'user@workspace': namedClient },
-      });
-
-      expect(store.credentials['notion-mcp']).toEqual({ 'user@workspace': namedClient });
-      expect(store.preparations['notion-mcp']).toEqual(namedClient);
     });
   });
 });

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -10,13 +10,33 @@ import {
   readDataFormatVersion,
   LATEST_VERSION,
   MigrationError,
+  type CredentialResolver,
 } from '../src/migrations.js';
+import { ApiCredentialStatus } from '../src/apiCredentials/base.js';
+import type { CredentialCheck } from '../src/services/core/base.js';
 
 function createTestConfig(directory: string): Config {
   return new Config((name) => {
     if (name === 'LATCHKEY_DIRECTORY') return directory;
     return undefined;
   });
+}
+
+/**
+ * Resolver that never hits the network. It reports every credential as
+ * inconclusive, which makes the accounts migration keep each service under the
+ * default account (the pre-network behaviour these tests were written for).
+ */
+const inconclusiveResolver: CredentialResolver = () =>
+  Promise.resolve({ status: ApiCredentialStatus.Unknown, account: null });
+
+/**
+ * Build a resolver from a fixed map of service name to credential-check result,
+ * defaulting to inconclusive for anything not listed.
+ */
+function resolverFromMap(results: Record<string, CredentialCheck>): CredentialResolver {
+  return (serviceName) =>
+    Promise.resolve(results[serviceName] ?? { status: ApiCredentialStatus.Unknown, account: null });
 }
 
 describe('migrations', () => {
@@ -63,32 +83,32 @@ describe('migrations', () => {
   });
 
   describe('runMigrations', () => {
-    it('should skip migrations on first installation (no directory)', () => {
+    it('should skip migrations on first installation (no directory)', async () => {
       const freshConfig = createTestConfig(join(tempDir, 'nonexistent'));
-      runMigrations(freshConfig, encryptedStorage);
+      await runMigrations(freshConfig, encryptedStorage, inconclusiveResolver);
       // Should not throw and should not create any files
       expect(existsSync(join(tempDir, 'nonexistent', 'data-format-version'))).toBe(false);
     });
 
-    it('should skip migrations on first installation (directory exists but no credentials)', () => {
+    it('should skip migrations on first installation (directory exists but no credentials)', async () => {
       // tempDir exists but has no credentials file
-      runMigrations(config, encryptedStorage);
+      await runMigrations(config, encryptedStorage, inconclusiveResolver);
       expect(existsSync(join(tempDir, 'data-format-version'))).toBe(false);
     });
 
-    it('should run migrations when credentials exist and version is 0', () => {
+    it('should run migrations when credentials exist and version is 0', async () => {
       // Create a credentials store with no "google" entry
       encryptedStorage.writeFile(
         config.credentialStorePath,
         JSON.stringify({ slack: { objectType: 'slack', token: 't', dCookie: 'd' } })
       );
 
-      runMigrations(config, encryptedStorage);
+      await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       expect(readDataFormatVersion(config)).toBe(LATEST_VERSION);
     });
 
-    it('should not run migrations when already at latest version', () => {
+    it('should not run migrations when already at latest version', async () => {
       encryptedStorage.writeFile(
         config.credentialStorePath,
         JSON.stringify({ slack: { objectType: 'slack', token: 't', dCookie: 'd' } })
@@ -96,25 +116,25 @@ describe('migrations', () => {
       writeFileSync(join(tempDir, 'data-format-version'), String(LATEST_VERSION), 'utf-8');
 
       // Should not throw
-      runMigrations(config, encryptedStorage);
+      await runMigrations(config, encryptedStorage, inconclusiveResolver);
       expect(readDataFormatVersion(config)).toBe(LATEST_VERSION);
     });
 
-    it('should throw when version is newer than latest', () => {
+    it('should throw when version is newer than latest', async () => {
       encryptedStorage.writeFile(
         config.credentialStorePath,
         JSON.stringify({ slack: { objectType: 'slack', token: 't', dCookie: 'd' } })
       );
       writeFileSync(join(tempDir, 'data-format-version'), String(LATEST_VERSION + 1), 'utf-8');
 
-      expect(() => {
-        runMigrations(config, encryptedStorage);
-      }).toThrow(MigrationError);
+      await expect(runMigrations(config, encryptedStorage, inconclusiveResolver)).rejects.toThrow(
+        MigrationError
+      );
     });
   });
 
   describe('migration 1: split google credentials', () => {
-    it('should replace "google" with individual service entries', () => {
+    it('should replace "google" with individual service entries', async () => {
       const googleCredentials = {
         objectType: 'oauth',
         clientId: 'test-client-id',
@@ -128,7 +148,7 @@ describe('migrations', () => {
         JSON.stringify({ google: googleCredentials })
       );
 
-      runMigrations(config, encryptedStorage);
+      await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
       const store = JSON.parse(content) as Record<string, unknown>;
@@ -147,7 +167,7 @@ describe('migrations', () => {
       expect(store).not.toHaveProperty('google-directions');
     });
 
-    it('should not overwrite existing individual service credentials', () => {
+    it('should not overwrite existing individual service credentials', async () => {
       const googleCredentials = {
         objectType: 'oauth',
         clientId: 'old-client',
@@ -169,7 +189,7 @@ describe('migrations', () => {
         })
       );
 
-      runMigrations(config, encryptedStorage);
+      await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
       const store = JSON.parse(content) as Record<string, unknown>;
@@ -178,7 +198,7 @@ describe('migrations', () => {
       expect(store['google-gmail']).toEqual({ '': googleCredentials });
     });
 
-    it('should preserve non-google credentials', () => {
+    it('should preserve non-google credentials', async () => {
       const slackCredentials = { objectType: 'slack', token: 't', dCookie: 'd' };
       const googleCredentials = {
         objectType: 'oauth',
@@ -194,7 +214,7 @@ describe('migrations', () => {
         })
       );
 
-      runMigrations(config, encryptedStorage);
+      await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
       const store = JSON.parse(content) as Record<string, unknown>;
@@ -202,7 +222,7 @@ describe('migrations', () => {
       expect(store.slack).toEqual({ '': slackCredentials });
     });
 
-    it('should be a no-op when there is no "google" entry', () => {
+    it('should be a no-op when there is no "google" entry', async () => {
       const slackCredentials = { objectType: 'slack', token: 't', dCookie: 'd' };
 
       encryptedStorage.writeFile(
@@ -210,7 +230,7 @@ describe('migrations', () => {
         JSON.stringify({ slack: slackCredentials })
       );
 
-      runMigrations(config, encryptedStorage);
+      await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
       const store = JSON.parse(content) as Record<string, unknown>;
@@ -219,13 +239,13 @@ describe('migrations', () => {
       expect(Object.keys(store)).toEqual(['slack']);
     });
 
-    it('should update the version file after migration', () => {
+    it('should update the version file after migration', async () => {
       encryptedStorage.writeFile(
         config.credentialStorePath,
         JSON.stringify({ google: { objectType: 'oauth', clientId: 'c', clientSecret: 's' } })
       );
 
-      runMigrations(config, encryptedStorage);
+      await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const versionContent = readFileSync(join(tempDir, 'data-format-version'), 'utf-8');
       expect(versionContent).toBe(String(LATEST_VERSION));
@@ -233,7 +253,7 @@ describe('migrations', () => {
   });
 
   describe('migration 2: introduce accounts', () => {
-    it('should wrap each service credential under the default account', () => {
+    it('should wrap each service credential under the default account', async () => {
       const slackCredentials = { objectType: 'slack', token: 't', dCookie: 'd' };
       const discordCredentials = { objectType: 'authorizationBare', token: 'discord' };
 
@@ -242,7 +262,7 @@ describe('migrations', () => {
         JSON.stringify({ slack: slackCredentials, discord: discordCredentials })
       );
 
-      runMigrations(config, encryptedStorage);
+      await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
       const store = JSON.parse(content) as Record<string, unknown>;
@@ -251,13 +271,104 @@ describe('migrations', () => {
       expect(store.discord).toEqual({ '': discordCredentials });
     });
 
-    it('should produce an empty store for an empty store', () => {
+    it('should produce an empty store for an empty store', async () => {
       encryptedStorage.writeFile(config.credentialStorePath, JSON.stringify({}));
 
-      runMigrations(config, encryptedStorage);
+      await runMigrations(config, encryptedStorage, inconclusiveResolver);
 
       const content = encryptedStorage.readFile(config.credentialStorePath)!;
       expect(JSON.parse(content)).toEqual({});
+    });
+
+    it('should key valid credentials by their resolved account', async () => {
+      const slackCredentials = { objectType: 'slack', token: 't', dCookie: 'd' };
+
+      encryptedStorage.writeFile(
+        config.credentialStorePath,
+        JSON.stringify({ slack: slackCredentials })
+      );
+
+      await runMigrations(
+        config,
+        encryptedStorage,
+        resolverFromMap({
+          slack: { status: ApiCredentialStatus.Valid, account: 'user@example.com' },
+        })
+      );
+
+      const store = JSON.parse(
+        encryptedStorage.readFile(config.credentialStorePath)!
+      ) as Record<string, unknown>;
+
+      expect(store.slack).toEqual({ 'user@example.com': slackCredentials });
+    });
+
+    it('should keep valid credentials under the default account when the account is unknown', async () => {
+      const slackCredentials = { objectType: 'slack', token: 't', dCookie: 'd' };
+
+      encryptedStorage.writeFile(
+        config.credentialStorePath,
+        JSON.stringify({ slack: slackCredentials })
+      );
+
+      await runMigrations(
+        config,
+        encryptedStorage,
+        resolverFromMap({ slack: { status: ApiCredentialStatus.Valid, account: null } })
+      );
+
+      const store = JSON.parse(
+        encryptedStorage.readFile(config.credentialStorePath)!
+      ) as Record<string, unknown>;
+
+      expect(store.slack).toEqual({ '': slackCredentials });
+    });
+
+    it('should drop invalid credentials', async () => {
+      const slackCredentials = { objectType: 'slack', token: 't', dCookie: 'd' };
+      const discordCredentials = { objectType: 'authorizationBare', token: 'discord' };
+
+      encryptedStorage.writeFile(
+        config.credentialStorePath,
+        JSON.stringify({ slack: slackCredentials, discord: discordCredentials })
+      );
+
+      await runMigrations(
+        config,
+        encryptedStorage,
+        resolverFromMap({
+          slack: { status: ApiCredentialStatus.Invalid, account: null },
+          discord: { status: ApiCredentialStatus.Valid, account: 'me#1234' },
+        })
+      );
+
+      const store = JSON.parse(
+        encryptedStorage.readFile(config.credentialStorePath)!
+      ) as Record<string, unknown>;
+
+      expect(store).not.toHaveProperty('slack');
+      expect(store.discord).toEqual({ 'me#1234': discordCredentials });
+    });
+
+    it('should leave credentials under the default account on inconclusive checks', async () => {
+      const slackCredentials = { objectType: 'slack', token: 't', dCookie: 'd' };
+
+      encryptedStorage.writeFile(
+        config.credentialStorePath,
+        JSON.stringify({ slack: slackCredentials })
+      );
+
+      await runMigrations(
+        config,
+        encryptedStorage,
+        resolverFromMap({ slack: { status: ApiCredentialStatus.Unknown, account: null } })
+      );
+
+      const store = JSON.parse(
+        encryptedStorage.readFile(config.credentialStorePath)!
+      ) as Record<string, unknown>;
+
+      expect(store.slack).toEqual({ '': slackCredentials });
     });
   });
 });

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -11,9 +11,9 @@ import {
   LATEST_VERSION,
   MigrationError,
   type CredentialResolver,
+  type ResolvedCredential,
 } from '../src/migrations.js';
 import { ApiCredentialStatus } from '../src/apiCredentials/base.js';
-import type { CredentialCheck } from '../src/services/core/base.js';
 import {
   setCapturingSubprocessRunner,
   resetCapturingSubprocessRunner,
@@ -36,10 +36,10 @@ const inconclusiveResolver: CredentialResolver = () =>
   Promise.resolve({ status: ApiCredentialStatus.Unknown, account: null });
 
 /**
- * Build a resolver from a fixed map of service name to credential-check result,
+ * Build a resolver from a fixed map of service name to resolved credential,
  * defaulting to inconclusive for anything not listed.
  */
-function resolverFromMap(results: Record<string, CredentialCheck>): CredentialResolver {
+function resolverFromMap(results: Record<string, ResolvedCredential>): CredentialResolver {
   return (serviceName) =>
     Promise.resolve(results[serviceName] ?? { status: ApiCredentialStatus.Unknown, account: null });
 }
@@ -415,22 +415,24 @@ describe('migrations', () => {
     });
 
     it('should key google credentials by the account from the userinfo endpoint', async () => {
-      // Google services learn both validity and the account from their
-      // credential check against the OpenID userinfo endpoint. This exercises
-      // the real registry resolver (no injected resolver) to ensure that path
-      // runs during the migration. The curl runner is stubbed so nothing hits
-      // the network; the check appends the HTTP status code as the final line
-      // (via `-w '\n%{http_code}'`).
+      // Google services learn validity from their credential check and the
+      // account from getAccount(), both against the OpenID userinfo endpoint.
+      // This exercises the real registry resolver (no injected resolver) to
+      // ensure that path runs during the migration. The curl runner is stubbed
+      // so nothing hits the network; only the check appends the HTTP status
+      // code as the final line (via `-w '\n%{http_code}'`), the account
+      // request receives the bare body.
       setCapturingSubprocessRunner((args: readonly string[]): CurlResult => {
+        const isCredentialCheck = args.includes('-w');
         const joined = args.join(' ');
-        if (joined.includes('openidconnect.googleapis.com')) {
-          return {
-            returncode: 0,
-            stdout: `${JSON.stringify({ email: 'alice@example.com' })}\n200`,
-            stderr: '',
-          };
-        }
-        return { returncode: 0, stdout: '{}\n200', stderr: '' };
+        const body = joined.includes('openidconnect.googleapis.com')
+          ? JSON.stringify({ email: 'alice@example.com' })
+          : '{}';
+        return {
+          returncode: 0,
+          stdout: isCredentialCheck ? `${body}\n200` : body,
+          stderr: '',
+        };
       });
 
       const gmailCredentials = {

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -14,6 +14,11 @@ import {
 } from '../src/migrations.js';
 import { ApiCredentialStatus } from '../src/apiCredentials/base.js';
 import type { CredentialCheck } from '../src/services/core/base.js';
+import {
+  setCapturingSubprocessRunner,
+  resetCapturingSubprocessRunner,
+  type CurlResult,
+} from '../src/curl.js';
 
 function createTestConfig(directory: string): Config {
   return new Config((name) => {
@@ -53,6 +58,7 @@ describe('migrations', () => {
   });
 
   afterEach(() => {
+    resetCapturingSubprocessRunner();
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -348,6 +354,50 @@ describe('migrations', () => {
 
       expect(store).not.toHaveProperty('slack');
       expect(store.discord).toEqual({ 'me#1234': discordCredentials });
+    });
+
+    it('should key google credentials by the account from determineAccount()', async () => {
+      // Google services validate credentials via a check endpoint that carries
+      // no identity and learn the account from a separate userinfo endpoint by
+      // overriding determineAccount(). This exercises the real registry
+      // resolver (no injected resolver) to ensure that fallback runs during the
+      // migration. The curl runner is stubbed so nothing hits the network.
+      setCapturingSubprocessRunner((args: readonly string[]): CurlResult => {
+        const joined = args.join(' ');
+        if (joined.includes('openidconnect.googleapis.com')) {
+          // determineAccount() reads the signed-in e-mail from userinfo.
+          return {
+            returncode: 0,
+            stdout: JSON.stringify({ email: 'alice@example.com' }),
+            stderr: '',
+          };
+        }
+        // Credential check endpoint: valid (HTTP 200), but the body carries no
+        // identity, so checkApiCredentials() reports a null account.
+        return { returncode: 0, stdout: '{}\n200', stderr: '' };
+      });
+
+      const gmailCredentials = {
+        objectType: 'oauth',
+        clientId: 'client',
+        clientSecret: 'secret',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      };
+
+      encryptedStorage.writeFile(
+        config.credentialStorePath,
+        JSON.stringify({ 'google-gmail': gmailCredentials })
+      );
+
+      // Note: no resolver is injected, so the default registry resolver runs.
+      await runMigrations(config, encryptedStorage);
+
+      const store = JSON.parse(
+        encryptedStorage.readFile(config.credentialStorePath)!
+      ) as Record<string, unknown>;
+
+      expect(store['google-gmail']).toEqual({ 'alice@example.com': gmailCredentials });
     });
 
     it('should leave credentials under the default account on inconclusive checks', async () => {

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -325,9 +325,9 @@ describe('migrations', () => {
         })
       );
 
-      const store = JSON.parse(
-        encryptedStorage.readFile(config.credentialStorePath)!
-      ) as { credentials: Record<string, unknown> };
+      const store = JSON.parse(encryptedStorage.readFile(config.credentialStorePath)!) as {
+        credentials: Record<string, unknown>;
+      };
 
       expect(store.credentials.slack).toEqual({ 'user@example.com': slackCredentials });
     });
@@ -346,9 +346,9 @@ describe('migrations', () => {
         resolverFromMap({ slack: { status: ApiCredentialStatus.Valid, account: null } })
       );
 
-      const store = JSON.parse(
-        encryptedStorage.readFile(config.credentialStorePath)!
-      ) as { credentials: Record<string, unknown> };
+      const store = JSON.parse(encryptedStorage.readFile(config.credentialStorePath)!) as {
+        credentials: Record<string, unknown>;
+      };
 
       expect(store.credentials.slack).toEqual({ '': slackCredentials });
     });
@@ -375,9 +375,10 @@ describe('migrations', () => {
         })
       );
 
-      const store = JSON.parse(
-        encryptedStorage.readFile(config.credentialStorePath)!
-      ) as { credentials: Record<string, unknown>; preparations: Record<string, unknown> };
+      const store = JSON.parse(encryptedStorage.readFile(config.credentialStorePath)!) as {
+        credentials: Record<string, unknown>;
+        preparations: Record<string, unknown>;
+      };
 
       expect(store.credentials).not.toHaveProperty('google-gmail');
       expect(store.preparations['google-gmail']).toEqual({
@@ -405,9 +406,9 @@ describe('migrations', () => {
         })
       );
 
-      const store = JSON.parse(
-        encryptedStorage.readFile(config.credentialStorePath)!
-      ) as { credentials: Record<string, unknown> };
+      const store = JSON.parse(encryptedStorage.readFile(config.credentialStorePath)!) as {
+        credentials: Record<string, unknown>;
+      };
 
       expect(store.credentials).not.toHaveProperty('slack');
       expect(store.credentials.discord).toEqual({ 'me#1234': discordCredentials });
@@ -448,9 +449,10 @@ describe('migrations', () => {
       // Note: no resolver is injected, so the default registry resolver runs.
       await runMigrations(config, encryptedStorage);
 
-      const store = JSON.parse(
-        encryptedStorage.readFile(config.credentialStorePath)!
-      ) as { credentials: Record<string, unknown>; preparations: Record<string, unknown> };
+      const store = JSON.parse(encryptedStorage.readFile(config.credentialStorePath)!) as {
+        credentials: Record<string, unknown>;
+        preparations: Record<string, unknown>;
+      };
 
       expect(store.credentials['google-gmail']).toEqual({
         'alice@example.com': gmailCredentials,
@@ -476,9 +478,9 @@ describe('migrations', () => {
         resolverFromMap({ slack: { status: ApiCredentialStatus.Unknown, account: null } })
       );
 
-      const store = JSON.parse(
-        encryptedStorage.readFile(config.credentialStorePath)!
-      ) as { credentials: Record<string, unknown> };
+      const store = JSON.parse(encryptedStorage.readFile(config.credentialStorePath)!) as {
+        credentials: Record<string, unknown>;
+      };
 
       expect(store.credentials.slack).toEqual({ '': slackCredentials });
     });

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -378,24 +378,22 @@ describe('migrations', () => {
       expect(store.credentials.discord).toEqual({ 'me#1234': discordCredentials });
     });
 
-    it('should key google credentials by the account from determineAccount()', async () => {
-      // Google services validate credentials via a check endpoint that carries
-      // no identity and learn the account from a separate userinfo endpoint by
-      // overriding determineAccount(). This exercises the real registry
-      // resolver (no injected resolver) to ensure that fallback runs during the
-      // migration. The curl runner is stubbed so nothing hits the network.
+    it('should key google credentials by the account from the userinfo endpoint', async () => {
+      // Google services learn both validity and the account from their
+      // credential check against the OpenID userinfo endpoint. This exercises
+      // the real registry resolver (no injected resolver) to ensure that path
+      // runs during the migration. The curl runner is stubbed so nothing hits
+      // the network; the check appends the HTTP status code as the final line
+      // (via `-w '\n%{http_code}'`).
       setCapturingSubprocessRunner((args: readonly string[]): CurlResult => {
         const joined = args.join(' ');
         if (joined.includes('openidconnect.googleapis.com')) {
-          // determineAccount() reads the signed-in e-mail from userinfo.
           return {
             returncode: 0,
-            stdout: JSON.stringify({ email: 'alice@example.com' }),
+            stdout: `${JSON.stringify({ email: 'alice@example.com' })}\n200`,
             stderr: '',
           };
         }
-        // Credential check endpoint: valid (HTTP 200), but the body carries no
-        // identity, so checkApiCredentials() reports a null account.
         return { returncode: 0, stdout: '{}\n200', stderr: '' };
       });
 

--- a/tests/mockService.ts
+++ b/tests/mockService.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared Service test double.
+ *
+ * Service has protected members (the credential-check hooks), so plain object
+ * literals can no longer satisfy the Service type; fakes must subclass it.
+ * MockService exposes every configurable member as a public, writable field
+ * with Slack-flavored defaults matching the historical inline fakes.
+ */
+
+import { vi } from 'vitest';
+import { ApiCredentialStatus, type ApiCredentials } from '../src/apiCredentials/base.js';
+import { SlackApiCredentials } from '../src/services/slack.js';
+import { NoCurlCredentialsNotSupportedError, Service } from '../src/services/core/base.js';
+
+export class MockService extends Service {
+  name = 'slack';
+  displayName = 'Slack';
+  baseApiUrls: readonly (string | RegExp)[] = ['https://slack.com/api/'];
+  loginUrl = 'https://slack.com/signin';
+  info = 'Test info for Slack service.';
+  credentialCheckCurlArguments: readonly string[] = ['https://slack.com/api/auth.test'];
+
+  override checkApiCredentials: Service['checkApiCredentials'] = vi
+    .fn()
+    .mockResolvedValue({ status: ApiCredentialStatus.Valid, account: null });
+
+  setCredentialsExample(serviceName: string): string {
+    return `latchkey auth set ${serviceName} -H "Authorization: Bearer xoxb-your-token"`;
+  }
+
+  override getCredentialsNoCurl(_arguments: readonly string[]): ApiCredentials {
+    throw new NoCurlCredentialsNotSupportedError(this.name);
+  }
+
+  override getSession: Service['getSession'] = vi.fn().mockReturnValue({
+    login: vi.fn().mockResolvedValue({
+      credentials: new SlackApiCredentials('xoxc-test-token', 'test-cookie'),
+      account: '',
+    }),
+  });
+}
+
+export function createMockService(overrides: Partial<MockService> = {}): MockService {
+  return Object.assign(new MockService(), overrides);
+}

--- a/tests/mockService.ts
+++ b/tests/mockService.ts
@@ -22,7 +22,9 @@ export class MockService extends Service {
 
   override checkApiCredentials: Service['checkApiCredentials'] = vi
     .fn()
-    .mockResolvedValue({ status: ApiCredentialStatus.Valid, account: null });
+    .mockResolvedValue(ApiCredentialStatus.Valid);
+
+  override getAccount: Service['getAccount'] = vi.fn().mockResolvedValue(null);
 
   setCredentialsExample(serviceName: string): string {
     return `latchkey auth set ${serviceName} -H "Authorization: Bearer xoxb-your-token"`;

--- a/tests/serviceAccounts.test.ts
+++ b/tests/serviceAccounts.test.ts
@@ -13,10 +13,7 @@ import {
   AuthorizationBearer,
   OAuthCredentials,
 } from '../src/apiCredentials/base.js';
-import {
-  resetCapturingSubprocessRunner,
-  setCapturingSubprocessRunner,
-} from '../src/curl.js';
+import { resetCapturingSubprocessRunner, setCapturingSubprocessRunner } from '../src/curl.js';
 import { RegisteredService } from '../src/services/core/registered.js';
 import { AWS } from '../src/services/aws.js';
 import { CALENDLY } from '../src/services/calendly.js';
@@ -109,25 +106,19 @@ describe('account parsing from the credential check', () => {
   });
 
   it('discord prefers the e-mail over the username', async () => {
-    mockCurlOutput(
-      withStatusLine('{"username":"gamer","email":"gamer@example.com","id":"1234"}')
-    );
+    mockCurlOutput(withStatusLine('{"username":"gamer","email":"gamer@example.com","id":"1234"}'));
     const result = await DISCORD.checkApiCredentials(BEARER);
     expect(result.account).toBe('gamer@example.com');
   });
 
   it('dropbox uses the e-mail from get_current_account', async () => {
-    mockCurlOutput(
-      withStatusLine('{"account_id":"dbid:abc","email":"user@example.com"}')
-    );
+    mockCurlOutput(withStatusLine('{"account_id":"dbid:abc","email":"user@example.com"}'));
     const result = await DROPBOX.checkApiCredentials(BEARER);
     expect(result.account).toBe('user@example.com');
   });
 
   it('linear uses the viewer e-mail', async () => {
-    mockCurlOutput(
-      withStatusLine('{"data":{"viewer":{"id":"uuid-1","email":"dev@example.com"}}}')
-    );
+    mockCurlOutput(withStatusLine('{"data":{"viewer":{"id":"uuid-1","email":"dev@example.com"}}}'));
     const result = await LINEAR.checkApiCredentials(BEARER);
     expect(result.account).toBe('dev@example.com');
   });
@@ -141,9 +132,7 @@ describe('account parsing from the credential check', () => {
   });
 
   it('notion combines the bot name and workspace', async () => {
-    mockCurlOutput(
-      withStatusLine('{"name":"My Integration","bot":{"workspace_name":"Acme Inc"}}')
-    );
+    mockCurlOutput(withStatusLine('{"name":"My Integration","bot":{"workspace_name":"Acme Inc"}}'));
     const result = await NOTION.checkApiCredentials(BEARER);
     expect(result.account).toBe('My Integration@Acme Inc');
   });
@@ -177,9 +166,7 @@ describe('slack credential check', () => {
 
   it('combines the user and the workspace subdomain', async () => {
     mockCurlOutput(
-      withStatusLine(
-        '{"ok":true,"url":"https://acme.slack.com/","team":"Acme Inc","user":"jane"}'
-      )
+      withStatusLine('{"ok":true,"url":"https://acme.slack.com/","team":"Acme Inc","user":"jane"}')
     );
     const result = await SLACK.checkApiCredentials(BEARER);
     expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: 'jane@acme' });

--- a/tests/serviceAccounts.test.ts
+++ b/tests/serviceAccounts.test.ts
@@ -1,10 +1,12 @@
 /**
- * Tests for account determination via the credential check.
+ * Tests for the credential check and for account determination.
  *
  * The credential check runs a single curl call whose output is the response
  * body followed by the HTTP status code on the final line (produced by
- * `-w '\n%{http_code}'`). These tests mock the capturing subprocess runner to
- * feed service implementations recorded response bodies.
+ * `-w '\n%{http_code}'`). Account determination (`getAccount`) runs its own
+ * curl call against an identity-revealing endpoint and parses the account
+ * from the raw response body. These tests mock the capturing subprocess
+ * runner to feed service implementations recorded response bodies.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
@@ -47,181 +49,196 @@ afterEach(() => {
 });
 
 describe('base credential check', () => {
-  it('reports valid credentials without an account when the body carries no identity', async () => {
+  it('reports valid credentials on a 200 response', async () => {
     mockCurlOutput(withStatusLine('{}'));
-    const result = await GITHUB.checkApiCredentials(BEARER);
-    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: null });
+    const status = await GITHUB.checkApiCredentials(BEARER);
+    expect(status).toBe(ApiCredentialStatus.Valid);
   });
 
   it('reports invalid credentials on non-200 responses', async () => {
     mockCurlOutput(withStatusLine('{"message":"Bad credentials"}', '401'));
-    const result = await GITHUB.checkApiCredentials(BEARER);
-    expect(result).toEqual({ status: ApiCredentialStatus.Invalid, account: null });
+    const status = await GITHUB.checkApiCredentials(BEARER);
+    expect(status).toBe(ApiCredentialStatus.Invalid);
   });
 
   it('reports missing credentials when injection fails', async () => {
     const tokenlessCredentials = new OAuthCredentials('client-id', 'client-secret');
-    const result = await GITHUB.checkApiCredentials(tokenlessCredentials);
-    expect(result).toEqual({ status: ApiCredentialStatus.Missing, account: null });
-  });
-
-  it('never crashes on a malformed body', async () => {
-    mockCurlOutput(withStatusLine('this is not JSON'));
-    const result = await GITHUB.checkApiCredentials(BEARER);
-    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: null });
+    const status = await GITHUB.checkApiCredentials(tokenlessCredentials);
+    expect(status).toBe(ApiCredentialStatus.Missing);
   });
 
   it('reports unknown status for registered services without a request', async () => {
     const registered = new RegisteredService('my-service', 'https://example.com/api/');
-    const result = await registered.checkApiCredentials();
-    expect(result).toEqual({ status: ApiCredentialStatus.Unknown, account: null });
+    const status = await registered.checkApiCredentials();
+    expect(status).toBe(ApiCredentialStatus.Unknown);
   });
 });
 
-describe('account parsing from the credential check', () => {
+describe('base account determination', () => {
+  it('returns null when the body carries no identity', async () => {
+    mockCurlOutput('{}');
+    const account = await GITHUB.getAccount(BEARER);
+    expect(account).toBeNull();
+  });
+
+  it('returns null when credential injection fails', async () => {
+    const tokenlessCredentials = new OAuthCredentials('client-id', 'client-secret');
+    const account = await GITHUB.getAccount(tokenlessCredentials);
+    expect(account).toBeNull();
+  });
+
+  it('never crashes on a malformed body', async () => {
+    mockCurlOutput('this is not JSON');
+    const account = await GITHUB.getAccount(BEARER);
+    expect(account).toBeNull();
+  });
+
+  it('returns null for registered services without a request', async () => {
+    const registered = new RegisteredService('my-service', 'https://example.com/api/');
+    const account = await registered.getAccount(BEARER);
+    expect(account).toBeNull();
+  });
+});
+
+describe('account parsing', () => {
   it('github uses the login handle', async () => {
-    mockCurlOutput(withStatusLine('{"login":"octocat","email":null}'));
-    const result = await GITHUB.checkApiCredentials(BEARER);
-    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: 'octocat' });
+    mockCurlOutput('{"login":"octocat","email":null}');
+    const account = await GITHUB.getAccount(BEARER);
+    expect(account).toBe('octocat');
   });
 
   it('gitlab uses the e-mail', async () => {
-    mockCurlOutput(withStatusLine('{"username":"jane","email":"jane@example.com"}'));
-    const result = await GITLAB.checkApiCredentials(BEARER);
-    expect(result.account).toBe('jane@example.com');
+    mockCurlOutput('{"username":"jane","email":"jane@example.com"}');
+    const account = await GITLAB.getAccount(BEARER);
+    expect(account).toBe('jane@example.com');
   });
 
   it('calendly uses the e-mail from the resource', async () => {
-    mockCurlOutput(
-      withStatusLine('{"resource":{"email":"host@example.com","name":"Host Person"}}')
-    );
-    const result = await CALENDLY.checkApiCredentials(BEARER);
-    expect(result.account).toBe('host@example.com');
+    mockCurlOutput('{"resource":{"email":"host@example.com","name":"Host Person"}}');
+    const account = await CALENDLY.getAccount(BEARER);
+    expect(account).toBe('host@example.com');
   });
 
   it('figma uses the e-mail', async () => {
-    mockCurlOutput(withStatusLine('{"email":"designer@example.com","handle":"Designer"}'));
-    const result = await FIGMA.checkApiCredentials(BEARER);
-    expect(result.account).toBe('designer@example.com');
+    mockCurlOutput('{"email":"designer@example.com","handle":"Designer"}');
+    const account = await FIGMA.getAccount(BEARER);
+    expect(account).toBe('designer@example.com');
   });
 
   it('discord prefers the e-mail over the username', async () => {
-    mockCurlOutput(withStatusLine('{"username":"gamer","email":"gamer@example.com","id":"1234"}'));
-    const result = await DISCORD.checkApiCredentials(BEARER);
-    expect(result.account).toBe('gamer@example.com');
+    mockCurlOutput('{"username":"gamer","email":"gamer@example.com","id":"1234"}');
+    const account = await DISCORD.getAccount(BEARER);
+    expect(account).toBe('gamer@example.com');
   });
 
   it('dropbox uses the e-mail from get_current_account', async () => {
-    mockCurlOutput(withStatusLine('{"account_id":"dbid:abc","email":"user@example.com"}'));
-    const result = await DROPBOX.checkApiCredentials(BEARER);
-    expect(result.account).toBe('user@example.com');
+    mockCurlOutput('{"account_id":"dbid:abc","email":"user@example.com"}');
+    const account = await DROPBOX.getAccount(BEARER);
+    expect(account).toBe('user@example.com');
   });
 
   it('linear uses the viewer e-mail', async () => {
-    mockCurlOutput(withStatusLine('{"data":{"viewer":{"id":"uuid-1","email":"dev@example.com"}}}'));
-    const result = await LINEAR.checkApiCredentials(BEARER);
-    expect(result.account).toBe('dev@example.com');
+    mockCurlOutput('{"data":{"viewer":{"id":"uuid-1","email":"dev@example.com"}}}');
+    const account = await LINEAR.getAccount(BEARER);
+    expect(account).toBe('dev@example.com');
   });
 
   it('mailchimp uses the login e-mail', async () => {
-    mockCurlOutput(
-      withStatusLine('{"accountname":"Acme","login":{"email":"marketer@example.com"}}')
-    );
-    const result = await MAILCHIMP.checkApiCredentials(BEARER);
-    expect(result.account).toBe('marketer@example.com');
+    mockCurlOutput('{"accountname":"Acme","login":{"email":"marketer@example.com"}}');
+    const account = await MAILCHIMP.getAccount(BEARER);
+    expect(account).toBe('marketer@example.com');
   });
 
   it('notion combines the bot name and workspace', async () => {
-    mockCurlOutput(withStatusLine('{"name":"My Integration","bot":{"workspace_name":"Acme Inc"}}'));
-    const result = await NOTION.checkApiCredentials(BEARER);
-    expect(result.account).toBe('My Integration@Acme Inc');
+    mockCurlOutput('{"name":"My Integration","bot":{"workspace_name":"Acme Inc"}}');
+    const account = await NOTION.getAccount(BEARER);
+    expect(account).toBe('My Integration@Acme Inc');
   });
 
   it('telegram uses the bot username', async () => {
-    mockCurlOutput(withStatusLine('{"ok":true,"result":{"id":42,"username":"my_bot"}}'));
-    const result = await TELEGRAM.checkApiCredentials(BEARER);
-    expect(result.account).toBe('my_bot');
+    mockCurlOutput('{"ok":true,"result":{"id":42,"username":"my_bot"}}');
+    const account = await TELEGRAM.getAccount(BEARER);
+    expect(account).toBe('my_bot');
   });
 
   it('aws uses the caller ARN from the XML response', async () => {
     mockCurlOutput(
-      withStatusLine(
-        '<GetCallerIdentityResponse><GetCallerIdentityResult>' +
-          '<Arn>arn:aws:iam::123456789012:user/alice</Arn>' +
-          '<UserId>AIDAEXAMPLE</UserId><Account>123456789012</Account>' +
-          '</GetCallerIdentityResult></GetCallerIdentityResponse>'
-      )
+      '<GetCallerIdentityResponse><GetCallerIdentityResult>' +
+        '<Arn>arn:aws:iam::123456789012:user/alice</Arn>' +
+        '<UserId>AIDAEXAMPLE</UserId><Account>123456789012</Account>' +
+        '</GetCallerIdentityResult></GetCallerIdentityResponse>'
     );
-    const result = await AWS.checkApiCredentials(BEARER);
-    expect(result.account).toBe('arn:aws:iam::123456789012:user/alice');
+    const account = await AWS.getAccount(BEARER);
+    expect(account).toBe('arn:aws:iam::123456789012:user/alice');
   });
 });
 
-describe('slack credential check', () => {
+describe('slack', () => {
   it('treats ok:false as invalid even though the HTTP status is 200', async () => {
     mockCurlOutput(withStatusLine('{"ok":false,"error":"invalid_auth"}'));
-    const result = await SLACK.checkApiCredentials(BEARER);
-    expect(result).toEqual({ status: ApiCredentialStatus.Invalid, account: null });
+    const status = await SLACK.checkApiCredentials(BEARER);
+    expect(status).toBe(ApiCredentialStatus.Invalid);
+  });
+
+  it('treats ok:true as valid', async () => {
+    mockCurlOutput(withStatusLine('{"ok":true,"url":"https://acme.slack.com/","user":"jane"}'));
+    const status = await SLACK.checkApiCredentials(BEARER);
+    expect(status).toBe(ApiCredentialStatus.Valid);
   });
 
   it('combines the user and the workspace subdomain', async () => {
-    mockCurlOutput(
-      withStatusLine('{"ok":true,"url":"https://acme.slack.com/","team":"Acme Inc","user":"jane"}')
-    );
-    const result = await SLACK.checkApiCredentials(BEARER);
-    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: 'jane@acme' });
+    mockCurlOutput('{"ok":true,"url":"https://acme.slack.com/","team":"Acme Inc","user":"jane"}');
+    const account = await SLACK.getAccount(BEARER);
+    expect(account).toBe('jane@acme');
   });
 });
 
-describe('sentry credential check', () => {
+describe('sentry', () => {
   it('requires the user field for validity', async () => {
     mockCurlOutput(withStatusLine('{"user":null}'));
-    const result = await SENTRY.checkApiCredentials(BEARER);
-    expect(result).toEqual({ status: ApiCredentialStatus.Invalid, account: null });
+    const status = await SENTRY.checkApiCredentials(BEARER);
+    expect(status).toBe(ApiCredentialStatus.Invalid);
   });
 
-  it('uses the user e-mail', async () => {
-    mockCurlOutput(withStatusLine('{"user":{"email":"dev@example.com"}}'));
-    const result = await SENTRY.checkApiCredentials(BEARER);
-    expect(result).toEqual({
-      status: ApiCredentialStatus.Valid,
-      account: 'dev@example.com',
-    });
+  it('uses the user e-mail as the account', async () => {
+    mockCurlOutput('{"user":{"email":"dev@example.com"}}');
+    const account = await SENTRY.getAccount(BEARER);
+    expect(account).toBe('dev@example.com');
   });
 });
 
-describe('google credential check', () => {
-  it('google services check credentials against the OpenID userinfo endpoint', async () => {
+describe('google', () => {
+  it('google services determine the account via the OpenID userinfo endpoint', async () => {
     let requestedUrl: string | undefined;
     setCapturingSubprocessRunner((args) => {
       requestedUrl = args[args.length - 1];
       return {
         returncode: 0,
-        stdout: withStatusLine('{"email":"user@gmail.com","sub":"1"}'),
+        stdout: '{"email":"user@gmail.com","sub":"1"}',
         stderr: '',
       };
     });
     const credentials = new OAuthCredentials('client-id', 'client-secret', 'access-token');
-    const result = await GOOGLE_GMAIL.checkApiCredentials(credentials);
-    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: 'user@gmail.com' });
+    const account = await GOOGLE_GMAIL.getAccount(credentials);
+    expect(account).toBe('user@gmail.com');
     expect(requestedUrl).toBe('https://openidconnect.googleapis.com/v1/userinfo');
   });
 
   it('google services report token-less prepared credentials as missing', async () => {
     const prepared = new OAuthCredentials('client-id', 'client-secret');
-    const result = await GOOGLE_GMAIL.checkApiCredentials(prepared);
-    expect(result).toEqual({ status: ApiCredentialStatus.Missing, account: null });
+    const status = await GOOGLE_GMAIL.checkApiCredentials(prepared);
+    expect(status).toBe(ApiCredentialStatus.Missing);
   });
 
   it('google services report tokens rejected by userinfo as invalid', async () => {
     mockCurlOutput(withStatusLine('{"error":"invalid_token"}', '401'));
     const credentials = new OAuthCredentials('client-id', 'client-secret', 'access-token');
-    const result = await GOOGLE_GMAIL.checkApiCredentials(credentials);
-    expect(result).toEqual({ status: ApiCredentialStatus.Invalid, account: null });
+    const status = await GOOGLE_GMAIL.checkApiCredentials(credentials);
+    expect(status).toBe(ApiCredentialStatus.Invalid);
   });
 });
 
-describe('credential check via a separate account endpoint', () => {
+describe('account determination via a separate endpoint', () => {
   it('stripe asks the account endpoint and prefers the e-mail', async () => {
     let requestedUrl: string | undefined;
     setCapturingSubprocessRunner((args) => {
@@ -232,40 +249,26 @@ describe('credential check via a separate account endpoint', () => {
         stderr: '',
       };
     });
-    const result = await STRIPE.checkApiCredentials(BEARER);
-    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: 'owner@example.com' });
+    const account = await STRIPE.getAccount(BEARER);
+    expect(account).toBe('owner@example.com');
     expect(requestedUrl).toBe('https://api.stripe.com/v1/account');
   });
 
-  it('stripe falls back to the balance check when the key may not read the account', async () => {
-    setCapturingSubprocessRunner((args) => {
-      const url = args[args.length - 1] ?? '';
-      if (url.endsWith('/v1/account')) {
-        return {
-          returncode: 0,
-          stdout: '{"error":{"type":"invalid_request_error"}}',
-          stderr: '',
-        };
-      }
-      return { returncode: 0, stdout: withStatusLine('{"balance": []}'), stderr: '' };
-    });
-    const result = await STRIPE.checkApiCredentials(BEARER);
-    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: null });
+  it('stripe leaves the account undetermined when the key may not read it', async () => {
+    mockCurlOutput('{"error":{"type":"invalid_request_error"}}');
+    const account = await STRIPE.getAccount(BEARER);
+    expect(account).toBeNull();
   });
 
-  it('zoom falls back to the user-list check for server-to-server tokens', async () => {
-    setCapturingSubprocessRunner((args) => {
-      const url = args[args.length - 1] ?? '';
-      if (url.endsWith('/users/me')) {
-        return {
-          returncode: 0,
-          stdout: '{"code":124,"message":"Invalid access token."}',
-          stderr: '',
-        };
-      }
-      return { returncode: 0, stdout: withStatusLine('{"users":[]}'), stderr: '' };
-    });
-    const result = await ZOOM.checkApiCredentials(BEARER);
-    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: null });
+  it('zoom leaves the account undetermined for server-to-server tokens', async () => {
+    mockCurlOutput('{"code":124,"message":"Invalid access token."}');
+    const account = await ZOOM.getAccount(BEARER);
+    expect(account).toBeNull();
+  });
+
+  it('zoom uses the e-mail from /users/me', async () => {
+    mockCurlOutput('{"id":"abc","email":"host@example.com"}');
+    const account = await ZOOM.getAccount(BEARER);
+    expect(account).toBe('host@example.com');
   });
 });

--- a/tests/serviceAccounts.test.ts
+++ b/tests/serviceAccounts.test.ts
@@ -28,6 +28,7 @@ import { GOOGLE_GMAIL } from '../src/services/google/gmail.js';
 import { LINEAR } from '../src/services/linear.js';
 import { MAILCHIMP } from '../src/services/mailchimp.js';
 import { NOTION } from '../src/services/notion.js';
+import { NOTION_MCP } from '../src/services/notion-mcp.js';
 import { SENTRY } from '../src/services/sentry.js';
 import { SLACK } from '../src/services/slack.js';
 import { STRIPE } from '../src/services/stripe.js';
@@ -270,5 +271,53 @@ describe('account determination via a separate endpoint', () => {
     mockCurlOutput('{"id":"abc","email":"host@example.com"}');
     const account = await ZOOM.getAccount(BEARER);
     expect(account).toBe('host@example.com');
+  });
+});
+
+describe('notion-mcp account determination via the get-users MCP tool', () => {
+  // SSE-framed response as actually returned by mcp.notion.com.
+  const recordedGetSelfResponse =
+    'event: message\n' +
+    'data: {"result":{"content":[{"type":"text","text":"{\\"results\\":[{\\"type\\":\\"person\\",\\"id\\":\\"uuid-1\\",\\"name\\":\\"Jane Doe\\",\\"email\\":\\"jane@example.com\\"}],\\"has_more\\":false}"}]},"jsonrpc":"2.0","id":2}\n';
+
+  it('resolves the e-mail via a single stateless tools/call', async () => {
+    let observedArguments: readonly string[] = [];
+    setCapturingSubprocessRunner((args) => {
+      observedArguments = args;
+      return { returncode: 0, stdout: recordedGetSelfResponse, stderr: '' };
+    });
+    const account = await NOTION_MCP.getAccount(BEARER);
+    expect(account).toBe('jane@example.com');
+    expect(observedArguments[observedArguments.length - 1]).toBe('https://mcp.notion.com/mcp');
+    const payloadArgument = observedArguments[observedArguments.indexOf('-d') + 1] ?? '{}';
+    expect(JSON.parse(payloadArgument)).toMatchObject({
+      method: 'tools/call',
+      params: { name: 'notion-get-users', arguments: { user_id: 'self' } },
+    });
+  });
+
+  it('falls back to the name when the user has no e-mail (bots)', async () => {
+    const toolResultText = JSON.stringify({
+      results: [{ type: 'bot', id: 'uuid-2', name: 'My Bot' }],
+      has_more: false,
+    });
+    mockCurlOutput(
+      JSON.stringify({ result: { content: [{ type: 'text', text: toolResultText }] }, id: 2 })
+    );
+    const account = await NOTION_MCP.getAccount(BEARER);
+    expect(account).toBe('My Bot');
+  });
+
+  it('leaves the account undetermined on an error or malformed response', async () => {
+    mockCurlOutput('{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"unauthorized"}}');
+    expect(await NOTION_MCP.getAccount(BEARER)).toBeNull();
+    mockCurlOutput('not json at all');
+    expect(await NOTION_MCP.getAccount(BEARER)).toBeNull();
+  });
+
+  it('leaves the account undetermined for token-less prepared credentials', async () => {
+    const prepared = new OAuthCredentials('client-id', '');
+    const account = await NOTION_MCP.getAccount(prepared);
+    expect(account).toBeNull();
   });
 });

--- a/tests/serviceAccounts.test.ts
+++ b/tests/serviceAccounts.test.ts
@@ -95,7 +95,7 @@ describe('base account determination', () => {
 
   it('returns null for registered services without a request', async () => {
     const registered = new RegisteredService('my-service', 'https://example.com/api/');
-    const account = await registered.getAccount(BEARER);
+    const account = await registered.getAccount();
     expect(account).toBeNull();
   });
 });

--- a/tests/serviceAccounts.test.ts
+++ b/tests/serviceAccounts.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for account determination via the credential check.
+ *
+ * The credential check runs a single curl call whose output is the response
+ * body followed by the HTTP status code on the final line (produced by
+ * `-w '\n%{http_code}'`). These tests mock the capturing subprocess runner to
+ * feed service implementations recorded response bodies.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  ApiCredentialStatus,
+  AuthorizationBearer,
+  OAuthCredentials,
+} from '../src/apiCredentials/base.js';
+import {
+  resetCapturingSubprocessRunner,
+  setCapturingSubprocessRunner,
+} from '../src/curl.js';
+import { RegisteredService } from '../src/services/core/registered.js';
+import { AWS } from '../src/services/aws.js';
+import { CALENDLY } from '../src/services/calendly.js';
+import { DISCORD } from '../src/services/discord.js';
+import { DROPBOX } from '../src/services/dropbox.js';
+import { FIGMA } from '../src/services/figma.js';
+import { GITHUB } from '../src/services/github.js';
+import { GITLAB } from '../src/services/gitlab.js';
+import { GOOGLE_GMAIL } from '../src/services/google/gmail.js';
+import { LINEAR } from '../src/services/linear.js';
+import { MAILCHIMP } from '../src/services/mailchimp.js';
+import { NOTION } from '../src/services/notion.js';
+import { SENTRY } from '../src/services/sentry.js';
+import { SLACK } from '../src/services/slack.js';
+import { STRIPE } from '../src/services/stripe.js';
+import { TELEGRAM } from '../src/services/telegram.js';
+
+const BEARER = new AuthorizationBearer('test-token');
+
+function mockCurlOutput(stdout: string): void {
+  setCapturingSubprocessRunner(() => ({ returncode: 0, stdout, stderr: '' }));
+}
+
+function withStatusLine(body: string, statusCode = '200'): string {
+  return `${body}\n${statusCode}`;
+}
+
+afterEach(() => {
+  resetCapturingSubprocessRunner();
+});
+
+describe('base credential check', () => {
+  it('reports valid credentials without an account when the body carries no identity', async () => {
+    mockCurlOutput(withStatusLine('{"balance": []}'));
+    const result = await STRIPE.checkApiCredentials(BEARER);
+    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: null });
+  });
+
+  it('reports invalid credentials on non-200 responses', async () => {
+    mockCurlOutput(withStatusLine('{"message":"Bad credentials"}', '401'));
+    const result = await GITHUB.checkApiCredentials(BEARER);
+    expect(result).toEqual({ status: ApiCredentialStatus.Invalid, account: null });
+  });
+
+  it('reports missing credentials when injection fails', async () => {
+    const tokenlessCredentials = new OAuthCredentials('client-id', 'client-secret');
+    const result = await GITHUB.checkApiCredentials(tokenlessCredentials);
+    expect(result).toEqual({ status: ApiCredentialStatus.Missing, account: null });
+  });
+
+  it('never crashes on a malformed body', async () => {
+    mockCurlOutput(withStatusLine('this is not JSON'));
+    const result = await GITHUB.checkApiCredentials(BEARER);
+    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: null });
+  });
+
+  it('reports unknown status for registered services without a request', async () => {
+    const registered = new RegisteredService('my-service', 'https://example.com/api/');
+    const result = await registered.checkApiCredentials();
+    expect(result).toEqual({ status: ApiCredentialStatus.Unknown, account: null });
+  });
+});
+
+describe('account parsing from the credential check', () => {
+  it('github uses the login handle', async () => {
+    mockCurlOutput(withStatusLine('{"login":"octocat","email":null}'));
+    const result = await GITHUB.checkApiCredentials(BEARER);
+    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: 'octocat' });
+  });
+
+  it('gitlab uses the e-mail', async () => {
+    mockCurlOutput(withStatusLine('{"username":"jane","email":"jane@example.com"}'));
+    const result = await GITLAB.checkApiCredentials(BEARER);
+    expect(result.account).toBe('jane@example.com');
+  });
+
+  it('calendly uses the e-mail from the resource', async () => {
+    mockCurlOutput(
+      withStatusLine('{"resource":{"email":"host@example.com","name":"Host Person"}}')
+    );
+    const result = await CALENDLY.checkApiCredentials(BEARER);
+    expect(result.account).toBe('host@example.com');
+  });
+
+  it('figma uses the e-mail', async () => {
+    mockCurlOutput(withStatusLine('{"email":"designer@example.com","handle":"Designer"}'));
+    const result = await FIGMA.checkApiCredentials(BEARER);
+    expect(result.account).toBe('designer@example.com');
+  });
+
+  it('discord prefers the e-mail over the username', async () => {
+    mockCurlOutput(
+      withStatusLine('{"username":"gamer","email":"gamer@example.com","id":"1234"}')
+    );
+    const result = await DISCORD.checkApiCredentials(BEARER);
+    expect(result.account).toBe('gamer@example.com');
+  });
+
+  it('dropbox uses the e-mail from get_current_account', async () => {
+    mockCurlOutput(
+      withStatusLine('{"account_id":"dbid:abc","email":"user@example.com"}')
+    );
+    const result = await DROPBOX.checkApiCredentials(BEARER);
+    expect(result.account).toBe('user@example.com');
+  });
+
+  it('linear uses the viewer e-mail', async () => {
+    mockCurlOutput(
+      withStatusLine('{"data":{"viewer":{"id":"uuid-1","email":"dev@example.com"}}}')
+    );
+    const result = await LINEAR.checkApiCredentials(BEARER);
+    expect(result.account).toBe('dev@example.com');
+  });
+
+  it('mailchimp uses the login e-mail', async () => {
+    mockCurlOutput(
+      withStatusLine('{"accountname":"Acme","login":{"email":"marketer@example.com"}}')
+    );
+    const result = await MAILCHIMP.checkApiCredentials(BEARER);
+    expect(result.account).toBe('marketer@example.com');
+  });
+
+  it('notion combines the bot name and workspace', async () => {
+    mockCurlOutput(
+      withStatusLine('{"name":"My Integration","bot":{"workspace_name":"Acme Inc"}}')
+    );
+    const result = await NOTION.checkApiCredentials(BEARER);
+    expect(result.account).toBe('My Integration@Acme Inc');
+  });
+
+  it('telegram uses the bot username', async () => {
+    mockCurlOutput(withStatusLine('{"ok":true,"result":{"id":42,"username":"my_bot"}}'));
+    const result = await TELEGRAM.checkApiCredentials(BEARER);
+    expect(result.account).toBe('my_bot');
+  });
+
+  it('aws uses the caller ARN from the XML response', async () => {
+    mockCurlOutput(
+      withStatusLine(
+        '<GetCallerIdentityResponse><GetCallerIdentityResult>' +
+          '<Arn>arn:aws:iam::123456789012:user/alice</Arn>' +
+          '<UserId>AIDAEXAMPLE</UserId><Account>123456789012</Account>' +
+          '</GetCallerIdentityResult></GetCallerIdentityResponse>'
+      )
+    );
+    const result = await AWS.checkApiCredentials(BEARER);
+    expect(result.account).toBe('arn:aws:iam::123456789012:user/alice');
+  });
+});
+
+describe('slack credential check', () => {
+  it('treats ok:false as invalid even though the HTTP status is 200', async () => {
+    mockCurlOutput(withStatusLine('{"ok":false,"error":"invalid_auth"}'));
+    const result = await SLACK.checkApiCredentials(BEARER);
+    expect(result).toEqual({ status: ApiCredentialStatus.Invalid, account: null });
+  });
+
+  it('combines the user and the workspace subdomain', async () => {
+    mockCurlOutput(
+      withStatusLine(
+        '{"ok":true,"url":"https://acme.slack.com/","team":"Acme Inc","user":"jane"}'
+      )
+    );
+    const result = await SLACK.checkApiCredentials(BEARER);
+    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: 'jane@acme' });
+  });
+});
+
+describe('sentry credential check', () => {
+  it('requires the user field for validity', async () => {
+    mockCurlOutput(withStatusLine('{"user":null}'));
+    const result = await SENTRY.checkApiCredentials(BEARER);
+    expect(result).toEqual({ status: ApiCredentialStatus.Invalid, account: null });
+  });
+
+  it('uses the user e-mail', async () => {
+    mockCurlOutput(withStatusLine('{"user":{"email":"dev@example.com"}}'));
+    const result = await SENTRY.checkApiCredentials(BEARER);
+    expect(result).toEqual({
+      status: ApiCredentialStatus.Valid,
+      account: 'dev@example.com',
+    });
+  });
+});
+
+describe('service-level determineAccount', () => {
+  it('defaults to the credential-check account', async () => {
+    mockCurlOutput(withStatusLine('{"login":"octocat"}'));
+    expect(await GITHUB.determineAccount(BEARER)).toBe('octocat');
+  });
+
+  it('google services ask the OpenID userinfo endpoint', async () => {
+    let requestedUrl: string | undefined;
+    setCapturingSubprocessRunner((args) => {
+      requestedUrl = args[args.length - 1];
+      return { returncode: 0, stdout: '{"email":"user@gmail.com","sub":"1"}', stderr: '' };
+    });
+    const credentials = new OAuthCredentials('client-id', 'client-secret', 'access-token');
+    expect(await GOOGLE_GMAIL.determineAccount(credentials)).toBe('user@gmail.com');
+    expect(requestedUrl).toBe('https://openidconnect.googleapis.com/v1/userinfo');
+  });
+
+  it('google services return null for token-less prepared credentials', async () => {
+    const prepared = new OAuthCredentials('client-id', 'client-secret');
+    expect(await GOOGLE_GMAIL.determineAccount(prepared)).toBeNull();
+  });
+
+  it('stripe asks the account endpoint and prefers the e-mail', async () => {
+    let requestedUrl: string | undefined;
+    setCapturingSubprocessRunner((args) => {
+      requestedUrl = args[args.length - 1];
+      return {
+        returncode: 0,
+        stdout: '{"id":"acct_123","email":"owner@example.com"}',
+        stderr: '',
+      };
+    });
+    expect(await STRIPE.determineAccount(BEARER)).toBe('owner@example.com');
+    expect(requestedUrl).toBe('https://api.stripe.com/v1/account');
+  });
+
+  it('stripe returns null when the key may not read the account', async () => {
+    mockCurlOutput('{"error":{"type":"invalid_request_error"}}');
+    expect(await STRIPE.determineAccount(BEARER)).toBeNull();
+  });
+});

--- a/tests/serviceAccounts.test.ts
+++ b/tests/serviceAccounts.test.ts
@@ -33,6 +33,7 @@ import { SENTRY } from '../src/services/sentry.js';
 import { SLACK } from '../src/services/slack.js';
 import { STRIPE } from '../src/services/stripe.js';
 import { TELEGRAM } from '../src/services/telegram.js';
+import { ZOOM } from '../src/services/zoom.js';
 
 const BEARER = new AuthorizationBearer('test-token');
 
@@ -50,8 +51,8 @@ afterEach(() => {
 
 describe('base credential check', () => {
   it('reports valid credentials without an account when the body carries no identity', async () => {
-    mockCurlOutput(withStatusLine('{"balance": []}'));
-    const result = await STRIPE.checkApiCredentials(BEARER);
+    mockCurlOutput(withStatusLine('{}'));
+    const result = await GITHUB.checkApiCredentials(BEARER);
     expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: null });
   });
 
@@ -202,28 +203,38 @@ describe('sentry credential check', () => {
   });
 });
 
-describe('service-level determineAccount', () => {
-  it('defaults to the credential-check account', async () => {
-    mockCurlOutput(withStatusLine('{"login":"octocat"}'));
-    expect(await GITHUB.determineAccount(BEARER)).toBe('octocat');
-  });
-
-  it('google services ask the OpenID userinfo endpoint', async () => {
+describe('google credential check', () => {
+  it('google services check credentials against the OpenID userinfo endpoint', async () => {
     let requestedUrl: string | undefined;
     setCapturingSubprocessRunner((args) => {
       requestedUrl = args[args.length - 1];
-      return { returncode: 0, stdout: '{"email":"user@gmail.com","sub":"1"}', stderr: '' };
+      return {
+        returncode: 0,
+        stdout: withStatusLine('{"email":"user@gmail.com","sub":"1"}'),
+        stderr: '',
+      };
     });
     const credentials = new OAuthCredentials('client-id', 'client-secret', 'access-token');
-    expect(await GOOGLE_GMAIL.determineAccount(credentials)).toBe('user@gmail.com');
+    const result = await GOOGLE_GMAIL.checkApiCredentials(credentials);
+    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: 'user@gmail.com' });
     expect(requestedUrl).toBe('https://openidconnect.googleapis.com/v1/userinfo');
   });
 
-  it('google services return null for token-less prepared credentials', async () => {
+  it('google services report token-less prepared credentials as missing', async () => {
     const prepared = new OAuthCredentials('client-id', 'client-secret');
-    expect(await GOOGLE_GMAIL.determineAccount(prepared)).toBeNull();
+    const result = await GOOGLE_GMAIL.checkApiCredentials(prepared);
+    expect(result).toEqual({ status: ApiCredentialStatus.Missing, account: null });
   });
 
+  it('google services report tokens rejected by userinfo as invalid', async () => {
+    mockCurlOutput(withStatusLine('{"error":"invalid_token"}', '401'));
+    const credentials = new OAuthCredentials('client-id', 'client-secret', 'access-token');
+    const result = await GOOGLE_GMAIL.checkApiCredentials(credentials);
+    expect(result).toEqual({ status: ApiCredentialStatus.Invalid, account: null });
+  });
+});
+
+describe('credential check via a separate account endpoint', () => {
   it('stripe asks the account endpoint and prefers the e-mail', async () => {
     let requestedUrl: string | undefined;
     setCapturingSubprocessRunner((args) => {
@@ -234,12 +245,40 @@ describe('service-level determineAccount', () => {
         stderr: '',
       };
     });
-    expect(await STRIPE.determineAccount(BEARER)).toBe('owner@example.com');
+    const result = await STRIPE.checkApiCredentials(BEARER);
+    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: 'owner@example.com' });
     expect(requestedUrl).toBe('https://api.stripe.com/v1/account');
   });
 
-  it('stripe returns null when the key may not read the account', async () => {
-    mockCurlOutput('{"error":{"type":"invalid_request_error"}}');
-    expect(await STRIPE.determineAccount(BEARER)).toBeNull();
+  it('stripe falls back to the balance check when the key may not read the account', async () => {
+    setCapturingSubprocessRunner((args) => {
+      const url = args[args.length - 1] ?? '';
+      if (url.endsWith('/v1/account')) {
+        return {
+          returncode: 0,
+          stdout: '{"error":{"type":"invalid_request_error"}}',
+          stderr: '',
+        };
+      }
+      return { returncode: 0, stdout: withStatusLine('{"balance": []}'), stderr: '' };
+    });
+    const result = await STRIPE.checkApiCredentials(BEARER);
+    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: null });
+  });
+
+  it('zoom falls back to the user-list check for server-to-server tokens', async () => {
+    setCapturingSubprocessRunner((args) => {
+      const url = args[args.length - 1] ?? '';
+      if (url.endsWith('/users/me')) {
+        return {
+          returncode: 0,
+          stdout: '{"code":124,"message":"Invalid access token."}',
+          stderr: '',
+        };
+      }
+      return { returncode: 0, stdout: withStatusLine('{"users":[]}'), stderr: '' };
+    });
+    const result = await ZOOM.checkApiCredentials(BEARER);
+    expect(result).toEqual({ status: ApiCredentialStatus.Valid, account: null });
   });
 });

--- a/tests/sharedOperations.test.ts
+++ b/tests/sharedOperations.test.ts
@@ -16,6 +16,7 @@ import { GOOGLE_GMAIL } from '../src/services/google/gmail.js';
 import { NOTION_MCP } from '../src/services/notion-mcp.js';
 import { RegisteredService } from '../src/services/core/registered.js';
 import { ServiceRegistry } from '../src/serviceRegistry.js';
+import { saveBrowserConfig } from '../src/configDataStore.js';
 import { Config } from '../src/config.js';
 import {
   servicesList,
@@ -158,7 +159,7 @@ describe('operations', () => {
       expect(info.baseApiUrls).toEqual(['https://slack.com/api/']);
       expect(info.authOptions).toContain('browser');
       expect(info.authOptions).toContain('set');
-      expect(info.credentialStatus).toBe('missing');
+      expect(info.credentials).toEqual({});
       expect(info.developerNotes).toBe('Test info for Slack service.');
     });
 
@@ -194,6 +195,22 @@ describe('operations', () => {
 
       expect(info.type).toBe('user-registered');
     });
+
+    it('should return stored credentials keyed by account', async () => {
+      const service = createMockService();
+      const registry = new ServiceRegistry([service]);
+      const store = createApiCredentialStore();
+      store.save('slack', new SlackApiCredentials('default-token', 'default-cookie'));
+      store.save('slack', new SlackApiCredentials('work-token', 'work-cookie'), 'work@example.com');
+      const config = createMockConfig();
+
+      const info = await servicesInfo(registry, store, config, 'slack');
+
+      expect(info.credentials).toEqual({
+        '': { credentialType: 'slack', credentialStatus: 'valid' },
+        'work@example.com': { credentialType: 'slack', credentialStatus: 'valid' },
+      });
+    });
   });
 
   describe('authList', () => {
@@ -207,8 +224,10 @@ describe('operations', () => {
       const result = await authList(registry, store, createMockConfig());
 
       expect(result.slack).toEqual({
-        credentialType: 'slack',
-        credentialStatus: 'valid',
+        '': {
+          credentialType: 'slack',
+          credentialStatus: 'valid',
+        },
       });
     });
 
@@ -230,8 +249,10 @@ describe('operations', () => {
       const result = await authList(registry, store, createMockConfig());
 
       expect(result.unknown).toEqual({
-        credentialType: 'rawCurl',
-        credentialStatus: 'valid',
+        '': {
+          credentialType: 'rawCurl',
+          credentialStatus: 'valid',
+        },
       });
     });
   });
@@ -275,6 +296,39 @@ describe('operations', () => {
       await expect(authBrowser(registry, store, encryptedStorage, config, 'slack')).rejects.toThrow(
         PreparationRequiredError
       );
+    });
+
+    it('stores credentials under the account reported by the login flow', async () => {
+      const originalPlatform = process.platform;
+      // Pretend we are on macOS so the graphical-environment check passes
+      // without relying on DISPLAY being set.
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      try {
+        const login = vi.fn().mockResolvedValue({
+          credentials: new SlackApiCredentials('xoxc-token', 'cookie'),
+          account: 'user@example.com',
+        });
+        const service = createMockService({ getSession: vi.fn().mockReturnValue({ login }) });
+        const registry = new ServiceRegistry([service]);
+        const store = createApiCredentialStore();
+        const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
+        const config = createMockConfig({ directory: tempDir } as Partial<Config>);
+        // A valid browser config is required for the login flow to start; point
+        // it at any existing file.
+        saveBrowserConfig(config.configPath, {
+          executablePath: process.execPath,
+          source: 'system',
+          discoveredAt: new Date().toISOString(),
+        });
+
+        const result = await authBrowser(registry, store, encryptedStorage, config, 'slack');
+
+        expect(result).toEqual({ account: 'user@example.com' });
+        expect(store.listAccounts('slack')).toEqual(['user@example.com']);
+        expect(store.get('slack', 'user@example.com')).toBeInstanceOf(SlackApiCredentials);
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+      }
     });
   });
 
@@ -336,6 +390,37 @@ describe('operations', () => {
       const result = await authBrowserPrepare(registry, store, encryptedStorage, config, 'slack');
 
       expect(result.alreadyPrepared).toBe(true);
+    });
+
+    it('stores prepared credentials under the account reported by prepare', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      try {
+        const prepare = vi.fn().mockResolvedValue({
+          credentials: new SlackApiCredentials('prep-token', 'prep-cookie'),
+          account: '',
+        });
+        const service = createMockService({
+          getSession: vi.fn().mockReturnValue({ prepare, login: vi.fn() }),
+        });
+        const registry = new ServiceRegistry([service]);
+        const store = createApiCredentialStore();
+        const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
+        const config = createMockConfig({ directory: tempDir } as Partial<Config>);
+        saveBrowserConfig(config.configPath, {
+          executablePath: process.execPath,
+          source: 'system',
+          discoveredAt: new Date().toISOString(),
+        });
+
+        const result = await authBrowserPrepare(registry, store, encryptedStorage, config, 'slack');
+
+        expect(result).toEqual({ alreadyPrepared: false, account: '' });
+        expect(store.listAccounts('slack')).toEqual(['']);
+        expect(prepare).toHaveBeenCalledOnce();
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+      }
     });
   });
 

--- a/tests/sharedOperations.test.ts
+++ b/tests/sharedOperations.test.ts
@@ -4,14 +4,14 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { EncryptedStorage } from '../src/encryptedStorage.js';
 import { ApiCredentialStore } from '../src/apiCredentials/store.js';
-import { ApiCredentialStatus, OAuthCredentials } from '../src/apiCredentials/base.js';
+import { OAuthCredentials } from '../src/apiCredentials/base.js';
 import { SlackApiCredentials } from '../src/services/slack.js';
 import {
-  NoCurlCredentialsNotSupportedError,
   PrepareInputInvalidError,
   PrepareNotSupportedError,
   Service,
 } from '../src/services/core/base.js';
+import { MockService } from './mockService.js';
 import { GOOGLE_GMAIL } from '../src/services/google/gmail.js';
 import { NOTION_MCP } from '../src/services/notion-mcp.js';
 import { RegisteredService } from '../src/services/core/registered.js';
@@ -37,26 +37,8 @@ function writeSecureFile(path: string, content: string): void {
   storage.writeFile(path, content);
 }
 
-function createMockService(overrides: Partial<Service> = {}): Service {
-  return {
-    name: 'slack',
-    displayName: 'Slack',
-    baseApiUrls: ['https://slack.com/api/'],
-    loginUrl: 'https://slack.com/signin',
-    info: 'Test info for Slack service.',
-    credentialCheckCurlArguments: ['https://slack.com/api/auth.test'],
-    checkApiCredentials: vi.fn().mockResolvedValue(ApiCredentialStatus.Valid),
-    setCredentialsExample(serviceName: string) {
-      return `latchkey auth set ${serviceName} -H "Authorization: Bearer xoxb-your-token"`;
-    },
-    getCredentialsNoCurl() {
-      throw new NoCurlCredentialsNotSupportedError('slack');
-    },
-    getSession: vi.fn().mockReturnValue({
-      login: vi.fn().mockResolvedValue(new SlackApiCredentials('xoxc-test-token', 'test-cookie')),
-    }),
-    ...overrides,
-  };
+function createMockService(overrides: Partial<MockService> = {}): Service {
+  return Object.assign(new MockService(), overrides);
 }
 
 function createMockConfig(overrides: Partial<Config> = {}): Config {
@@ -326,6 +308,108 @@ describe('operations', () => {
         expect(result).toEqual({ account: 'user@example.com' });
         expect(store.listAccounts('slack')).toEqual(['user@example.com']);
         expect(store.get('slack', 'user@example.com')).toBeInstanceOf(SlackApiCredentials);
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+      }
+    });
+
+    it('logs in to an additional account without ambiguity, reusing a stored account', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      try {
+        const login = vi.fn().mockResolvedValue({
+          credentials: new SlackApiCredentials('second-token', 'second-cookie'),
+          account: 'second@example.com',
+        });
+        const service = createMockService({ getSession: vi.fn().mockReturnValue({ login }) });
+        const registry = new ServiceRegistry([service]);
+        const store = createApiCredentialStore();
+        store.save('slack', new SlackApiCredentials('first-token', 'first-cookie'), 'first@example.com');
+        const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
+        const config = createMockConfig({ directory: tempDir } as Partial<Config>);
+        saveBrowserConfig(config.configPath, {
+          executablePath: process.execPath,
+          source: 'system',
+          discoveredAt: new Date().toISOString(),
+        });
+
+        const result = await authBrowser(registry, store, encryptedStorage, config, 'slack');
+
+        expect(result).toEqual({ account: 'second@example.com' });
+        expect(store.listAccounts('slack')).toEqual(['first@example.com', 'second@example.com']);
+        // The stored account's credentials are offered for reuse during login.
+        const reusedCredentials = login.mock.calls[0]?.[2] as SlackApiCredentials;
+        expect(reusedCredentials.token).toBe('first-token');
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+      }
+    });
+
+    it('drops the token-less prepared placeholder once login stores a real account', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      try {
+        const preparedClient = new OAuthCredentials('client-id', 'client-secret');
+        const fullCredentials = new OAuthCredentials(
+          'client-id',
+          'client-secret',
+          'access-token',
+          'refresh-token'
+        );
+        const login = vi.fn().mockResolvedValue({
+          credentials: fullCredentials,
+          account: 'user@example.com',
+        });
+        const service = createMockService({
+          getSession: vi.fn().mockReturnValue({ prepare: vi.fn(), login }),
+        });
+        const registry = new ServiceRegistry([service]);
+        const store = createApiCredentialStore();
+        store.save('slack', preparedClient, '');
+        const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
+        const config = createMockConfig({ directory: tempDir } as Partial<Config>);
+        saveBrowserConfig(config.configPath, {
+          executablePath: process.execPath,
+          source: 'system',
+          discoveredAt: new Date().toISOString(),
+        });
+
+        const result = await authBrowser(registry, store, encryptedStorage, config, 'slack');
+
+        expect(result).toEqual({ account: 'user@example.com' });
+        // The placeholder created by browser-prepare is gone; only the real
+        // account remains, carrying the OAuth client onward.
+        expect(store.listAccounts('slack')).toEqual(['user@example.com']);
+        const reusedCredentials = login.mock.calls[0]?.[2] as OAuthCredentials;
+        expect(reusedCredentials.clientId).toBe('client-id');
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+      }
+    });
+
+    it('keeps complete default-account credentials when a login adds a named account', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      try {
+        const login = vi.fn().mockResolvedValue({
+          credentials: new SlackApiCredentials('named-token', 'named-cookie'),
+          account: 'user@example.com',
+        });
+        const service = createMockService({ getSession: vi.fn().mockReturnValue({ login }) });
+        const registry = new ServiceRegistry([service]);
+        const store = createApiCredentialStore();
+        store.save('slack', new SlackApiCredentials('default-token', 'default-cookie'), '');
+        const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
+        const config = createMockConfig({ directory: tempDir } as Partial<Config>);
+        saveBrowserConfig(config.configPath, {
+          executablePath: process.execPath,
+          source: 'system',
+          discoveredAt: new Date().toISOString(),
+        });
+
+        await authBrowser(registry, store, encryptedStorage, config, 'slack');
+
+        expect(store.listAccounts('slack')).toEqual(['', 'user@example.com']);
       } finally {
         Object.defineProperty(process, 'platform', { value: originalPlatform });
       }

--- a/tests/sharedOperations.test.ts
+++ b/tests/sharedOperations.test.ts
@@ -325,7 +325,11 @@ describe('operations', () => {
         const service = createMockService({ getSession: vi.fn().mockReturnValue({ login }) });
         const registry = new ServiceRegistry([service]);
         const store = createApiCredentialStore();
-        store.save('slack', new SlackApiCredentials('first-token', 'first-cookie'), 'first@example.com');
+        store.save(
+          'slack',
+          new SlackApiCredentials('first-token', 'first-cookie'),
+          'first@example.com'
+        );
         const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
         const config = createMockConfig({ directory: tempDir } as Partial<Config>);
         saveBrowserConfig(config.configPath, {

--- a/tests/sharedOperations.test.ts
+++ b/tests/sharedOperations.test.ts
@@ -26,6 +26,7 @@ import {
   authBrowserPrepare,
   prepareService,
   UnknownServiceError,
+  AccountNotFoundError,
   PreparationRequiredError,
 } from '../src/sharedOperations.js';
 import { BrowserFlowsNotSupportedError } from '../src/playwrightUtils.js';
@@ -71,7 +72,7 @@ describe('operations', () => {
     const nestedCredentials = Object.fromEntries(
       Object.entries(credentialsData).map(([service, creds]) => [service, { '': creds }])
     );
-    writeSecureFile(storePath, JSON.stringify(nestedCredentials));
+    writeSecureFile(storePath, JSON.stringify({ credentials: nestedCredentials }));
     const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
     return new ApiCredentialStore(storePath, encryptedStorage);
   }
@@ -313,7 +314,7 @@ describe('operations', () => {
       }
     });
 
-    it('logs in to an additional account without ambiguity, reusing a stored account', async () => {
+    it('logs in to an additional account without ambiguity', async () => {
       const originalPlatform = process.platform;
       Object.defineProperty(process, 'platform', { value: 'darwin' });
       try {
@@ -337,15 +338,12 @@ describe('operations', () => {
 
         expect(result).toEqual({ account: 'second@example.com' });
         expect(store.listAccounts('slack')).toEqual(['first@example.com', 'second@example.com']);
-        // The stored account's credentials are offered for reuse during login.
-        const reusedCredentials = login.mock.calls[0]?.[2] as SlackApiCredentials;
-        expect(reusedCredentials.token).toBe('first-token');
       } finally {
         Object.defineProperty(process, 'platform', { value: originalPlatform });
       }
     });
 
-    it('drops the token-less prepared placeholder once login stores a real account', async () => {
+    it('uses the stored preparation for login and keeps it for future logins', async () => {
       const originalPlatform = process.platform;
       Object.defineProperty(process, 'platform', { value: 'darwin' });
       try {
@@ -365,7 +363,7 @@ describe('operations', () => {
         });
         const registry = new ServiceRegistry([service]);
         const store = createApiCredentialStore();
-        store.save('slack', preparedClient, '');
+        store.savePreparation('slack', preparedClient);
         const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
         const config = createMockConfig({ directory: tempDir } as Partial<Config>);
         saveBrowserConfig(config.configPath, {
@@ -377,14 +375,80 @@ describe('operations', () => {
         const result = await authBrowser(registry, store, encryptedStorage, config, 'slack');
 
         expect(result).toEqual({ account: 'user@example.com' });
-        // The placeholder created by browser-prepare is gone; only the real
-        // account remains, carrying the OAuth client onward.
         expect(store.listAccounts('slack')).toEqual(['user@example.com']);
         const reusedCredentials = login.mock.calls[0]?.[2] as OAuthCredentials;
         expect(reusedCredentials.clientId).toBe('client-id');
+        // The preparation stays around so another account can log in with the
+        // same client.
+        expect(store.getPreparation('slack')).toBeInstanceOf(OAuthCredentials);
       } finally {
         Object.defineProperty(process, 'platform', { value: originalPlatform });
       }
+    });
+
+    it("reuses the named account's credentials when an account is given", async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      try {
+        const existingCredentials = new OAuthCredentials(
+          'client-id',
+          'client-secret',
+          'old-access-token',
+          'old-refresh-token'
+        );
+        const login = vi.fn().mockResolvedValue({
+          credentials: new OAuthCredentials(
+            'client-id',
+            'client-secret',
+            'new-access-token',
+            'new-refresh-token'
+          ),
+          account: 'second@example.com',
+        });
+        const service = createMockService({
+          getSession: vi.fn().mockReturnValue({ prepare: vi.fn(), login }),
+        });
+        const registry = new ServiceRegistry([service]);
+        const store = createApiCredentialStore();
+        store.save('slack', existingCredentials, 'first@example.com');
+        const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
+        const config = createMockConfig({ directory: tempDir } as Partial<Config>);
+        saveBrowserConfig(config.configPath, {
+          executablePath: process.execPath,
+          source: 'system',
+          discoveredAt: new Date().toISOString(),
+        });
+
+        const result = await authBrowser(
+          registry,
+          store,
+          encryptedStorage,
+          config,
+          'slack',
+          'first@example.com'
+        );
+
+        expect(result).toEqual({ account: 'second@example.com' });
+        expect(store.listAccounts('slack')).toEqual(['first@example.com', 'second@example.com']);
+        const reusedCredentials = login.mock.calls[0]?.[2] as OAuthCredentials;
+        expect(reusedCredentials.accessToken).toBe('old-access-token');
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+      }
+    });
+
+    it('throws AccountNotFoundError when the given account has no credentials', async () => {
+      const service = createMockService({
+        getSession: vi.fn().mockReturnValue({ login: vi.fn() }),
+      });
+      const registry = new ServiceRegistry([service]);
+      const store = createApiCredentialStore();
+      const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
+      const config = createMockConfig();
+
+      await expect(
+        authBrowser(registry, store, encryptedStorage, config, 'slack', 'missing@example.com')
+      ).rejects.toThrow(AccountNotFoundError);
     });
 
     it('keeps complete default-account credentials when a login adds a named account', async () => {
@@ -445,23 +509,24 @@ describe('operations', () => {
       expect(result.alreadyPrepared).toBe(true);
     });
 
-    it('should return alreadyPrepared true when credentials already exist', async () => {
+    it('should return alreadyPrepared true when a preparation already exists', async () => {
+      const prepare = vi.fn();
       const service = createMockService({
         getSession: vi.fn().mockReturnValue({
-          prepare: vi.fn(),
+          prepare,
           login: vi.fn(),
         }),
       });
       const registry = new ServiceRegistry([service]);
-      const store = createApiCredentialStore({
-        slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
-      });
+      const store = createApiCredentialStore();
+      store.savePreparation('slack', new OAuthCredentials('client-id', 'client-secret'));
       const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
       const config = createMockConfig();
 
       const result = await authBrowserPrepare(registry, store, encryptedStorage, config, 'slack');
 
       expect(result.alreadyPrepared).toBe(true);
+      expect(prepare).not.toHaveBeenCalled();
     });
 
     it('should return alreadyPrepared true when service has no getSession', async () => {
@@ -476,12 +541,12 @@ describe('operations', () => {
       expect(result.alreadyPrepared).toBe(true);
     });
 
-    it('stores prepared credentials under the account reported by prepare', async () => {
+    it("stores the prepared credentials as the service's preparation", async () => {
       const originalPlatform = process.platform;
       Object.defineProperty(process, 'platform', { value: 'darwin' });
       try {
         const prepare = vi.fn().mockResolvedValue({
-          credentials: new SlackApiCredentials('prep-token', 'prep-cookie'),
+          credentials: new OAuthCredentials('client-id', 'client-secret'),
           account: '',
         });
         const service = createMockService({
@@ -499,8 +564,10 @@ describe('operations', () => {
 
         const result = await authBrowserPrepare(registry, store, encryptedStorage, config, 'slack');
 
-        expect(result).toEqual({ alreadyPrepared: false, account: '' });
-        expect(store.listAccounts('slack')).toEqual(['']);
+        expect(result).toEqual({ alreadyPrepared: false });
+        expect(store.getPreparation('slack')).toBeInstanceOf(OAuthCredentials);
+        // Preparations are not account credentials.
+        expect(store.listAccounts('slack')).toEqual([]);
         expect(prepare).toHaveBeenCalledOnce();
       } finally {
         Object.defineProperty(process, 'platform', { value: originalPlatform });
@@ -509,7 +576,7 @@ describe('operations', () => {
   });
 
   describe('prepareService', () => {
-    it('stores token-less OAuth credentials for a Google service and returns the result', () => {
+    it('stores a token-less OAuth preparation for a Google service and returns the result', () => {
       const registry = new ServiceRegistry([GOOGLE_GMAIL]);
       const store = createApiCredentialStore();
 
@@ -521,20 +588,21 @@ describe('operations', () => {
       );
 
       expect(result).toEqual({ serviceName: 'google-gmail', credentialType: 'oauth' });
-      const stored = store.get('google-gmail');
+      const stored = store.getPreparation('google-gmail');
       expect(stored).toBeInstanceOf(OAuthCredentials);
       const oauth = stored as OAuthCredentials;
       expect(oauth.clientId).toBe('cid');
       expect(oauth.clientSecret).toBe('csecret');
       expect(oauth.accessToken).toBeUndefined();
       expect(oauth.refreshToken).toBeUndefined();
+      // Preparations do not touch the credentials section.
+      expect(store.get('google-gmail')).toBeNull();
     });
 
-    it('overwrites existing credentials unconditionally', () => {
+    it('overwrites an existing preparation unconditionally', () => {
       const registry = new ServiceRegistry([GOOGLE_GMAIL]);
-      const store = createApiCredentialStore({
-        'google-gmail': { objectType: 'oauth', clientId: 'old-id', clientSecret: 'old-secret' },
-      });
+      const store = createApiCredentialStore();
+      store.savePreparation('google-gmail', new OAuthCredentials('old-id', 'old-secret'));
 
       prepareService(
         registry,
@@ -543,8 +611,10 @@ describe('operations', () => {
         JSON.stringify({ clientId: 'new-id', clientSecret: 'new-secret' })
       );
 
-      expect((store.get('google-gmail') as OAuthCredentials).clientId).toBe('new-id');
-      expect((store.get('google-gmail') as OAuthCredentials).clientSecret).toBe('new-secret');
+      expect((store.getPreparation('google-gmail') as OAuthCredentials).clientId).toBe('new-id');
+      expect((store.getPreparation('google-gmail') as OAuthCredentials).clientSecret).toBe(
+        'new-secret'
+      );
     });
 
     it('throws UnknownServiceError for an unknown service', () => {
@@ -566,7 +636,7 @@ describe('operations', () => {
           JSON.stringify({ clientId: 'a', clientSecret: 'b' })
         )
       ).toThrow(PrepareNotSupportedError);
-      expect(store.get('slack')).toBeNull();
+      expect(store.getPreparation('slack')).toBeNull();
     });
 
     it('rejects malformed JSON without storing anything', () => {
@@ -576,7 +646,7 @@ describe('operations', () => {
       expect(() => prepareService(registry, store, 'google-gmail', '{not valid')).toThrow(
         PrepareInputInvalidError
       );
-      expect(store.get('google-gmail')).toBeNull();
+      expect(store.getPreparation('google-gmail')).toBeNull();
     });
 
     it('rejects input missing required fields without storing anything', () => {
@@ -586,7 +656,7 @@ describe('operations', () => {
       expect(() =>
         prepareService(registry, store, 'google-gmail', JSON.stringify({ clientId: 'only-id' }))
       ).toThrow(PrepareInputInvalidError);
-      expect(store.get('google-gmail')).toBeNull();
+      expect(store.getPreparation('google-gmail')).toBeNull();
     });
 
     it('rejects unknown keys (strict schema)', () => {
@@ -601,7 +671,7 @@ describe('operations', () => {
           JSON.stringify({ clientId: 'a', clientSecret: 'b', extra: 'nope' })
         )
       ).toThrow(PrepareInputInvalidError);
-      expect(store.get('google-gmail')).toBeNull();
+      expect(store.getPreparation('google-gmail')).toBeNull();
     });
 
     it('rejects empty string fields', () => {
@@ -630,7 +700,7 @@ describe('operations', () => {
       );
 
       expect(result).toEqual({ serviceName: 'notion-mcp', credentialType: 'oauth' });
-      const stored = store.get('notion-mcp');
+      const stored = store.getPreparation('notion-mcp');
       expect(stored).toBeInstanceOf(OAuthCredentials);
       const oauth = stored as OAuthCredentials;
       expect(oauth.clientId).toBe('notion-client-id');
@@ -651,7 +721,7 @@ describe('operations', () => {
           JSON.stringify({ clientId: 'a', clientSecret: 'b' })
         )
       ).toThrow(PrepareInputInvalidError);
-      expect(store.get('notion-mcp')).toBeNull();
+      expect(store.getPreparation('notion-mcp')).toBeNull();
     });
 
     it('rejects notion-mcp input missing clientId', () => {
@@ -661,7 +731,7 @@ describe('operations', () => {
       expect(() => prepareService(registry, store, 'notion-mcp', '{}')).toThrow(
         PrepareInputInvalidError
       );
-      expect(store.get('notion-mcp')).toBeNull();
+      expect(store.getPreparation('notion-mcp')).toBeNull();
     });
   });
 });

--- a/tests/sharedOperations.test.ts
+++ b/tests/sharedOperations.test.ts
@@ -513,24 +513,40 @@ describe('operations', () => {
       expect(result.alreadyPrepared).toBe(true);
     });
 
-    it('should return alreadyPrepared true when a preparation already exists', async () => {
-      const prepare = vi.fn();
-      const service = createMockService({
-        getSession: vi.fn().mockReturnValue({
-          prepare,
-          login: vi.fn(),
-        }),
-      });
-      const registry = new ServiceRegistry([service]);
-      const store = createApiCredentialStore();
-      store.savePreparation('slack', new OAuthCredentials('client-id', 'client-secret'));
-      const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
-      const config = createMockConfig();
+    it('re-runs the prepare flow when a preparation already exists', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      try {
+        const prepare = vi
+          .fn()
+          .mockResolvedValue(new OAuthCredentials('new-client-id', 'new-client-secret'));
+        const service = createMockService({
+          getSession: vi.fn().mockReturnValue({
+            prepare,
+            login: vi.fn(),
+          }),
+        });
+        const registry = new ServiceRegistry([service]);
+        const store = createApiCredentialStore();
+        store.savePreparation('slack', new OAuthCredentials('client-id', 'client-secret'));
+        const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
+        const config = createMockConfig({ directory: tempDir } as Partial<Config>);
+        saveBrowserConfig(config.configPath, {
+          executablePath: process.execPath,
+          source: 'system',
+          discoveredAt: new Date().toISOString(),
+        });
 
-      const result = await authBrowserPrepare(registry, store, encryptedStorage, config, 'slack');
+        const result = await authBrowserPrepare(registry, store, encryptedStorage, config, 'slack');
 
-      expect(result.alreadyPrepared).toBe(true);
-      expect(prepare).not.toHaveBeenCalled();
+        expect(result).toEqual({ alreadyPrepared: false });
+        expect(prepare).toHaveBeenCalledOnce();
+        // The new preparation overwrites the previous one.
+        const preparation = store.getPreparation('slack') as OAuthCredentials;
+        expect(preparation.clientId).toBe('new-client-id');
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+      }
     });
 
     it('should return alreadyPrepared true when service has no getSession', async () => {

--- a/tests/sharedOperations.test.ts
+++ b/tests/sharedOperations.test.ts
@@ -84,7 +84,11 @@ describe('operations', () => {
     credentialsData: Record<string, unknown> = {}
   ): ApiCredentialStore {
     const storePath = join(tempDir, 'credentials.json');
-    writeSecureFile(storePath, JSON.stringify(credentialsData));
+    // Store credentials under the default account, matching the on-disk layout.
+    const nestedCredentials = Object.fromEntries(
+      Object.entries(credentialsData).map(([service, creds]) => [service, { '': creds }])
+    );
+    writeSecureFile(storePath, JSON.stringify(nestedCredentials));
     const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
     return new ApiCredentialStore(storePath, encryptedStorage);
   }

--- a/tests/sharedOperations.test.ts
+++ b/tests/sharedOperations.test.ts
@@ -549,10 +549,9 @@ describe('operations', () => {
       const originalPlatform = process.platform;
       Object.defineProperty(process, 'platform', { value: 'darwin' });
       try {
-        const prepare = vi.fn().mockResolvedValue({
-          credentials: new OAuthCredentials('client-id', 'client-secret'),
-          account: '',
-        });
+        const prepare = vi
+          .fn()
+          .mockResolvedValue(new OAuthCredentials('client-id', 'client-secret'));
         const service = createMockService({
           getSession: vi.fn().mockReturnValue({ prepare, login: vi.fn() }),
         });


### PR DESCRIPTION
## Add support for multiple accounts.

- Latchkey can now store different credentials for different accounts for the same service.
- The following commands now respect the optional `--account` top-level flag:
  - `latchkey --account username@domain curl ...`
  - `latchkey --account username@domain auth set ...`
  - `latchkey --account username@domain auth set-nocurl ...`
  - `latchkey --account username@domain auth browser ...`

In case of `latchkey auth browser`, the actual account for the resulting credentials is determined by the account the user actually logs in to. The `--account` option merely allows users to pick the account to use the existing OAuth client details from if needed.

## Backwards incompatible changes:

1. On-disk credential store format changed
    - Downgrading to main afterwards will not understand the new format.
2. `services info` JSON output changed
    - The single credentialStatus field was removed and replaced by a credentials object keyed by account (default account = empty string `""`).
    - The `missing` status value no longer exists — a service with no credentials now shows an empty credentials object: `{}`
3. `auth list` JSON output gained a nesting level
    - Was `{ service: { credentialType, credentialStatus } }`; now `{ service: { account: { credentialType, credentialStatus } } }`. Consumers must index by account.
4. `auth clear <service>` semantics changed
    - Previously cleared everything for the service. Now it clears only one account, and errors out if the service has multiple accounts and no `--account` is given.
    - To wipe a whole service (all accounts and its preparation), you must use the new latchkey `auth clear <service> --all`.
5. `services deregister` needs more clearing to happen first
    - The guard/error message changed: you must now run `latchkey auth clear <service> --all` (not just `auth clear <service>`) before deregistering.
6. `auth prepare` / `auth browser-prepare` store "preparations", not credentials
    - Prepared-but-not-logged-in state moved out of the credentials section into a separate preparations section. Consequence: a merely-prepared service no longer appears as having credentials in `auth list` / `services info`.
7. Multiple accounts make `--account` mandatory in the ambiguous case
    - For `curl`, `auth set`, `auth set-nocurl`, `auth clear`, and `auth browser`, once a service has more than one stored account, omitting `--account` now fails.
8. `auth browser` "Done" message changed
    - On success it may now print "Done. Stored credentials for account '<account>'." instead of the plain "Done" (also the gateway auth browser response now returns an account object instead of null).
9. Repeated `auth browser-prepare` calls are now possible. (Previously, they would fail with the "Already prepared." message.)
