### PR TITLE
openrouter: add OpenRouter connector

### DIFF
--- a/skills/generic/latchkey/SKILL.md
+++ b/skills/generic/latchkey/SKILL.md
@@ -127,7 +127,7 @@ in the key means "unknown account".
 Latchkey currently offers varying levels of support for the
 following services: AWS, Calendly, Coolify, Discord, Dropbox, Figma, GitHub, GitLab,
 Gmail, Google Analytics, Google Calendar, Google Docs, Google Drive, Google Sheets,
-Linear, Mailchimp, ngrok, Notion, Ramp, Sentry, Slack, Stripe, Telegram, Todoist, Umami, Yelp, Zoom, and more.
+Linear, Mailchimp, ngrok, Notion, OpenRouter, Ramp, Sentry, Slack, Stripe, Telegram, Todoist, Umami, Yelp, Zoom, and more.
 
 ### User-registered services
 

--- a/skills/openclaw/latchkey/SKILL.md
+++ b/skills/openclaw/latchkey/SKILL.md
@@ -119,7 +119,7 @@ in the key means "unknown account".
 Latchkey currently offers varying levels of support for the
 following services: AWS, Calendly, Coolify, Discord, Dropbox, Figma, GitHub, GitLab,
 Gmail, Google Analytics, Google Calendar, Google Docs, Google Drive, Google Sheets,
-Linear, Mailchimp, ngrok, Notion, Ramp, Sentry, Slack, Stripe, Telegram, Todoist, Umami, Yelp, Zoom, and more.
+Linear, Mailchimp, ngrok, Notion, OpenRouter, Ramp, Sentry, Slack, Stripe, Telegram, Todoist, Umami, Yelp, Zoom, and more.
 
 ### User-registered services
 

--- a/src/serviceRegistry.ts
+++ b/src/serviceRegistry.ts
@@ -39,6 +39,7 @@ import {
   RAMP,
   TODOIST,
   NGROK,
+  OPENROUTER,
 } from './services/index.js';
 
 export class DuplicateServiceNameError extends Error {
@@ -239,4 +240,5 @@ export const SERVICE_REGISTRY = new ServiceRegistry([
   RAMP,
   TODOIST,
   NGROK,
+  OPENROUTER,
 ]);

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -65,3 +65,4 @@ export { Umami, UMAMI } from './umami.js';
 export { Ramp, RAMP } from './ramp.js';
 export { Todoist, TODOIST } from './todoist.js';
 export { Ngrok, NGROK } from './ngrok.js';
+export { Openrouter, OPENROUTER } from './openrouter.js';

--- a/src/services/openrouter.ts
+++ b/src/services/openrouter.ts
@@ -1,0 +1,180 @@
+/**
+ * OpenRouter service implementation.
+ *
+ * OpenRouter issues personal API keys from the dashboard, and a key's value is
+ * revealed exactly once at creation time (like Linear). We sign the user into
+ * openrouter.ai, create a fresh API key on their behalf, and read its value from
+ * the one-time reveal dialog.
+ *
+ * The OpenRouter API is OpenAI-compatible: every request authenticates with a
+ * single `Authorization: Bearer sk-or-v1-...` header, so we store an
+ * AuthorizationBearer credential and let it inject that header into every
+ * matching request.
+ */
+
+import type { Response, BrowserContext } from 'playwright';
+import { ApiCredentials, AuthorizationBearer } from '../apiCredentials/base.js';
+import { typeLikeHuman } from '../playwrightUtils.js';
+import {
+  Service,
+  BrowserFollowupServiceSession,
+  FollowupWork,
+  LoginFailedError,
+} from './core/base.js';
+
+const DEFAULT_TIMEOUT_MS = 12000;
+
+// The OpenRouter REST API (OpenAI-compatible), served under /api/v1.
+const OPENROUTER_API_BASE_URL = 'https://openrouter.ai/api/v1/';
+
+const OPENROUTER_LOGIN_URL = 'https://openrouter.ai/sign-in';
+
+// The dashboard's API-keys page. It redirects to the workspace-scoped keys page
+// (/workspaces/<workspace>/keys); a plain goto follows that redirect.
+const OPENROUTER_KEYS_URL = 'https://openrouter.ai/keys';
+
+// GET /api/v1/key returns the calling key's metadata (label, usage, limit) and
+// answers 200 for any valid key, so it doubles as the credential check.
+const OPENROUTER_KEY_INFO_URL = 'https://openrouter.ai/api/v1/key';
+
+// Dashboard host, and the path prefixes served before the user is signed in. A
+// dashboard document response on any *other* path only happens once login has
+// succeeded, so we use it as the login-complete signal (works the same whether
+// the user signs in with a password or an SSO provider, since the final redirect
+// target is always a dashboard page). A new device also gets an email one-time
+// code under /sign-in, which this pattern keeps waiting through.
+const OPENROUTER_HOST = 'openrouter.ai';
+const OPENROUTER_PRE_LOGIN_PATH_PATTERN = /^\/(sign-in|sign-up|signin|signup|sso|oauth|auth)/i;
+
+// OpenRouter keys are prefixed `sk-or-v1-`; the reveal dialog renders the value
+// as plain text (not inside an input), so we extract it from the dialog text.
+const OPENROUTER_KEY_PATTERN = /sk-or-v1-[A-Za-z0-9-]+/;
+
+class OpenrouterServiceSession extends BrowserFollowupServiceSession {
+  protected readonly followupWork = FollowupWork.CreateApiToken;
+  private isLoggedIn = false;
+
+  onResponse(response: Response): void {
+    if (this.isLoggedIn) {
+      return;
+    }
+    if (response.request().resourceType() !== 'document') {
+      return;
+    }
+    let url: URL;
+    try {
+      url = new URL(response.url());
+    } catch {
+      return;
+    }
+    if (url.hostname !== OPENROUTER_HOST) {
+      return;
+    }
+    if (OPENROUTER_PRE_LOGIN_PATH_PATTERN.test(url.pathname)) {
+      return;
+    }
+    if (response.status() >= 200 && response.status() < 400) {
+      this.isLoggedIn = true;
+    }
+  }
+
+  protected isLoginComplete(): boolean {
+    return this.isLoggedIn;
+  }
+
+  protected async performBrowserFollowup(
+    context: BrowserContext,
+    _oldCredentials?: ApiCredentials
+  ): Promise<ApiCredentials | null> {
+    const page = context.pages()[0];
+    if (!page) {
+      throw new LoginFailedError('No page available in browser context.');
+    }
+
+    await page.goto(OPENROUTER_KEYS_URL, { waitUntil: 'domcontentloaded' });
+
+    // Open the "Create API Key" dialog. The keys page is a heavy client-rendered
+    // table, so the New Key button can sit in the DOM before React attaches its
+    // click handler; a too-early click is a no-op. Click until the dialog's name
+    // field actually appears (guarding against re-clicking an already-open
+    // dialog, whose overlay would swallow the click).
+    const newKeyButton = page.getByRole('button', { name: 'New Key' });
+    await newKeyButton.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+    const nameInput = page.locator('input#name');
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const alreadyOpen = await nameInput.isVisible().catch(() => false);
+      if (!alreadyOpen) {
+        await newKeyButton.click().catch(() => undefined);
+      }
+      try {
+        await nameInput.waitFor({ timeout: 3000 });
+        break;
+      } catch {
+        if (attempt === 4) {
+          throw new LoginFailedError('OpenRouter "New Key" dialog did not open.');
+        }
+      }
+    }
+
+    // Give the key a recognizable name so the user can find and revoke it.
+    const keyName = this.generateAppName();
+    await typeLikeHuman(page, nameInput, keyName);
+
+    // Scope to the named dialog: a bare [role="dialog"] is ambiguous on this page
+    // (it also matches a hidden email-verification dialog and a password-manager
+    // modal), which makes every locator under it strict-mode-fail. The dialog keeps
+    // this title through the reveal step. Its Create button stays disabled until the
+    // name is non-empty.
+    const dialog = page.getByRole('dialog', { name: 'Create API Key' });
+    const createButton = dialog.getByRole('button', { name: 'Create', exact: true });
+    await createButton.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+    await createButton.click();
+
+    // The same dialog then reveals the new key exactly once, as plain text.
+    await dialog.getByText('Your new key:').waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+    const dialogText = await dialog.innerText();
+    const match = OPENROUTER_KEY_PATTERN.exec(dialogText);
+    if (!match) {
+      throw new LoginFailedError('Failed to extract API key from OpenRouter.');
+    }
+
+    await page.close();
+    return new AuthorizationBearer(match[0]);
+  }
+}
+
+export class Openrouter extends Service {
+  readonly name = 'openrouter';
+  readonly displayName = 'OpenRouter';
+  readonly baseApiUrls = [OPENROUTER_API_BASE_URL] as const;
+  readonly loginUrl = OPENROUTER_LOGIN_URL;
+  // Signing in mints an OpenRouter API key. To run models, request the
+  // `openrouter-api` scope with `openrouter-inference` (POST chat/completions and
+  // completions, which consume credits); add `openrouter-read` to list models and
+  // read key/credit info, and `openrouter-write` to manage keys and settings.
+  readonly info =
+    'OpenRouter unified LLM API (OpenAI-compatible). Signing in mints an API key. ' +
+    'To run models, request the openrouter-api scope with openrouter-inference (POST ' +
+    'chat/completions; consumes credits). Add openrouter-read to list models and read ' +
+    'key/credit info. Docs: https://openrouter.ai/docs/api-reference/overview';
+
+  // GET /api/v1/key returns 200 for any valid key; the stored bearer header is
+  // added by the credential before the request is sent.
+  readonly credentialCheckCurlArguments = [OPENROUTER_KEY_INFO_URL] as const;
+
+  setCredentialsExample(serviceName: string): string {
+    return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  // An OpenRouter API key has no queryable user-identity endpoint, so the account
+  // is left as the default rather than guessed.
+  override getAccount(_apiCredentials: ApiCredentials): Promise<string | null> {
+    return Promise.resolve(null);
+  }
+
+  override getSession(appNamePrefix: string): OpenrouterServiceSession {
+    return new OpenrouterServiceSession(this, appNamePrefix);
+  }
+}
+
+export const OPENROUTER = new Openrouter();

--- a/src/services/openrouter.ts
+++ b/src/services/openrouter.ts
@@ -148,15 +148,8 @@ export class Openrouter extends Service {
   readonly displayName = 'OpenRouter';
   readonly baseApiUrls = [OPENROUTER_API_BASE_URL] as const;
   readonly loginUrl = OPENROUTER_LOGIN_URL;
-  // Signing in mints an OpenRouter API key. To run models, request the
-  // `openrouter-api` scope with `openrouter-inference` (POST chat/completions and
-  // completions, which consume credits); add `openrouter-read` to list models and
-  // read key/credit info, and `openrouter-write` to manage keys and settings.
   readonly info =
-    'OpenRouter unified LLM API (OpenAI-compatible). Signing in mints an API key. ' +
-    'To run models, request the openrouter-api scope with openrouter-inference (POST ' +
-    'chat/completions; consumes credits). Add openrouter-read to list models and read ' +
-    'key/credit info. Docs: https://openrouter.ai/docs/api-reference/overview';
+    'OpenRouter unified LLM API (OpenAI-compatible). Docs: https://openrouter.ai/docs/llms.txt';
 
   // GET /api/v1/key returns 200 for any valid key; the stored bearer header is
   // added by the credential before the request is sent.

--- a/tests/servicesAgainstRecordings.test.ts
+++ b/tests/servicesAgainstRecordings.test.ts
@@ -43,7 +43,7 @@ const DEFAULT_RECORDING_NAME = 'login_session.json';
 // from the dashboard's "New API Key" dialog, exactly like linear).
 // NOTE: todoist is also a BrowserFollowupServiceSession and arguably belongs here
 // too; it predates this list and is left as-is to keep this change scoped.
-const BLACKLIST = new Set(['dropbox', 'github', 'linear', 'ngrok']);
+const BLACKLIST = new Set(['dropbox', 'github', 'linear', 'ngrok', 'openrouter']);
 
 class InvalidRecordingError extends Error {
   constructor(message: string) {


### PR DESCRIPTION
Adds an OpenRouter connector: a browser login that mints a personal API key from the dashboard and stores it as an `Authorization: Bearer sk-or-v1-...` credential, so OpenRouter's OpenAI-compatible API can be funneled through the gateway with the key sealed.

- `src/services/openrouter.ts` — a `BrowserFollowupServiceSession`: signs in at `openrouter.ai/sign-in` (login-complete = an `openrouter.ai` document off the sign-in path), then mints a key from the "Create API Key" dialog and reads the one-time reveal (`sk-or-v1-...`). The dialog is scoped by accessible name to avoid a password-manager / leftover-modal clash, and the New Key click retries until the client-rendered dialog hydrates.
- Registered in `serviceRegistry.ts` + `services/index.ts`.
- Listed in the two `SKILL.md` service lists; blacklisted in the recordings test (a browser-followup connector with no recorded session, like linear/ngrok/huggingface).
- `getAccount` returns null (OpenRouter keys carry no queryable identity endpoint).
- `credentialCheckCurlArguments` = GET `/api/v1/key` (200 for any valid key).

Verified live end-to-end on a real Minds gateway: the browser login minted a sealed key, `POST /api/v1/chat/completions` returned 200, the key never entered the container (direct call 401), and granular scopes enforced (read 200 / non-inference write 403).

lint, typecheck, and 758 tests pass.

Pairs with the Detent scopes (imbue-ai/detent) and the mngr catalog entry (imbue-ai/mngr-internal). Mirrors the Hugging Face connector in #117.
