### PR TITLE
auth list: survive corrupt credential store entries

### DIFF
--- a/src/apiCredentials/base.ts
+++ b/src/apiCredentials/base.ts
@@ -9,6 +9,8 @@ export enum ApiCredentialStatus {
   Valid = 'valid',
   Invalid = 'invalid',
   Unknown = 'unknown',
+  /** The stored credential data does not match any known credential schema. */
+  Corrupt = 'corrupt',
 }
 
 /**

--- a/src/apiCredentials/store.ts
+++ b/src/apiCredentials/store.ts
@@ -21,7 +21,7 @@ export class ApiCredentialStoreError extends Error {
 type StoreData = Record<string, unknown>;
 
 /** A store entry whose data does not match any known credential schema. */
-export interface BrokenCredentialEntry {
+export interface CorruptCredentialEntry {
   /** The entry's claimed objectType, or null when it is missing or not a string. */
   readonly objectType: string | null;
   readonly error: string;
@@ -29,7 +29,7 @@ export interface BrokenCredentialEntry {
 
 export interface CredentialStoreListing {
   readonly credentials: ReadonlyMap<string, ApiCredentials>;
-  readonly brokenEntries: ReadonlyMap<string, BrokenCredentialEntry>;
+  readonly corruptEntries: ReadonlyMap<string, CorruptCredentialEntry>;
 }
 
 export function corruptEntryRemedy(serviceName: string): string {
@@ -115,16 +115,16 @@ export class ApiCredentialStore {
 
   /**
    * Load all entries, parsing each one independently: entries that do not match
-   * any known credential schema are returned in brokenEntries.
+   * any known credential schema are returned in corruptEntries.
    */
   getAll(): CredentialStoreListing {
     const data = this.loadStoreData();
     const credentials = new Map<string, ApiCredentials>();
-    const brokenEntries = new Map<string, BrokenCredentialEntry>();
+    const corruptEntries = new Map<string, CorruptCredentialEntry>();
     for (const [serviceName, credentialData] of Object.entries(data)) {
       const parseResult = ApiCredentialsSchema.safeParse(credentialData);
       if (!parseResult.success) {
-        brokenEntries.set(serviceName, {
+        corruptEntries.set(serviceName, {
           objectType: extractObjectType(credentialData),
           error: formatSchemaIssues(parseResult.error),
         });
@@ -132,7 +132,7 @@ export class ApiCredentialStore {
       }
       credentials.set(serviceName, deserializeCredentials(parseResult.data));
     }
-    return { credentials, brokenEntries };
+    return { credentials, corruptEntries };
   }
 
   delete(serviceName: string): boolean {

--- a/src/apiCredentials/store.ts
+++ b/src/apiCredentials/store.ts
@@ -32,6 +32,10 @@ export interface CredentialStoreListing {
   readonly brokenEntries: ReadonlyMap<string, BrokenCredentialEntry>;
 }
 
+export function corruptEntryRemedy(serviceName: string): string {
+  return `Run 'latchkey auth clear ${serviceName}' to remove the corrupt entry.`;
+}
+
 function formatSchemaIssues(error: ZodError): string {
   return error.issues
     .map((issue) =>
@@ -96,7 +100,7 @@ export class ApiCredentialStore {
     if (!parseResult.success) {
       throw new ApiCredentialStoreError(
         `Invalid credential data for service ${serviceName}: ${formatSchemaIssues(parseResult.error)}. ` +
-          `Run 'latchkey auth clear ${serviceName}' to remove the corrupt entry.`
+          corruptEntryRemedy(serviceName)
       );
     }
 

--- a/src/apiCredentials/store.ts
+++ b/src/apiCredentials/store.ts
@@ -2,6 +2,7 @@
  * API credential store for persisting and loading API credentials.
  */
 
+import type { ZodError } from 'zod';
 import type { ApiCredentials } from './base.js';
 import {
   ApiCredentialsSchema,
@@ -18,6 +19,38 @@ export class ApiCredentialStoreError extends Error {
 }
 
 type StoreData = Record<string, unknown>;
+
+/** A store entry whose data does not match any known credential schema. */
+export interface BrokenCredentialEntry {
+  /** The entry's claimed objectType, or null when it is missing or not a string. */
+  readonly objectType: string | null;
+  readonly error: string;
+}
+
+export interface CredentialStoreListing {
+  readonly credentials: ReadonlyMap<string, ApiCredentials>;
+  readonly brokenEntries: ReadonlyMap<string, BrokenCredentialEntry>;
+}
+
+function formatSchemaIssues(error: ZodError): string {
+  return error.issues
+    .map((issue) =>
+      issue.path.length > 0 ? `${issue.path.join('.')}: ${issue.message}` : issue.message
+    )
+    .join('; ');
+}
+
+function extractObjectType(credentialData: unknown): string | null {
+  if (
+    typeof credentialData === 'object' &&
+    credentialData !== null &&
+    'objectType' in credentialData &&
+    typeof (credentialData as { objectType: unknown }).objectType === 'string'
+  ) {
+    return (credentialData as { objectType: string }).objectType;
+  }
+  return null;
+}
 
 export class ApiCredentialStore {
   readonly path: string;
@@ -62,7 +95,8 @@ export class ApiCredentialStore {
     const parseResult = ApiCredentialsSchema.safeParse(credentialData);
     if (!parseResult.success) {
       throw new ApiCredentialStoreError(
-        `Invalid credential data for service ${serviceName}: ${parseResult.error.message}`
+        `Invalid credential data for service ${serviceName}: ${formatSchemaIssues(parseResult.error)}. ` +
+          `Run 'latchkey auth clear ${serviceName}' to remove the corrupt entry.`
       );
     }
 
@@ -75,19 +109,26 @@ export class ApiCredentialStore {
     this.saveStoreData(data);
   }
 
-  getAll(): ReadonlyMap<string, ApiCredentials> {
+  /**
+   * Load all entries, parsing each one independently: entries that do not match
+   * any known credential schema are returned in brokenEntries.
+   */
+  getAll(): CredentialStoreListing {
     const data = this.loadStoreData();
-    const result = new Map<string, ApiCredentials>();
+    const credentials = new Map<string, ApiCredentials>();
+    const brokenEntries = new Map<string, BrokenCredentialEntry>();
     for (const [serviceName, credentialData] of Object.entries(data)) {
       const parseResult = ApiCredentialsSchema.safeParse(credentialData);
       if (!parseResult.success) {
-        throw new ApiCredentialStoreError(
-          `Invalid credential data for service ${serviceName}: ${parseResult.error.message}`
-        );
+        brokenEntries.set(serviceName, {
+          objectType: extractObjectType(credentialData),
+          error: formatSchemaIssues(parseResult.error),
+        });
+        continue;
       }
-      result.set(serviceName, deserializeCredentials(parseResult.data));
+      credentials.set(serviceName, deserializeCredentials(parseResult.data));
     }
-    return result;
+    return { credentials, brokenEntries };
   }
 
   delete(serviceName: string): boolean {

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -239,25 +239,27 @@ async function createEncryptedStorageFromConfig(config: Config): Promise<Encrypt
 }
 
 async function clearService(deps: CliDependencies, serviceName: string): Promise<void> {
-  const service = deps.registry.getByName(serviceName);
-  if (service === null) {
-    deps.errorLog(`Error: Unknown service: ${serviceName}`);
-    deps.errorLog("Use 'latchkey services list' to see available services.");
-    deps.exit(1);
-  }
-
   const encryptedStorage = await createEncryptedStorageFromConfig(deps.config);
   const apiCredentialStore = new ApiCredentialStore(
     deps.config.credentialStorePath,
     encryptedStorage
   );
+  // Store entries can exist for services absent from the registry, so the
+  // delete is attempted before any registry lookup.
   const deleted = apiCredentialStore.delete(serviceName);
 
   if (deleted) {
     deps.log(`API credentials for ${serviceName} have been cleared.`);
-  } else {
-    deps.log(`No API credentials found for ${serviceName}.`);
+    return;
   }
+
+  if (deps.registry.getByName(serviceName) === null) {
+    deps.errorLog(`Error: Unknown service: ${serviceName}`);
+    deps.errorLog("Use 'latchkey services list' to see available services.");
+    deps.exit(1);
+  }
+
+  deps.log(`No API credentials found for ${serviceName}.`);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export { SlackApiCredentials } from './services/slack.js';
 export {
   ApiCredentialStore,
   ApiCredentialStoreError,
-  BrokenCredentialEntry,
+  CorruptCredentialEntry,
   CredentialStoreListing,
 } from './apiCredentials/store.js';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,12 @@ export {
 export { deserializeCredentials, serializeCredentials } from './apiCredentials/serialization.js';
 export { SlackApiCredentials } from './services/slack.js';
 
-export { ApiCredentialStore, ApiCredentialStoreError } from './apiCredentials/store.js';
+export {
+  ApiCredentialStore,
+  ApiCredentialStoreError,
+  BrokenCredentialEntry,
+  CredentialStoreListing,
+} from './apiCredentials/store.js';
 
 export { Config, CONFIG, InsecureFilePermissionsError } from './config.js';
 

--- a/src/sharedOperations.ts
+++ b/src/sharedOperations.ts
@@ -7,7 +7,7 @@
  */
 
 import { ApiCredentialStatus } from './apiCredentials/base.js';
-import type { ApiCredentialStore } from './apiCredentials/store.js';
+import { corruptEntryRemedy, type ApiCredentialStore } from './apiCredentials/store.js';
 import { getCredentialStatus } from './apiCredentials/utils.js';
 import type { Config } from './config.js';
 import { loadBrowserConfig } from './configDataStore.js';
@@ -176,9 +176,7 @@ export async function authList(
     entries.set(serviceName, {
       credentialType: brokenEntry.objectType ?? 'unknown',
       credentialStatus: ApiCredentialStatus.Corrupt,
-      error:
-        `${brokenEntry.error}. ` +
-        `Run 'latchkey auth clear ${serviceName}' to remove the corrupt entry.`,
+      error: `${brokenEntry.error}. ${corruptEntryRemedy(serviceName)}`,
     });
   }
   // Object.fromEntries creates own properties, so a service name like

--- a/src/sharedOperations.ts
+++ b/src/sharedOperations.ts
@@ -96,7 +96,7 @@ export function servicesList(
   }
 
   if (options.viable === true) {
-    const allCredentials = apiCredentialStore.getAll();
+    const allCredentials = apiCredentialStore.getAll().credentials;
     services = services.filter((service) => {
       if (allCredentials.has(service.name)) {
         return true;
@@ -145,17 +145,22 @@ export async function servicesInfo(
   };
 }
 
+export interface AuthListEntry {
+  readonly credentialType: string;
+  readonly credentialStatus: ApiCredentialStatus;
+  /** Only present for corrupt entries: what is wrong and how to remove the entry. */
+  readonly error?: string;
+}
+
 export async function authList(
   registry: ServiceRegistry,
   apiCredentialStore: ApiCredentialStore
-): Promise<Record<string, { credentialType: string; credentialStatus: ApiCredentialStatus }>> {
-  const allCredentials = apiCredentialStore.getAll();
+): Promise<Record<string, AuthListEntry>> {
+  const { credentials: allCredentials, brokenEntries } = apiCredentialStore.getAll();
 
   const statusChecks = Array.from(
     allCredentials,
-    async ([serviceName, credentials]): Promise<
-      readonly [string, { credentialType: string; credentialStatus: ApiCredentialStatus }]
-    > => {
+    async ([serviceName, credentials]): Promise<readonly [string, AuthListEntry]> => {
       const service = registry.getByName(serviceName);
       const credentialStatus =
         service !== null
@@ -166,7 +171,19 @@ export async function authList(
     }
   );
 
-  return Object.fromEntries(await Promise.all(statusChecks));
+  const entries = new Map<string, AuthListEntry>(await Promise.all(statusChecks));
+  for (const [serviceName, brokenEntry] of brokenEntries) {
+    entries.set(serviceName, {
+      credentialType: brokenEntry.objectType ?? 'unknown',
+      credentialStatus: ApiCredentialStatus.Corrupt,
+      error:
+        `${brokenEntry.error}. ` +
+        `Run 'latchkey auth clear ${serviceName}' to remove the corrupt entry.`,
+    });
+  }
+  // Object.fromEntries creates own properties, so a service name like
+  // '__proto__' still becomes a visible row.
+  return Object.fromEntries(entries);
 }
 
 export async function authBrowser(

--- a/src/sharedOperations.ts
+++ b/src/sharedOperations.ts
@@ -156,7 +156,7 @@ export async function authList(
   registry: ServiceRegistry,
   apiCredentialStore: ApiCredentialStore
 ): Promise<Record<string, AuthListEntry>> {
-  const { credentials: allCredentials, brokenEntries } = apiCredentialStore.getAll();
+  const { credentials: allCredentials, corruptEntries } = apiCredentialStore.getAll();
 
   const statusChecks = Array.from(
     allCredentials,
@@ -172,11 +172,11 @@ export async function authList(
   );
 
   const entries = new Map<string, AuthListEntry>(await Promise.all(statusChecks));
-  for (const [serviceName, brokenEntry] of brokenEntries) {
+  for (const [serviceName, corruptEntry] of corruptEntries) {
     entries.set(serviceName, {
-      credentialType: brokenEntry.objectType ?? 'unknown',
+      credentialType: corruptEntry.objectType ?? 'unknown',
       credentialStatus: ApiCredentialStatus.Corrupt,
-      error: `${brokenEntry.error}. ${corruptEntryRemedy(serviceName)}`,
+      error: `${corruptEntry.error}. ${corruptEntryRemedy(serviceName)}`,
     });
   }
   // Object.fromEntries creates own properties, so a service name like

--- a/tests/apiCredentialStore.test.ts
+++ b/tests/apiCredentialStore.test.ts
@@ -79,20 +79,20 @@ describe('ApiCredentialStore', () => {
   });
 
   describe('getAll', () => {
-    it('should return all valid credentials with no broken entries', () => {
+    it('should return all valid credentials with no corrupt entries', () => {
       const store = new ApiCredentialStore(storePath, encryptedStorage);
       store.save('github', new AuthorizationBearer('github-token'));
       store.save('discord', new AuthorizationBare('discord-token'));
 
-      const { credentials, brokenEntries } = store.getAll();
+      const { credentials, corruptEntries } = store.getAll();
 
       expect(credentials.size).toBe(2);
       expect(credentials.get('github')).toBeInstanceOf(AuthorizationBearer);
       expect(credentials.get('discord')).toBeInstanceOf(AuthorizationBare);
-      expect(brokenEntries.size).toBe(0);
+      expect(corruptEntries.size).toBe(0);
     });
 
-    it('should report a corrupt entry as broken and keep the valid ones', () => {
+    it('should report a corrupt entry and keep the valid ones', () => {
       encryptedStorage.writeFile(
         storePath,
         JSON.stringify({
@@ -102,39 +102,39 @@ describe('ApiCredentialStore', () => {
       );
       const store = new ApiCredentialStore(storePath, encryptedStorage);
 
-      const { credentials, brokenEntries } = store.getAll();
+      const { credentials, corruptEntries } = store.getAll();
 
       expect(credentials.size).toBe(1);
       expect(credentials.get('github')).toBeInstanceOf(AuthorizationBearer);
-      expect(brokenEntries.size).toBe(1);
-      const brokenEntry = brokenEntries.get('databricks');
-      expect(brokenEntry?.objectType).toBe('databricksOauth');
-      expect(brokenEntry?.error).toContain('objectType');
+      expect(corruptEntries.size).toBe(1);
+      const corruptEntry = corruptEntries.get('databricks');
+      expect(corruptEntry?.objectType).toBe('databricksOauth');
+      expect(corruptEntry?.error).toContain('objectType');
     });
 
-    it('should report a known credential type with missing fields as broken', () => {
+    it('should report a known credential type with missing fields as corrupt', () => {
       encryptedStorage.writeFile(
         storePath,
         JSON.stringify({ github: { objectType: 'authorizationBearer' } })
       );
       const store = new ApiCredentialStore(storePath, encryptedStorage);
 
-      const { credentials, brokenEntries } = store.getAll();
+      const { credentials, corruptEntries } = store.getAll();
 
       expect(credentials.size).toBe(0);
-      const brokenEntry = brokenEntries.get('github');
-      expect(brokenEntry?.objectType).toBe('authorizationBearer');
-      expect(brokenEntry?.error).toContain('token');
+      const corruptEntry = corruptEntries.get('github');
+      expect(corruptEntry?.objectType).toBe('authorizationBearer');
+      expect(corruptEntry?.error).toContain('token');
     });
 
-    it('should report a non-object entry as broken with a null objectType', () => {
+    it('should report a non-object entry as corrupt with a null objectType', () => {
       encryptedStorage.writeFile(storePath, JSON.stringify({ github: 'not-an-object' }));
       const store = new ApiCredentialStore(storePath, encryptedStorage);
 
-      const { credentials, brokenEntries } = store.getAll();
+      const { credentials, corruptEntries } = store.getAll();
 
       expect(credentials.size).toBe(0);
-      expect(brokenEntries.get('github')?.objectType).toBeNull();
+      expect(corruptEntries.get('github')?.objectType).toBeNull();
     });
   });
 

--- a/tests/apiCredentialStore.test.ts
+++ b/tests/apiCredentialStore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { ApiCredentialStore } from '../src/apiCredentials/store.js';
+import { ApiCredentialStore, ApiCredentialStoreError } from '../src/apiCredentials/store.js';
 import { AuthorizationBearer, AuthorizationBare } from '../src/apiCredentials/base.js';
 import { SlackApiCredentials } from '../src/services/slack.js';
 import { EncryptedStorage } from '../src/encryptedStorage.js';
@@ -64,6 +64,77 @@ describe('ApiCredentialStore', () => {
       expect(retrieved).toBeInstanceOf(SlackApiCredentials);
       expect((retrieved as SlackApiCredentials).token).toBe('xoxc-token');
       expect((retrieved as SlackApiCredentials).dCookie).toBe('d-cookie');
+    });
+
+    it('should throw an error naming the remedy for a corrupt entry', () => {
+      encryptedStorage.writeFile(
+        storePath,
+        JSON.stringify({ databricks: { objectType: 'databricksOauth', accessToken: 'stale' } })
+      );
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+
+      expect(() => store.get('databricks')).toThrow(ApiCredentialStoreError);
+      expect(() => store.get('databricks')).toThrow('latchkey auth clear databricks');
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return all valid credentials with no broken entries', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      store.save('github', new AuthorizationBearer('github-token'));
+      store.save('discord', new AuthorizationBare('discord-token'));
+
+      const { credentials, brokenEntries } = store.getAll();
+
+      expect(credentials.size).toBe(2);
+      expect(credentials.get('github')).toBeInstanceOf(AuthorizationBearer);
+      expect(credentials.get('discord')).toBeInstanceOf(AuthorizationBare);
+      expect(brokenEntries.size).toBe(0);
+    });
+
+    it('should report a corrupt entry as broken and keep the valid ones', () => {
+      encryptedStorage.writeFile(
+        storePath,
+        JSON.stringify({
+          databricks: { objectType: 'databricksOauth', accessToken: 'stale' },
+          github: { objectType: 'authorizationBearer', token: 'github-token' },
+        })
+      );
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+
+      const { credentials, brokenEntries } = store.getAll();
+
+      expect(credentials.size).toBe(1);
+      expect(credentials.get('github')).toBeInstanceOf(AuthorizationBearer);
+      expect(brokenEntries.size).toBe(1);
+      const brokenEntry = brokenEntries.get('databricks');
+      expect(brokenEntry?.objectType).toBe('databricksOauth');
+      expect(brokenEntry?.error).toContain('objectType');
+    });
+
+    it('should report a known credential type with missing fields as broken', () => {
+      encryptedStorage.writeFile(
+        storePath,
+        JSON.stringify({ github: { objectType: 'authorizationBearer' } })
+      );
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+
+      const { credentials, brokenEntries } = store.getAll();
+
+      expect(credentials.size).toBe(0);
+      const brokenEntry = brokenEntries.get('github');
+      expect(brokenEntry?.objectType).toBe('authorizationBearer');
+      expect(brokenEntry?.error).toContain('token');
+    });
+
+    it('should report a non-object entry as broken with a null objectType', () => {
+      encryptedStorage.writeFile(storePath, JSON.stringify({ github: 'not-an-object' }));
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+
+      const { credentials, brokenEntries } = store.getAll();
+
+      expect(credentials.size).toBe(0);
+      expect(brokenEntries.get('github')?.objectType).toBeNull();
     });
   });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -824,6 +824,27 @@ describe('CLI commands with dependency injection', () => {
       expect(errorLogs.length).toBeGreaterThan(0);
     });
 
+    it('should delete a corrupt entry for a service not in the registry', async () => {
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(
+        storePath,
+        JSON.stringify({
+          slack: { objectType: 'slack', token: 'slack-token', dCookie: 'slack-cookie' },
+          databricks: { objectType: 'databricksOauth', accessToken: 'stale' },
+        })
+      );
+
+      const deps = createMockDependencies();
+
+      await runCommand(['auth', 'clear', 'databricks'], deps);
+
+      expect(exitCode).toBeNull();
+      expect(logs).toContain('API credentials for databricks have been cleared.');
+      const storedData = JSON.parse(readSecureFile(storePath) ?? '{}') as StoredCredentials;
+      expect(storedData.databricks).toBeUndefined();
+      expect(storedData.slack).toBeDefined();
+    });
+
     it('should preserve other services when clearing one', async () => {
       const storePath = join(tempDir, 'credentials.json');
       writeSecureFile(
@@ -913,6 +934,33 @@ describe('CLI commands with dependency injection', () => {
         credentialType: 'rawCurl',
         credentialStatus: 'valid',
       });
+    });
+
+    it('should list valid credentials and flag a corrupt entry instead of crashing', async () => {
+      const storePath = join(tempDir, 'credentials.json');
+      writeSecureFile(
+        storePath,
+        JSON.stringify({
+          slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
+          databricks: { objectType: 'databricksOauth', accessToken: 'stale' },
+        })
+      );
+
+      const deps = createMockDependencies();
+      await runCommand(['auth', 'list'], deps);
+
+      expect(exitCode).toBeNull();
+      expect(logs).toHaveLength(1);
+      const entries = JSON.parse(logs[0] ?? '') as Record<
+        string,
+        { credentialType: string; credentialStatus: string; error?: string }
+      >;
+      expect(entries.slack).toEqual({
+        credentialType: 'slack',
+        credentialStatus: 'valid',
+      });
+      expect(entries.databricks?.credentialStatus).toBe('corrupt');
+      expect(entries.databricks?.error).toContain('latchkey auth clear databricks');
     });
   });
 

--- a/tests/latchkeyEndpoint.test.ts
+++ b/tests/latchkeyEndpoint.test.ts
@@ -353,7 +353,10 @@ describe('/latchkey/ endpoint', () => {
 
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
-        result: Record<string, { credentialType: string; credentialStatus: string; error?: string }>;
+        result: Record<
+          string,
+          { credentialType: string; credentialStatus: string; error?: string }
+        >;
       };
       expect(body.result.slack).toEqual({
         credentialType: 'slack',

--- a/tests/latchkeyEndpoint.test.ts
+++ b/tests/latchkeyEndpoint.test.ts
@@ -343,6 +343,25 @@ describe('/latchkey/ endpoint', () => {
         credentialStatus: 'valid',
       });
     });
+
+    it('should flag a corrupt entry instead of failing the whole listing', async () => {
+      gateway = await createTestGateway({
+        slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
+        databricks: { objectType: 'databricksOauth', accessToken: 'stale' },
+      });
+      const response = await postLatchkey({ command: 'auth list' });
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        result: Record<string, { credentialType: string; credentialStatus: string; error?: string }>;
+      };
+      expect(body.result.slack).toEqual({
+        credentialType: 'slack',
+        credentialStatus: 'valid',
+      });
+      expect(body.result.databricks?.credentialStatus).toBe('corrupt');
+      expect(body.result.databricks?.error).toContain('latchkey auth clear databricks');
+    });
   });
 
   describe('auth browser', () => {

--- a/tests/sharedOperations.test.ts
+++ b/tests/sharedOperations.test.ts
@@ -131,6 +131,20 @@ describe('operations', () => {
 
       expect(result).not.toContain('nologin');
     });
+
+    it('should keep viable filtering working when the store contains a corrupt entry', () => {
+      const service = createMockService({ name: 'slack', getSession: undefined });
+      const registry = new ServiceRegistry([service]);
+      const store = createApiCredentialStore({
+        slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
+        databricks: { objectType: 'databricksOauth', accessToken: 'stale' },
+      });
+      const config = createMockConfig({ browserDisabled: true } as Partial<Config>);
+
+      const result = servicesList(registry, store, config, { viable: true });
+
+      expect(result).toContain('slack');
+    });
   });
 
   describe('servicesInfo', () => {
@@ -221,6 +235,38 @@ describe('operations', () => {
         credentialType: 'rawCurl',
         credentialStatus: 'valid',
       });
+    });
+
+    it('should list valid credentials and flag a corrupt entry instead of throwing', async () => {
+      const service = createMockService();
+      const registry = new ServiceRegistry([service]);
+      const store = createApiCredentialStore({
+        slack: { objectType: 'slack', token: 'test-token', dCookie: 'test-cookie' },
+        databricks: { objectType: 'databricksOauth', accessToken: 'stale' },
+      });
+
+      const result = await authList(registry, store);
+
+      expect(result.slack).toEqual({
+        credentialType: 'slack',
+        credentialStatus: 'valid',
+      });
+      expect(result.databricks?.credentialType).toBe('databricksOauth');
+      expect(result.databricks?.credentialStatus).toBe('corrupt');
+      expect(result.databricks?.error).toContain('objectType');
+      expect(result.databricks?.error).toContain('latchkey auth clear databricks');
+    });
+
+    it('should flag a corrupt entry named __proto__ as a visible row', async () => {
+      const registry = new ServiceRegistry([]);
+      const store = createApiCredentialStore({
+        ['__proto__']: { objectType: 17 },
+      });
+
+      const result = await authList(registry, store);
+
+      const rows = new Map(Object.entries(result));
+      expect(rows.get('__proto__')?.credentialStatus).toBe('corrupt');
     });
   });
 


### PR DESCRIPTION
## Problem

One malformed entry in the credential store crashed `latchkey auth list` entirely:

```
ApiCredentialStoreError: Invalid credential data for service databricks: [invalid_union_discriminator]
```

`ApiCredentialStore.getAll()` threw on the first entry that failed schema parsing, so a single stale/corrupt entry hid every other credential — exactly when the listing is needed to find the bad entry — and the error named no remedy. `services list --viable` shares `getAll()` and crashed the same way.

## Fix

The parse-tolerance lives at the store layer, since both readers of `getAll()` are read-only diagnostics and schema/version skew belongs at the deserialization layer:

- **`getAll()`** now parses each entry independently and returns `{ credentials, brokenEntries }`. Broken entries carry the claimed `objectType` (the key diagnostic under version skew) and a compact per-field parse error. Nothing is swallowed — every failure is surfaced to the caller.
- **`authList`** emits a broken entry as a visible row: `credentialStatus: "corrupt"` (new `ApiCredentialStatus` member), the claimed type, and an `error` naming the remedy. Rows are built through a `Map` so a store key like `__proto__` cannot vanish via the object prototype setter.
- **`services list --viable`** treats a corrupt credential as non-viable (it cannot be injected into a request) instead of crashing; `auth list` is the diagnostic that flags it.
- **`auth clear <service>`** now deletes by store key before consulting the registry. A corrupt entry commonly belongs to a service the running version does not know, and the registry-first check rejected exactly those names with "Unknown service" — making the advertised remedy impossible to run. Unknown names with nothing stored still fail as before.
- **`get()`** (single-service reads) still throws loudly, but its error now names the same remedy.

Note: this changes the return shape of the public `getAll()`; the new `BrokenCredentialEntry` / `CredentialStoreListing` types are exported from the package index. Both in-repo callers are updated; external callers get a compile error rather than a behavior change.

`services info` on a corrupt entry still crashes via the `get()` path (pre-existing); left out to keep this PR single-purpose.

## Tests

Real malformed fixtures (no mocked parse errors) at all four layers: store unit tests, `authList`/`servicesList` operation tests, CLI command test, and gateway endpoint test. Nine of the new tests fail on the code before this change. One fixture orders the corrupt entry before a valid one so a stop-at-first-corrupt regression cannot pass. A CLI test seeds a corrupt entry for an unregistered service and asserts the advertised `auth clear` remedy actually removes it.

Verified end-to-end with the built CLI: `auth list` over a store containing a corrupt entry exits 0, lists the valid credentials, flags the corrupt one with the remedy; running the remedy removes only that entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

