### PR TITLE
Add Hugging Face connector

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -77,16 +77,13 @@ Every service must include an `info` property that provides developer notes. Thi
 - Special requirements (e.g., need to run `latchkey auth browser-prepare` first)
 - Any caveats or limitations
 
-Keep the `info` text about the *service* itself, not the Detent scopes or
-permission names an agent might request. Latchkey is intentionally fairly
-standalone: it matches URLs and injects credentials, and it does not know which
-scopes a service exposes. Scopes and permissions are defined in
-[Detent](https://github.com/imbue-ai/detent) (the enforcement layer), which is
-aware of Latchkey and is where those names belong. Pointing an agent at the
-service's own documentation (e.g. an `llms.txt` index) lets it discover the right
-endpoint and capability for the task instead of baking Detent's vocabulary into
-the connector. The same applies to comments on the `Service` class: describe what
-the token can do, not which Detent permissions it backs.
+Keep `info` about the service itself -- links to its own docs, caveats, special
+requirements -- not the Detent scopes or permission names an agent might request.
+Latchkey only matches URLs and injects credentials; scopes live in
+[Detent](https://github.com/imbue-ai/detent), the enforcement layer, which is the
+side that knows about Latchkey. Point agents at the service's own documentation
+(e.g. an `llms.txt` index) rather than baking Detent's vocabulary into the
+connector. The same applies to comments on the `Service` class.
 
 ### Potentially useful helpers
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -77,6 +77,17 @@ Every service must include an `info` property that provides developer notes. Thi
 - Special requirements (e.g., need to run `latchkey auth browser-prepare` first)
 - Any caveats or limitations
 
+Keep the `info` text about the *service* itself, not the Detent scopes or
+permission names an agent might request. Latchkey is intentionally fairly
+standalone: it matches URLs and injects credentials, and it does not know which
+scopes a service exposes. Scopes and permissions are defined in
+[Detent](https://github.com/imbue-ai/detent) (the enforcement layer), which is
+aware of Latchkey and is where those names belong. Pointing an agent at the
+service's own documentation (e.g. an `llms.txt` index) lets it discover the right
+endpoint and capability for the task instead of baking Detent's vocabulary into
+the connector. The same applies to comments on the `Service` class: describe what
+the token can do, not which Detent permissions it backs.
+
 ### Potentially useful helpers
 
 #### Codegen

--- a/docs/development.md
+++ b/docs/development.md
@@ -78,9 +78,7 @@ Every service must include an `info` property that provides developer notes. Thi
 - Any caveats or limitations
 
 Keep `info` (and comments on the `Service` class) about the service itself, not
-the Detent scopes or permission names an agent might request. Scopes live in
-[Detent](https://github.com/imbue-ai/detent), which is the side that knows about
-Latchkey -- not the other way around.
+the Detent scopes or permission names (not everyone uses them).
 
 ### Potentially useful helpers
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -77,11 +77,10 @@ Every service must include an `info` property that provides developer notes. Thi
 - Special requirements (e.g., need to run `latchkey auth browser-prepare` first)
 - Any caveats or limitations
 
-Keep `info` about the service itself -- links to its own docs, caveats, special
-requirements -- not the Detent scopes or permission names an agent might
-request. Latchkey only matches URLs and injects credentials; scopes live in
+Keep `info` (and comments on the `Service` class) about the service itself, not
+the Detent scopes or permission names an agent might request. Scopes live in
 [Detent](https://github.com/imbue-ai/detent), which is the side that knows about
-Latchkey. The same applies to comments on the `Service` class.
+Latchkey -- not the other way around.
 
 ### Potentially useful helpers
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -78,12 +78,10 @@ Every service must include an `info` property that provides developer notes. Thi
 - Any caveats or limitations
 
 Keep `info` about the service itself -- links to its own docs, caveats, special
-requirements -- not the Detent scopes or permission names an agent might request.
-Latchkey only matches URLs and injects credentials; scopes live in
-[Detent](https://github.com/imbue-ai/detent), the enforcement layer, which is the
-side that knows about Latchkey. Point agents at the service's own documentation
-(e.g. an `llms.txt` index) rather than baking Detent's vocabulary into the
-connector. The same applies to comments on the `Service` class.
+requirements -- not the Detent scopes or permission names an agent might
+request. Latchkey only matches URLs and injects credentials; scopes live in
+[Detent](https://github.com/imbue-ai/detent), which is the side that knows about
+Latchkey. The same applies to comments on the `Service` class.
 
 ### Potentially useful helpers
 

--- a/skills/generic/latchkey/SKILL.md
+++ b/skills/generic/latchkey/SKILL.md
@@ -126,7 +126,7 @@ in the key means "unknown account".
 
 Latchkey currently offers varying levels of support for the
 following services: AWS, Calendly, Coolify, Discord, Dropbox, Figma, GitHub, GitLab,
-Gmail, Google Analytics, Google Calendar, Google Docs, Google Drive, Google Sheets,
+Gmail, Google Analytics, Google Calendar, Google Docs, Google Drive, Google Sheets, Hugging Face,
 Linear, Mailchimp, ngrok, Notion, Ramp, Sentry, Slack, Stripe, Telegram, Todoist, Umami, Yelp, Zoom, and more.
 
 ### User-registered services

--- a/skills/openclaw/latchkey/SKILL.md
+++ b/skills/openclaw/latchkey/SKILL.md
@@ -118,7 +118,7 @@ in the key means "unknown account".
 
 Latchkey currently offers varying levels of support for the
 following services: AWS, Calendly, Coolify, Discord, Dropbox, Figma, GitHub, GitLab,
-Gmail, Google Analytics, Google Calendar, Google Docs, Google Drive, Google Sheets,
+Gmail, Google Analytics, Google Calendar, Google Docs, Google Drive, Google Sheets, Hugging Face,
 Linear, Mailchimp, ngrok, Notion, Ramp, Sentry, Slack, Stripe, Telegram, Todoist, Umami, Yelp, Zoom, and more.
 
 ### User-registered services

--- a/src/serviceRegistry.ts
+++ b/src/serviceRegistry.ts
@@ -38,8 +38,7 @@ import {
   UMAMI,
   RAMP,
   TODOIST,
-  NGROK,
-} from './services/index.js';
+  NGROK, HUGGINGFACE } from './services/index.js';
 
 export class DuplicateServiceNameError extends Error {
   constructor(name: string) {
@@ -239,4 +238,5 @@ export const SERVICE_REGISTRY = new ServiceRegistry([
   RAMP,
   TODOIST,
   NGROK,
+  HUGGINGFACE,
 ]);

--- a/src/serviceRegistry.ts
+++ b/src/serviceRegistry.ts
@@ -38,7 +38,9 @@ import {
   UMAMI,
   RAMP,
   TODOIST,
-  NGROK, HUGGINGFACE } from './services/index.js';
+  NGROK,
+  HUGGINGFACE,
+} from './services/index.js';
 
 export class DuplicateServiceNameError extends Error {
   constructor(name: string) {

--- a/src/services/huggingface.ts
+++ b/src/services/huggingface.ts
@@ -94,7 +94,8 @@ class HuggingfaceServiceSession extends BrowserFollowupServiceSession {
     await nameInput.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
     await typeLikeHuman(page, nameInput, tokenName);
 
-    const createButton = page.locator('button[type="submit"]', { hasText: 'Create token' });
+    // Locale-independent: the create button is the submit inside the token-name form.
+    const createButton = page.locator('form:has(input[name="displayName"]) button[type="submit"]');
     await createButton.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
     await createButton.click();
 
@@ -117,7 +118,14 @@ export class Huggingface extends Service {
   readonly displayName = 'Hugging Face';
   readonly baseApiUrls = [HF_HUB_BASE_URL, HF_ROUTER_BASE_URL] as const;
   readonly loginUrl = HF_LOGIN_URL;
-  readonly info = 'https://huggingface.co/docs/hub/en/api';
+  // Signing in mints a read-only User Access Token. To mint and run hosted
+  // inference, request the `huggingface-api` scope with `huggingface-inference`
+  // (add `huggingface-read` to list/download models & datasets; `huggingface-write`
+  // covers creating repos and uploading).
+  readonly info =
+    'Hugging Face Hub + Inference. Signing in mints a read-only token. To mint and run ' +
+    'hosted inference, request the huggingface-api scope with huggingface-inference (add ' +
+    'huggingface-read to download models/datasets). Docs: https://huggingface.co/docs/hub/en/api';
 
   // whoami-v2 returns 200 for any valid token; the stored bearer header is
   // added by the credential before the request is sent.

--- a/src/services/huggingface.ts
+++ b/src/services/huggingface.ts
@@ -123,9 +123,10 @@ export class Huggingface extends Service {
   // (add `huggingface-read` to list/download models & datasets; `huggingface-write`
   // covers creating repos and uploading).
   readonly info =
-    'Hugging Face Hub + Inference. Signing in mints a read-only token. To mint and run ' +
-    'hosted inference, request the huggingface-api scope with huggingface-inference (add ' +
-    'huggingface-read to download models/datasets). Docs: https://huggingface.co/docs/hub/en/api';
+    'Hugging Face Hub + Inference. Signing in mints a read-only token. Request the ' +
+    'huggingface-api scope with huggingface-read (list and download models/datasets), ' +
+    'huggingface-write (create repos, upload), or huggingface-inference (run hosted ' +
+    'inference). Docs: https://huggingface.co/docs/hub/en/api';
 
   // whoami-v2 returns 200 for any valid token; the stored bearer header is
   // added by the credential before the request is sent.

--- a/src/services/huggingface.ts
+++ b/src/services/huggingface.ts
@@ -26,7 +26,10 @@ import {
   LoginFailedError,
 } from './core/base.js';
 
-const DEFAULT_TIMEOUT_MS = 8000;
+// Token creation can lag behind a slow sign-in or an extra confirmation step
+// (a write token sometimes prompts before revealing), so this is more generous
+// than the 8s default other services use for quick form interactions.
+const DEFAULT_TIMEOUT_MS = 30000;
 
 // Hub API + Inference router. Hub model/dataset downloads and the whoami check
 // live under huggingface.co; hosted inference goes through the router.

--- a/src/services/huggingface.ts
+++ b/src/services/huggingface.ts
@@ -31,10 +31,22 @@ import {
 // than the 8s default other services use for quick form interactions.
 const DEFAULT_TIMEOUT_MS = 30000;
 
-// Hub API + Inference router. Hub model/dataset downloads and the whoami check
-// live under huggingface.co; hosted inference goes through the router.
+// Hub API + Inference router. The Hub API, repository file and git transfers and
+// the whoami check live under huggingface.co (hf.co is an alias for the same
+// host); hosted inference goes through the router, and the dataset viewer has
+// its own host.
 const HF_HUB_BASE_URL = 'https://huggingface.co/';
+const HF_HUB_ALIAS_BASE_URL = 'https://hf.co/';
 const HF_ROUTER_BASE_URL = 'https://router.huggingface.co/';
+const HF_DATASETS_SERVER_BASE_URL = 'https://datasets-server.huggingface.co/';
+
+// Deliberately not covered: the storage hosts that file transfers are redirected
+// to (*.cdn.hf.co, cdn-lfs*.hf.co and the Xet hosts). They authenticate through
+// the URL itself -- a signed CDN URL, or a repository-scoped Xet token the caller
+// fetches from the hub -- so there is nothing for this service to contribute, and
+// adding a bearer header there is at best ignored and at worst fatal (the Xet CAS
+// server answers 400 once a second Authorization header shows up). Such requests
+// need no credentials, so callers can make them directly.
 
 const HF_LOGIN_URL = 'https://huggingface.co/login';
 
@@ -131,7 +143,12 @@ class HuggingfaceServiceSession extends BrowserFollowupServiceSession {
 export class Huggingface extends Service {
   readonly name = 'huggingface';
   readonly displayName = 'Hugging Face';
-  readonly baseApiUrls = [HF_HUB_BASE_URL, HF_ROUTER_BASE_URL] as const;
+  readonly baseApiUrls = [
+    HF_HUB_BASE_URL,
+    HF_HUB_ALIAS_BASE_URL,
+    HF_ROUTER_BASE_URL,
+    HF_DATASETS_SERVER_BASE_URL,
+  ] as const;
   readonly loginUrl = HF_LOGIN_URL;
   readonly info =
     'Hugging Face Hub + Inference: download models and datasets, manage ' +

--- a/src/services/huggingface.ts
+++ b/src/services/huggingface.ts
@@ -40,7 +40,10 @@ const HF_LOGIN_URL = 'https://huggingface.co/login';
 
 // Navigating here opens the "Create new Access Token" form preset to a classic
 // write token (read + write, and a valid bearer for inference); the value is
-// shown once in a dialog after creation.
+// shown once in a dialog after creation. The settings page can trigger HF's
+// "sudo" re-authentication, so we bring the page to the front first (see
+// performBrowserFollowup) so the password prompt doesn't land on a tab the
+// user isn't looking at.
 const HF_NEW_TOKEN_URL = 'https://huggingface.co/settings/tokens/new?tokenType=write';
 
 // Endpoint that returns the signed-in identity; also used as the credential check.
@@ -94,6 +97,10 @@ class HuggingfaceServiceSession extends BrowserFollowupServiceSession {
       throw new LoginFailedError('No page available in browser context.');
     }
 
+    // The token settings page can trigger HF's "sudo" re-authentication; focus the
+    // page first so the password prompt surfaces on the tab the user is looking
+    // at, not a background one.
+    await page.bringToFront();
     await page.goto(HF_NEW_TOKEN_URL);
 
     // Give the token a recognizable name so the user can find and revoke it.
@@ -126,11 +133,6 @@ export class Huggingface extends Service {
   readonly displayName = 'Hugging Face';
   readonly baseApiUrls = [HF_HUB_BASE_URL, HF_ROUTER_BASE_URL] as const;
   readonly loginUrl = HF_LOGIN_URL;
-  // The `info` text is what an agent reads to decide whether this service is
-  // useful. Keep it about the *service*, not the Detent scopes/permissions --
-  // those are Detent's concern and only loosely connected to Latchkey (see
-  // DEVELOPING.md). Point agents at the docs index so they can find the right
-  // page for the task they have in mind.
   readonly info =
     'Hugging Face Hub + Inference: download models and datasets, manage ' +
     'repositories, and run hosted inference. Docs: https://huggingface.co/docs/hub/llms.txt';

--- a/src/services/huggingface.ts
+++ b/src/services/huggingface.ts
@@ -1,0 +1,146 @@
+/**
+ * Hugging Face service implementation.
+ *
+ * Hugging Face issues personal User Access Tokens from the account settings,
+ * and a token's value is revealed exactly once at creation time (like Linear).
+ * We sign the user into huggingface.co, create a fresh read-only token on their
+ * behalf, and read its value from the one-time reveal dialog.
+ *
+ * Requests to the Hub API and the Inference router authenticate with a single
+ * `Authorization: Bearer hf_...` header, so we store an AuthorizationBearer
+ * credential and let it inject that header into every matching request.
+ */
+
+import type { Response, BrowserContext } from 'playwright';
+import { ApiCredentials, AuthorizationBearer } from '../apiCredentials/base.js';
+import { fetchAccountFromEndpoint, tryParseJson } from '../apiCredentials/account.js';
+import { typeLikeHuman } from '../playwrightUtils.js';
+import {
+  Service,
+  BrowserFollowupServiceSession,
+  FollowupWork,
+  LoginFailedError,
+} from './core/base.js';
+
+const DEFAULT_TIMEOUT_MS = 8000;
+
+// Hub API + Inference router. Hub model/dataset downloads and the whoami check
+// live under huggingface.co; hosted inference goes through the router.
+const HF_HUB_BASE_URL = 'https://huggingface.co/';
+const HF_ROUTER_BASE_URL = 'https://router.huggingface.co/';
+
+const HF_LOGIN_URL = 'https://huggingface.co/login';
+
+// Navigating here opens the "Create new Access Token" form preset to a
+// read-only token; the value is shown once in a dialog after creation.
+const HF_NEW_READ_TOKEN_URL = 'https://huggingface.co/settings/tokens/new?tokenType=read';
+
+// Endpoint that returns the signed-in identity; also used as the credential check.
+const HF_WHOAMI_URL = 'https://huggingface.co/api/whoami-v2';
+
+// Hub host, and the path prefixes served before the user is signed in. A
+// document response to the hub host on any *other* path only happens once login
+// has succeeded, so we use it as the login-complete signal (works the same for
+// a password or SSO sign-in, since the final redirect target is a hub page).
+const HF_HUB_HOST = 'huggingface.co';
+const HF_PRE_LOGIN_PATH_PATTERN = /^\/(login|join|signup|oauth|sso|auth|logout)/i;
+
+class HuggingfaceServiceSession extends BrowserFollowupServiceSession {
+  protected readonly followupWork = FollowupWork.CreateApiToken;
+  private isLoggedIn = false;
+
+  onResponse(response: Response): void {
+    if (this.isLoggedIn) {
+      return;
+    }
+    if (response.request().resourceType() !== 'document') {
+      return;
+    }
+    let url: URL;
+    try {
+      url = new URL(response.url());
+    } catch {
+      return;
+    }
+    if (url.hostname !== HF_HUB_HOST) {
+      return;
+    }
+    if (HF_PRE_LOGIN_PATH_PATTERN.test(url.pathname)) {
+      return;
+    }
+    if (response.status() >= 200 && response.status() < 400) {
+      this.isLoggedIn = true;
+    }
+  }
+
+  protected isLoginComplete(): boolean {
+    return this.isLoggedIn;
+  }
+
+  protected async performBrowserFollowup(
+    context: BrowserContext,
+    _oldCredentials?: ApiCredentials
+  ): Promise<ApiCredentials | null> {
+    const page = context.pages()[0];
+    if (!page) {
+      throw new LoginFailedError('No page available in browser context.');
+    }
+
+    await page.goto(HF_NEW_READ_TOKEN_URL);
+
+    // Give the token a recognizable name so the user can find and revoke it.
+    const tokenName = this.generateAppName();
+    const nameInput = page.locator('input[name="displayName"]');
+    await nameInput.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+    await typeLikeHuman(page, nameInput, tokenName);
+
+    const createButton = page.locator('button[type="submit"]', { hasText: 'Create token' });
+    await createButton.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+    await createButton.click();
+
+    // The new token is revealed exactly once, inside the success dialog. Its
+    // value sits in a text input; Hugging Face tokens are prefixed `hf_`.
+    const tokenInput = page.locator('dialog input').first();
+    await tokenInput.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+    const token = (await tokenInput.inputValue()).trim();
+    if (token === '' || !token.startsWith('hf_')) {
+      throw new LoginFailedError('Failed to extract access token from Hugging Face.');
+    }
+
+    await page.close();
+    return new AuthorizationBearer(token);
+  }
+}
+
+export class Huggingface extends Service {
+  readonly name = 'huggingface';
+  readonly displayName = 'Hugging Face';
+  readonly baseApiUrls = [HF_HUB_BASE_URL, HF_ROUTER_BASE_URL] as const;
+  readonly loginUrl = HF_LOGIN_URL;
+  readonly info = 'https://huggingface.co/docs/hub/en/api';
+
+  // whoami-v2 returns 200 for any valid token; the stored bearer header is
+  // added by the credential before the request is sent.
+  readonly credentialCheckCurlArguments = [HF_WHOAMI_URL] as const;
+
+  setCredentialsExample(serviceName: string): string {
+    return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    return fetchAccountFromEndpoint(
+      apiCredentials,
+      this.credentialCheckCurlArguments,
+      (responseBody) => {
+        const data = tryParseJson(responseBody) as { name?: string; email?: string } | null;
+        return data?.name ?? data?.email ?? null;
+      }
+    );
+  }
+
+  override getSession(appNamePrefix: string): HuggingfaceServiceSession {
+    return new HuggingfaceServiceSession(this, appNamePrefix);
+  }
+}
+
+export const HUGGINGFACE = new Huggingface();

--- a/src/services/huggingface.ts
+++ b/src/services/huggingface.ts
@@ -3,10 +3,14 @@
  *
  * Hugging Face issues personal User Access Tokens from the account settings,
  * and a token's value is revealed exactly once at creation time (like Linear).
- * We sign the user into huggingface.co, create a fresh read-only token on their
- * behalf, and read its value from the one-time reveal dialog.
+ * We sign the user into huggingface.co, create a fresh token on their behalf,
+ * and read its value from the one-time reveal dialog.
  *
- * Requests to the Hub API and the Inference router authenticate with a single
+ * A classic `write` token grants read and write access to the user's
+ * repositories and also serves as a bearer token for the Inference Providers
+ * router, so one minted token is capable of everything an agent might do
+ * through this service (download, upload, run inference). Requests to the Hub
+ * API and the Inference router authenticate with a single
  * `Authorization: Bearer hf_...` header, so we store an AuthorizationBearer
  * credential and let it inject that header into every matching request.
  */
@@ -31,9 +35,10 @@ const HF_ROUTER_BASE_URL = 'https://router.huggingface.co/';
 
 const HF_LOGIN_URL = 'https://huggingface.co/login';
 
-// Navigating here opens the "Create new Access Token" form preset to a
-// read-only token; the value is shown once in a dialog after creation.
-const HF_NEW_READ_TOKEN_URL = 'https://huggingface.co/settings/tokens/new?tokenType=read';
+// Navigating here opens the "Create new Access Token" form preset to a classic
+// write token (read + write, and a valid bearer for inference); the value is
+// shown once in a dialog after creation.
+const HF_NEW_TOKEN_URL = 'https://huggingface.co/settings/tokens/new?tokenType=write';
 
 // Endpoint that returns the signed-in identity; also used as the credential check.
 const HF_WHOAMI_URL = 'https://huggingface.co/api/whoami-v2';
@@ -86,7 +91,7 @@ class HuggingfaceServiceSession extends BrowserFollowupServiceSession {
       throw new LoginFailedError('No page available in browser context.');
     }
 
-    await page.goto(HF_NEW_READ_TOKEN_URL);
+    await page.goto(HF_NEW_TOKEN_URL);
 
     // Give the token a recognizable name so the user can find and revoke it.
     const tokenName = this.generateAppName();
@@ -118,15 +123,14 @@ export class Huggingface extends Service {
   readonly displayName = 'Hugging Face';
   readonly baseApiUrls = [HF_HUB_BASE_URL, HF_ROUTER_BASE_URL] as const;
   readonly loginUrl = HF_LOGIN_URL;
-  // Signing in mints a read-only User Access Token. To mint and run hosted
-  // inference, request the `huggingface-api` scope with `huggingface-inference`
-  // (add `huggingface-read` to list/download models & datasets; `huggingface-write`
-  // covers creating repos and uploading).
+  // The `info` text is what an agent reads to decide whether this service is
+  // useful. Keep it about the *service*, not the Detent scopes/permissions --
+  // those are Detent's concern and only loosely connected to Latchkey (see
+  // DEVELOPING.md). Point agents at the docs index so they can find the right
+  // page for the task they have in mind.
   readonly info =
-    'Hugging Face Hub + Inference. Signing in mints a read-only token. Request the ' +
-    'huggingface-api scope with huggingface-read (list and download models/datasets), ' +
-    'huggingface-write (create repos, upload), or huggingface-inference (run hosted ' +
-    'inference). Docs: https://huggingface.co/docs/hub/en/api';
+    'Hugging Face Hub + Inference: download models and datasets, manage ' +
+    'repositories, and run hosted inference. Docs: https://huggingface.co/docs/hub/llms.txt';
 
   // whoami-v2 returns 200 for any valid token; the stored bearer header is
   // added by the credential before the request is sent.

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -65,3 +65,4 @@ export { Umami, UMAMI } from './umami.js';
 export { Ramp, RAMP } from './ramp.js';
 export { Todoist, TODOIST } from './todoist.js';
 export { Ngrok, NGROK } from './ngrok.js';
+export { Huggingface, HUGGINGFACE } from './huggingface.js';

--- a/tests/huggingface.test.ts
+++ b/tests/huggingface.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { HUGGINGFACE } from '../src/services/huggingface.js';
+import { SERVICE_REGISTRY } from '../src/serviceRegistry.js';
+import type { Service } from '../src/services/core/base.js';
+
+function primaryServiceForUrl(url: string): Service | null {
+  return SERVICE_REGISTRY.getByUrl(url);
+}
+
+describe('Hugging Face URL matching', () => {
+  it('matches the Hub API on both hub hostnames', () => {
+    expect(primaryServiceForUrl('https://huggingface.co/api/whoami-v2')).toBe(HUGGINGFACE);
+    expect(primaryServiceForUrl('https://hf.co/api/models?limit=1')).toBe(HUGGINGFACE);
+  });
+
+  it('matches repository file transfers and git endpoints', () => {
+    expect(
+      primaryServiceForUrl('https://huggingface.co/openai-community/gpt2/resolve/main/config.json')
+    ).toBe(HUGGINGFACE);
+    expect(
+      primaryServiceForUrl(
+        'https://huggingface.co/owner/repo.git/info/refs?service=git-upload-pack'
+      )
+    ).toBe(HUGGINGFACE);
+  });
+
+  it('matches the inference router and the dataset viewer', () => {
+    expect(primaryServiceForUrl('https://router.huggingface.co/v1/chat/completions')).toBe(
+      HUGGINGFACE
+    );
+    expect(primaryServiceForUrl('https://datasets-server.huggingface.co/rows?dataset=x')).toBe(
+      HUGGINGFACE
+    );
+  });
+
+  // Redirected file transfers are authenticated by the URL itself, so the
+  // storage hosts are left to the caller: a bearer header would be pointless
+  // there, and the Xet CAS server even rejects the request once it sees a
+  // second Authorization header.
+  it('does not match the storage hosts that transfers are redirected to', () => {
+    expect(
+      primaryServiceForUrl('https://us.aws.cdn.hf.co/xet-bridge-us/abc?Expires=1&Signature=x')
+    ).toBeNull();
+    expect(primaryServiceForUrl('https://cdn-lfs.hf.co/repos/aa/bb/file?Expires=1')).toBeNull();
+    expect(primaryServiceForUrl('https://cdn-lfs-us-1.hf.co/repos/aa/bb/file')).toBeNull();
+    expect(primaryServiceForUrl('https://cas-server.xethub.hf.co/reconstruction/abc')).toBeNull();
+    expect(primaryServiceForUrl('https://transfer.xethub.hf.co/xorbs/default/abc')).toBeNull();
+  });
+
+  it('does not match unrelated hosts, including hosted Spaces', () => {
+    expect(primaryServiceForUrl('https://myspace.hf.space/api/predict')).toBeNull();
+    expect(primaryServiceForUrl('https://hf.co.example.com/api/models')).toBeNull();
+  });
+});

--- a/tests/servicesAgainstRecordings.test.ts
+++ b/tests/servicesAgainstRecordings.test.ts
@@ -43,7 +43,7 @@ const DEFAULT_RECORDING_NAME = 'login_session.json';
 // from the dashboard's "New API Key" dialog, exactly like linear).
 // NOTE: todoist is also a BrowserFollowupServiceSession and arguably belongs here
 // too; it predates this list and is left as-is to keep this change scoped.
-const BLACKLIST = new Set(['dropbox', 'github', 'linear', 'ngrok']);
+const BLACKLIST = new Set(['dropbox', 'github', 'linear', 'ngrok', 'huggingface']);
 
 class InvalidRecordingError extends Error {
   constructor(message: string) {

--- a/tests/servicesAgainstRecordings.test.ts
+++ b/tests/servicesAgainstRecordings.test.ts
@@ -39,8 +39,8 @@ const DEFAULT_RECORDING_NAME = 'login_session.json';
 // Do not test services that require special followup steps: their credential is
 // minted by an interactive browser action (a BrowserFollowupServiceSession) and
 // is not present in the recorded login network traffic, so replaying a recording
-// cannot reconstruct it. ngrok is such a service (its API key is created and read
-// from the dashboard's "New API Key" dialog, exactly like linear).
+// cannot reconstruct it. ngrok and huggingface are such services -- their token
+// is created and read from a one-time reveal dialog, exactly like linear.
 // NOTE: todoist is also a BrowserFollowupServiceSession and arguably belongs here
 // too; it predates this list and is left as-is to keep this change scoped.
 const BLACKLIST = new Set(['dropbox', 'github', 'linear', 'ngrok', 'huggingface']);


### PR DESCRIPTION
Adds a Hugging Face service connector: sign-in mints a read-only User Access Token (revealed once, scraped from the reveal dialog, like Linear); stored as a bearer credential; matches the Hub (`huggingface.co`) and the Inference router (`router.huggingface.co`). `getAccount` reports the username via `/api/whoami-v2`. Listed in SKILL.md; blacklisted from `servicesAgainstRecordings` (browser-followup service).

## Usage (scopes, defined in imbue-ai/detent#23)
- **Download models/datasets:** `huggingface-api` + `huggingface-read` (safe methods incl. the HEAD before a download).
- **Run inference:** `huggingface-api` + `huggingface-inference` (POST to the router).
- **Create repos / upload:** `huggingface-api` + `huggingface-write` (Hub writes only).

## Verified live
Browser login minted a sealed read-only token; downloads work (`GET`/`HEAD resolve` -> 200), writes are denied under a read grant (403), inference reaches the router. Token never leaves the gateway. lint/typecheck/format/`npm test` (758) green.

Needs a Detent release + dependency bump to ship (as ngrok did in #113).
