### PR TITLE
scripts: add latchkey dev shim that runs the working checkout from source

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,26 @@ After that, every time you make a change to the code, run
 `npm run rebuild`. Invoking `latchkey` in your terminal will
 then use the version you just built.
 
+### Dev shim: run from source, no rebuild
+
+Alternatively, put the dev shim on your PATH (ahead of any
+npm-linked or globally installed `latchkey`). From the repository
+root:
+
+```bash
+mkdir -p ~/.local/bin && ln -sfn "$PWD/scripts/latchkey" ~/.local/bin/latchkey
+```
+
+The shim runs `src/cli.ts` directly under [bun](https://bun.sh),
+so edits take effect immediately with no build step. It resolves
+the checkout from your current directory, which makes worktrees
+and secondary clones work without relinking; outside any checkout
+it falls back to the checkout the shim was installed from.
+
+Without bun on PATH (or with `LATCHKEY_DEV_SHIM_USE_DIST=1`), the
+shim runs the compiled `dist/src/cli.js` under node instead, which
+requires `npm run build`.
+
 ## Before you submit a PR
 
 - Run `npm run lint` and `npm test` to validate your changes.
@@ -131,6 +151,7 @@ npx tsx scripts/cryptFile.ts decrypt ~/.latchkey/credentials.json.enc
 The following environment variables can be set for development and debugging:
 
 - `LATCHKEY_DISABLE_SPINNER=1`: Disables the spinner overlay that normally hides browser activity during credential finalization. Useful for debugging browser automation sequences.
+- `LATCHKEY_DEV_SHIM_USE_DIST=1`: Makes the dev shim (`scripts/latchkey`) run the compiled `dist/src/cli.js` under node instead of `src/cli.ts` under bun.
 
 
 ## Style guidelines

--- a/scripts/latchkey
+++ b/scripts/latchkey
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# latchkey dev shim -- LATCHKEY_DEV_SHIM_V1
+#
+# Routes `latchkey ...` to the latchkey checkout you are actually working in:
+#   - inside any latchkey checkout/worktree: use THAT tree, running src/cli.ts
+#     directly under bun, so local edits take effect with no build step.
+#   - anywhere else: fall back to the checkout this shim is installed from,
+#     discovered from the shim's own path (no hard-coded per-user path).
+#
+# Without bun on PATH -- or with LATCHKEY_DEV_SHIM_USE_DIST=1 -- runs the
+# compiled dist/src/cli.js under node instead, which requires `npm run build`.
+#
+# Install onto PATH from the repository root with:
+#   mkdir -p ~/.local/bin && ln -sfn "$PWD/scripts/latchkey" ~/.local/bin/latchkey
+set -euo pipefail
+
+_resolve() {
+    # Portable `readlink -f` (macOS ships no GNU readlink by default).
+    local path=$1 target
+    while [ -L "$path" ]; do
+        target=$(readlink "$path")
+        case $target in
+            /*) path=$target ;;
+            *) path=$(cd -P "$(dirname "$path")" && cd -P "$(dirname "$target")" && pwd)/$(basename "$target") ;;
+        esac
+    done
+    printf '%s\n' "$(cd -P "$(dirname "$path")" && pwd)/$(basename "$path")"
+}
+
+_is_latchkey_checkout() {
+    [ -f "$1/src/cli.ts" ] && grep -Eq '"name"[[:space:]]*:[[:space:]]*"latchkey"' "$1/package.json" 2>/dev/null
+}
+
+if root=$(git rev-parse --show-toplevel 2>/dev/null) && _is_latchkey_checkout "$root"; then
+    :
+else
+    shim=$(_resolve "${BASH_SOURCE[0]}")
+    if root=$(git -C "$(dirname "$shim")" rev-parse --show-toplevel 2>/dev/null) && _is_latchkey_checkout "$root"; then
+        :
+    else
+        echo "latchkey: shim at $shim is not inside a latchkey checkout" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -d "$root/node_modules" ]; then
+    echo "latchkey: no node_modules in $root; run \`npm install\` there first" >&2
+    exit 1
+fi
+
+if [ -z "${LATCHKEY_DEV_SHIM_USE_DIST:-}" ] && command -v bun >/dev/null 2>&1; then
+    # src/version.ts is gitignored and generated, so fresh checkouts and
+    # worktrees lack it until a build or test run creates it.
+    [ -f "$root/src/version.ts" ] || bun "$root/scripts/generateVersion.js"
+    exec bun "$root/src/cli.ts" "$@"
+fi
+
+if [ ! -f "$root/dist/src/cli.js" ]; then
+    echo "latchkey: no built output at $root/dist/src/cli.js; run \`npm run build\` in $root (or install bun to run from source)" >&2
+    exit 1
+fi
+exec node "$root/dist/src/cli.js" "$@"

--- a/tests/devShim.test.ts
+++ b/tests/devShim.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const TEST_ENCRYPTION_KEY = 'dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleXRlc3Q=';
+
+const projectRoot = join(__dirname, '..');
+const shimPath = join(projectRoot, 'scripts', 'latchkey');
+const projectVersion = (
+  JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf-8')) as { version: string }
+).version;
+
+// PATH with no bun on it: just node's own directory plus the system tools
+// (bash, git, grep, ...) the shim needs.
+const pathWithoutBun = [dirname(process.execPath), '/usr/bin', '/bin'].join(':');
+
+function isBunAvailable(): boolean {
+  try {
+    execFileSync('bun', ['--version'], { stdio: 'pipe' });
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+const bunAvailable = isBunAvailable();
+
+interface ShimResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface ExecError {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runShim(
+  args: string[],
+  options: { cwd: string; env?: Record<string, string>; command?: string }
+): ShimResult {
+  try {
+    const stdout = execFileSync(options.command ?? shimPath, args, {
+      cwd: options.cwd,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        LATCHKEY_ENCRYPTION_KEY: TEST_ENCRYPTION_KEY,
+        LATCHKEY_DISABLE_COUNTING: '1',
+        ...options.env,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (error) {
+    const execError = error as ExecError;
+    return {
+      exitCode: execError.status ?? 1,
+      stdout: execError.stdout,
+      stderr: execError.stderr,
+    };
+  }
+}
+
+function createFakeLatchkeyCheckout(directory: string): void {
+  execFileSync('git', ['init', '--quiet'], { cwd: directory });
+  writeFileSync(join(directory, 'package.json'), `${JSON.stringify({ name: 'latchkey' })}\n`);
+  mkdirSync(join(directory, 'src'));
+  mkdirSync(join(directory, 'node_modules'));
+  writeFileSync(join(directory, 'src', 'cli.ts'), "console.log('fake-cli source v1');\n");
+  writeFileSync(join(directory, 'src', 'version.ts'), "export const VERSION = '0.0.0-fake';\n");
+}
+
+describe('dev shim (scripts/latchkey)', () => {
+  let tempDir: string;
+  let latchkeyDirectory: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'latchkey-dev-shim-test-'));
+    latchkeyDirectory = join(tempDir, 'latchkey-home');
+    mkdirSync(latchkeyDirectory);
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(!bunAvailable)('runs the real CLI from source in the checkout containing cwd', () => {
+    const result = runShim(['--version'], {
+      cwd: projectRoot,
+      env: { LATCHKEY_DIRECTORY: latchkeyDirectory },
+    });
+
+    expect(result.stderr).toBe('');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe(projectVersion);
+  });
+
+  it.skipIf(!bunAvailable)('reflects source edits in the cwd checkout without a build', () => {
+    const fakeCheckout = join(tempDir, 'fake-checkout');
+    mkdirSync(fakeCheckout);
+    createFakeLatchkeyCheckout(fakeCheckout);
+
+    const firstRun = runShim([], { cwd: fakeCheckout });
+    expect(firstRun.exitCode).toBe(0);
+    expect(firstRun.stdout.trim()).toBe('fake-cli source v1');
+
+    writeFileSync(join(fakeCheckout, 'src', 'cli.ts'), "console.log('fake-cli source v2');\n");
+
+    const secondRun = runShim([], { cwd: fakeCheckout });
+    expect(secondRun.exitCode).toBe(0);
+    expect(secondRun.stdout.trim()).toBe('fake-cli source v2');
+  });
+
+  it.skipIf(!bunAvailable)(
+    'falls back to its own checkout when cwd is outside any checkout',
+    () => {
+      // Invoke through a symlink, like the ~/.local/bin install, so the shim has
+      // to resolve its real location before discovering its checkout.
+      const symlinkedShim = join(tempDir, 'latchkey');
+      symlinkSync(shimPath, symlinkedShim);
+
+      const result = runShim(['--version'], {
+        cwd: tempDir,
+        env: { LATCHKEY_DIRECTORY: latchkeyDirectory },
+        command: symlinkedShim,
+      });
+
+      expect(result.stderr).toBe('');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe(projectVersion);
+    }
+  );
+
+  it.skipIf(!bunAvailable)('ignores enclosing git repositories that are not latchkey', () => {
+    const unrelatedRepository = join(tempDir, 'unrelated');
+    mkdirSync(unrelatedRepository);
+    execFileSync('git', ['init', '--quiet'], { cwd: unrelatedRepository });
+
+    const result = runShim(['--version'], {
+      cwd: unrelatedRepository,
+      env: { LATCHKEY_DIRECTORY: latchkeyDirectory },
+    });
+
+    expect(result.stderr).toBe('');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe(projectVersion);
+  });
+
+  it('runs the built output under node when bun is not on PATH', () => {
+    const fakeCheckout = join(tempDir, 'fake-checkout');
+    mkdirSync(fakeCheckout);
+    createFakeLatchkeyCheckout(fakeCheckout);
+    mkdirSync(join(fakeCheckout, 'dist', 'src'), { recursive: true });
+    writeFileSync(
+      join(fakeCheckout, 'dist', 'src', 'cli.js'),
+      "console.log('fake-cli dist build');\n"
+    );
+
+    const result = runShim([], { cwd: fakeCheckout, env: { PATH: pathWithoutBun } });
+
+    expect(result.stderr).toBe('');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('fake-cli dist build');
+  });
+
+  it('runs the built output when LATCHKEY_DEV_SHIM_USE_DIST is set', () => {
+    const fakeCheckout = join(tempDir, 'fake-checkout');
+    mkdirSync(fakeCheckout);
+    createFakeLatchkeyCheckout(fakeCheckout);
+    mkdirSync(join(fakeCheckout, 'dist', 'src'), { recursive: true });
+    writeFileSync(
+      join(fakeCheckout, 'dist', 'src', 'cli.js'),
+      "console.log('fake-cli dist build');\n"
+    );
+
+    const result = runShim([], { cwd: fakeCheckout, env: { LATCHKEY_DEV_SHIM_USE_DIST: '1' } });
+
+    expect(result.stderr).toBe('');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('fake-cli dist build');
+  });
+
+  it('fails with a build instruction when bun is not on PATH and dist is missing', () => {
+    const fakeCheckout = join(tempDir, 'fake-checkout');
+    mkdirSync(fakeCheckout);
+    createFakeLatchkeyCheckout(fakeCheckout);
+
+    const result = runShim([], { cwd: fakeCheckout, env: { PATH: pathWithoutBun } });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('npm run build');
+  });
+
+  it('fails with an install instruction when the checkout has no node_modules', () => {
+    const fakeCheckout = join(tempDir, 'fake-checkout');
+    mkdirSync(fakeCheckout);
+    createFakeLatchkeyCheckout(fakeCheckout);
+    rmSync(join(fakeCheckout, 'node_modules'), { recursive: true });
+
+    const result = runShim([], { cwd: fakeCheckout });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('npm install');
+  });
+});


### PR DESCRIPTION
## Problem

The development setup in `docs/development.md` routes `latchkey` through a global install (`npm install && npm run build && npm link`). That has two silent failure modes:

1. **Stale builds.** The global bin points at `dist/src/cli.js`, which is gitignored and only refreshed by an explicit rebuild — after editing `src/`, the CLI on PATH keeps running the old build with no warning.
2. **One pinned checkout.** The link targets a single clone. Working in a worktree or a second clone, `latchkey` still silently runs the original tree.

## Change

`scripts/latchkey`, an opt-in dev shim (plus tests and a `docs/development.md` section):

- Resolves the latchkey checkout containing the current directory (git toplevel with `src/cli.ts` and `"name": "latchkey"` in `package.json`), so worktrees and secondary clones are automatically correct. Outside any checkout, it falls back to the checkout the shim itself lives in, discovered from the shim's own path — no hard-coded path.
- Runs `src/cli.ts` directly under bun, so edits are live with no build step. bun is already a repo dependency of sorts (`bun.lock`, the `bun-compile` script, `scripts/releaseBinaries.sh`).
- Falls back to `node dist/src/cli.js` when bun is not on PATH, or when `LATCHKEY_DEV_SHIM_USE_DIST=1` is set, so bun never becomes a hard requirement for development; if `dist/` is missing there, it fails with the exact command to run. This does nudge bun toward being the de-facto dev runtime — the fallback is deliberate so it stays a convenience, not a dependency.
- Generates the gitignored `src/version.ts` (via `scripts/generateVersion.js`) when missing, so fresh worktrees work with zero setup.
- Portable across macOS and Linux (hand-rolled `readlink -f`, since macOS ships no GNU readlink); shellcheck-clean.

The published npm package is unaffected: `scripts/` is not in `package.json#files`, and `bin` still points at `dist/src/cli.js`.

## Playwright under bun

Browser flows were verified under the bun path on bun 1.3.5 with playwright ~1.60.0 (macOS):

- The exact launch cycle `withTempBrowserContext` uses — `chromium.launch` (with `executablePath`, the automation-tell flags) → `newContext` → page navigation → `context.storageState` → `close` — succeeds under bun with output identical to a node control run (headless; a headed interactive login was not exercised in this environment).
- `playwright-core/lib/coreBundle` (registry + `extractZip`, used by `ensure-browser`/download) loads under bun.
- Real CLI runs from source under bun: `--version`, `services list`, and `ensure-browser` end-to-end against a sandboxed `LATCHKEY_DIRECTORY`.

If a bun/playwright incompatibility does surface on some machine, `LATCHKEY_DEV_SHIM_USE_DIST=1` routes that machine back to node + `dist/` without uninstalling anything.

Running the TS source under node directly is not an option: node's type stripping does not map the codebase's `.js` import specifiers to `.ts` files (`node src/cli.ts` fails with `ERR_MODULE_NOT_FOUND` on `./cliCommands.js`), so node remains the compiled-output runtime.

## Tests

`tests/devShim.test.ts` executes the actual shim script: cwd-checkout resolution running the real CLI from source, live source edits visible across runs with no build, fallback to the shim's own checkout from outside any repo (through a symlink, as installed), ignoring enclosing non-latchkey git repos, the node + `dist/` fallback (via both a bun-less PATH and `LATCHKEY_DEV_SHIM_USE_DIST=1`), and both failure messages. bun-dependent cases skip when bun is absent; the fallback and error cases are runtime-independent.

`npm run lint`, `npm run typecheck`, `npm run format:check`, and `npm test` (538 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
