### PR TITLE
Add Tailscale connector

### DIFF
--- a/skills/generic/latchkey/SKILL.md
+++ b/skills/generic/latchkey/SKILL.md
@@ -127,7 +127,7 @@ in the key means "unknown account".
 Latchkey currently offers varying levels of support for the
 following services: AWS, Calendly, Coolify, Discord, Dropbox, Figma, GitHub, GitLab,
 Gmail, Google Analytics, Google Calendar, Google Docs, Google Drive, Google Sheets, Hugging Face,
-Linear, Mailchimp, ngrok, Notion, OpenRouter, Ramp, Sentry, Slack, Stripe, Telegram, Todoist, Umami, Yelp, Zoom, and more.
+Linear, Mailchimp, ngrok, Notion, OpenRouter, Ramp, Sentry, Slack, Stripe, Telegram, Tailscale, Todoist, Umami, Yelp, Zoom, and more.
 
 ### User-registered services
 

--- a/skills/openclaw/latchkey/SKILL.md
+++ b/skills/openclaw/latchkey/SKILL.md
@@ -119,7 +119,7 @@ in the key means "unknown account".
 Latchkey currently offers varying levels of support for the
 following services: AWS, Calendly, Coolify, Discord, Dropbox, Figma, GitHub, GitLab,
 Gmail, Google Analytics, Google Calendar, Google Docs, Google Drive, Google Sheets, Hugging Face,
-Linear, Mailchimp, ngrok, Notion, OpenRouter, Ramp, Sentry, Slack, Stripe, Telegram, Todoist, Umami, Yelp, Zoom, and more.
+Linear, Mailchimp, ngrok, Notion, OpenRouter, Ramp, Sentry, Slack, Stripe, Telegram, Tailscale, Todoist, Umami, Yelp, Zoom, and more.
 
 ### User-registered services
 

--- a/src/apiCredentials/serialization.ts
+++ b/src/apiCredentials/serialization.ts
@@ -26,6 +26,7 @@ import {
   ZoomServerToServerCredentials,
   ZoomServerToServerCredentialsSchema,
 } from '../services/zoom.js';
+import { TailscaleCredentials, TailscaleCredentialsSchema } from '../services/tailscale.js';
 
 /**
  * Union schema for all credential types.
@@ -40,6 +41,7 @@ export const ApiCredentialsSchema = z.discriminatedUnion('objectType', [
   AwsCredentialsSchema,
   GoogleApiKeyCredentialsSchema,
   ZoomServerToServerCredentialsSchema,
+  TailscaleCredentialsSchema,
 ]);
 
 export type ApiCredentialsData = z.infer<typeof ApiCredentialsSchema>;
@@ -67,6 +69,8 @@ export function deserializeCredentials(data: ApiCredentialsData): ApiCredentials
       return GoogleApiKeyCredentials.fromJSON(data);
     case 'zoomServerToServer':
       return ZoomServerToServerCredentials.fromJSON(data);
+    case 'tailscale':
+      return TailscaleCredentials.fromJSON(data);
     default: {
       const exhaustiveCheck: never = data;
       throw new ApiCredentialsSerializationError(
@@ -105,6 +109,9 @@ export function serializeCredentials(credentials: ApiCredentials): ApiCredential
     return credentials.toJSON();
   }
   if (credentials instanceof ZoomServerToServerCredentials) {
+    return credentials.toJSON();
+  }
+  if (credentials instanceof TailscaleCredentials) {
     return credentials.toJSON();
   }
   throw new ApiCredentialsSerializationError(`Unknown credential type: ${credentials.objectType}`);

--- a/src/serviceRegistry.ts
+++ b/src/serviceRegistry.ts
@@ -41,6 +41,7 @@ import {
   NGROK,
   HUGGINGFACE,
   OPENROUTER,
+  TAILSCALE,
 } from './services/index.js';
 
 export class DuplicateServiceNameError extends Error {
@@ -243,4 +244,5 @@ export const SERVICE_REGISTRY = new ServiceRegistry([
   NGROK,
   HUGGINGFACE,
   OPENROUTER,
+  TAILSCALE,
 ]);

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -67,3 +67,4 @@ export { Todoist, TODOIST } from './todoist.js';
 export { Ngrok, NGROK } from './ngrok.js';
 export { Huggingface, HUGGINGFACE } from './huggingface.js';
 export { Openrouter, OPENROUTER } from './openrouter.js';
+export { Tailscale, TAILSCALE } from './tailscale.js';

--- a/src/services/tailscale.ts
+++ b/src/services/tailscale.ts
@@ -1,0 +1,273 @@
+/**
+ * Tailscale service implementation.
+ *
+ * The Tailscale admin API (https://api.tailscale.com/api/v2/) authenticates with
+ * an API access token (`tskey-api-...`) that an Owner/Admin creates in the
+ * admin console's Keys page. The token's value is revealed exactly once at
+ * creation time (like Linear, HuggingFace and OpenRouter), so we sign the user
+ * into the admin console, generate a fresh access token on their behalf, and
+ * read its value from the one-time reveal dialog.
+ *
+ * A single API access token grants the full set of actions its owning user may
+ * perform: tailnet-wide user management (role changes, approval, suspension,
+ * deletion), device management, ACL/policy, DNS, and the minting of further
+ * keys (including the auth keys the `tailscale` CLI consumes to bring up
+ * nodes). It expires after at most 90 days, after which the user re-runs the
+ * browser login to mint a new one -- the token is static and is not refreshable.
+ */
+
+import type { Response, BrowserContext } from 'playwright';
+import { z } from 'zod';
+import { ApiCredentialStatus, ApiCredentials } from '../apiCredentials/base.js';
+import { typeLikeHuman } from '../playwrightUtils.js';
+import { runCapturedAsync } from '../curl.js';
+import {
+  Service,
+  BrowserFollowupServiceSession,
+  FollowupWork,
+  LoginFailedError,
+  isBrowserClosedError,
+  LoginCancelledError,
+} from './core/base.js';
+
+const DEFAULT_TIMEOUT_MS = 12000;
+
+// The Tailscale admin REST API.
+const TAILSCALE_API_BASE_URL = 'https://api.tailscale.com/';
+
+// `latchkey auth browser` opens this; it redirects to the SSO sign-in page and
+// then back to the admin console once the user is signed in.
+const TAILSCALE_LOGIN_URL = 'https://login.tailscale.com/admin';
+
+// The admin console's Keys page, where API access tokens are generated.
+const TAILSCALE_KEYS_URL = 'https://console.tailscale.com/admin/settings/keys';
+
+// The admin console host; a document response served from it means the user is
+// signed in (the sign-in flow itself is served from login.tailscale.com and the
+// SSO provider).
+const TAILSCALE_CONSOLE_HOST = 'console.tailscale.com';
+
+// GET /tailnet/{tailnet}/settings is a cheap read that answers 200 for any
+// valid token with the access the API access token carries (full user powers).
+// It doubles as the credential check once the tailnet is known.
+const TAILSCALE_SETTINGS_URL_PREFIX = 'https://api.tailscale.com/api/v2/tailnet/';
+
+// API access tokens are prefixed `tskey-api-`; the reveal dialog renders the
+// value as plain text (not inside an input).
+const TAILSCALE_TOKEN_PATTERN = /tskey-api-[A-Za-z0-9-]+/;
+
+/**
+ * Credentials for the Tailscale API: a static API access token plus the tailnet
+ * it belongs to. The tailnet is part of nearly every useful Tailscale API path
+ * and the API exposes no tailnet-independent way to validate a token, so the
+ * connector captures it at mint time (it is shown in the admin console's
+ * navigation) and stores it alongside the token.
+ */
+export const TailscaleCredentialsSchema = z.object({
+  objectType: z.literal('tailscale'),
+  token: z.string(),
+  tailnet: z.string(),
+});
+
+export type TailscaleCredentialsData = z.infer<typeof TailscaleCredentialsSchema>;
+
+export class TailscaleCredentials implements ApiCredentials {
+  readonly objectType = 'tailscale' as const;
+  readonly token: string;
+  readonly tailnet: string;
+
+  constructor(token: string, tailnet: string) {
+    this.token = token;
+    this.tailnet = tailnet;
+  }
+
+  injectIntoCurlCall(curlArguments: readonly string[]): Promise<readonly string[]> {
+    return Promise.resolve(['-H', `Authorization: Bearer ${this.token}`, ...curlArguments]);
+  }
+
+  // The token is static and its expiry date is not exposed in a parseable form
+  // at creation time; validity is determined by the live credential check
+  // rather than a local clock.
+  isExpired(): boolean | undefined {
+    return undefined;
+  }
+
+  toJSON(): TailscaleCredentialsData {
+    return {
+      objectType: this.objectType,
+      token: this.token,
+      tailnet: this.tailnet,
+    };
+  }
+
+  static fromJSON(data: TailscaleCredentialsData): TailscaleCredentials {
+    return new TailscaleCredentials(data.token, data.tailnet);
+  }
+}
+
+class TailscaleServiceSession extends BrowserFollowupServiceSession {
+  protected readonly followupWork = FollowupWork.CreateApiToken;
+  private isLoggedIn = false;
+
+  onResponse(response: Response): void {
+    if (this.isLoggedIn) {
+      return;
+    }
+    if (response.request().resourceType() !== 'document') {
+      return;
+    }
+    let url: URL;
+    try {
+      url = new URL(response.url());
+    } catch {
+      return;
+    }
+    if (url.hostname !== TAILSCALE_CONSOLE_HOST) {
+      return;
+    }
+    if (response.status() >= 200 && response.status() < 400) {
+      this.isLoggedIn = true;
+    }
+  }
+
+  protected isLoginComplete(): boolean {
+    return this.isLoggedIn;
+  }
+
+  protected async performBrowserFollowup(
+    context: BrowserContext,
+    _oldCredentials?: ApiCredentials
+  ): Promise<ApiCredentials | null> {
+    const page = context.pages()[0];
+    if (!page) {
+      throw new LoginFailedError('No page available in browser context.');
+    }
+
+    try {
+      await page.goto(TAILSCALE_KEYS_URL, { waitUntil: 'domcontentloaded' });
+
+      // The tailnet name is the first link in the admin shell's navigation; it
+      // is part of every useful API call, so read it before the mint dialog
+      // covers the page.
+      const tailnetLink = page.locator('#app-root a').first();
+      await tailnetLink.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+      const tailnet = (await tailnetLink.innerText()).trim();
+      if (!tailnet) {
+        throw new LoginFailedError('Failed to read the Tailscale tailnet name.');
+      }
+
+      // Open the "Generate API access token" dialog. There are two "Generate..."
+      // buttons on the Keys page (auth key and access token); the access-token
+      // one is labelled with a trailing ellipsis, which distinguishes it from
+      // the dialog's submit button.
+      const openButton = page.getByRole('button', { name: 'Generate access token\u2026' });
+      await openButton.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+      await openButton.click();
+
+      const mintDialog = page.getByRole('dialog', { name: 'Generate API access token' });
+      await mintDialog.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+
+      // Give the token a recognizable description so the user can find and
+      // revoke it from the Keys page.
+      const descriptionInput = mintDialog.getByPlaceholder(
+        'Add an optional description for the key.'
+      );
+      await descriptionInput.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+      await typeLikeHuman(page, descriptionInput, this.generateAppName());
+
+      // Expiration defaults to 90 days; leave it as-is.
+      const generateButton = mintDialog.getByRole('button', {
+        name: 'Generate access token',
+        exact: true,
+      });
+      await generateButton.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+      await generateButton.click();
+
+      // The same dialog is then reused to reveal the new token exactly once,
+      // as plain text.
+      const revealDialog = page.getByRole('dialog', { name: 'Generated new key' });
+      await revealDialog.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
+      const revealText = await revealDialog.innerText();
+      const match = TAILSCALE_TOKEN_PATTERN.exec(revealText);
+      if (!match) {
+        throw new LoginFailedError('Failed to extract the API access token from Tailscale.');
+      }
+
+      await page.close();
+      return new TailscaleCredentials(match[0], tailnet);
+    } catch (error: unknown) {
+      if (error instanceof Error && isBrowserClosedError(error)) {
+        throw new LoginCancelledError();
+      }
+      throw error;
+    }
+  }
+}
+
+export class Tailscale extends Service {
+  readonly name = 'tailscale';
+  readonly displayName = 'Tailscale';
+  readonly baseApiUrls = [TAILSCALE_API_BASE_URL] as const;
+  readonly loginUrl = TAILSCALE_LOGIN_URL;
+  readonly info =
+    'Tailscale admin API for tailnet-wide management (users, devices, policy, keys). ' +
+    'Docs: https://tailscale.com/docs/reference/tailscale-api and interactive ' +
+    'https://tailscale.com/api. A browser login mints an API access token (tskey-api) ' +
+    'that carries the full set of actions its owning user may perform and expires ' +
+    'after at most 90 days; re-run the login to mint a new one. Most endpoints are ' +
+    'scoped to a tailnet (e.g. /api/v2/tailnet/{tailnet}/users); the stored credential ' +
+    'remembers the tailnet seen at login.';
+
+  // The credential check needs the tailnet, which the static
+  // credentialCheckCurlArguments cannot carry, so checkApiCredentials is
+  // overridden below. This value is unused but satisfies the abstract member.
+  readonly credentialCheckCurlArguments = [TAILSCALE_SETTINGS_URL_PREFIX] as const;
+
+  override async checkApiCredentials(apiCredentials: ApiCredentials): Promise<ApiCredentialStatus> {
+    // The tailnet is needed to validate a token and is only carried by the
+    // browser-minted credential. A manually-set credential (e.g. `auth set -H
+    // "Authorization: Bearer ..."`) has no tailnet to build the check URL
+    // from, so its status cannot be determined locally; `latchkey curl` still
+    // injects it normally.
+    if (!(apiCredentials instanceof TailscaleCredentials)) {
+      return ApiCredentialStatus.Unknown;
+    }
+
+    const checkUrl = `${TAILSCALE_SETTINGS_URL_PREFIX}${encodeURIComponent(apiCredentials.tailnet)}/settings`;
+    const result = await runCapturedAsync(
+      [
+        '-s',
+        '-w',
+        '\n%{http_code}',
+        '-H',
+        `Authorization: Bearer ${apiCredentials.token}`,
+        checkUrl,
+      ],
+      10
+    );
+
+    // The `-w '\n%{http_code}'` above appends the status code as the final line.
+    const statusCode = result.stdout.slice(result.stdout.lastIndexOf('\n') + 1).trim();
+    return statusCode === '200' ? ApiCredentialStatus.Valid : ApiCredentialStatus.Invalid;
+  }
+
+  setCredentialsExample(serviceName: string): string {
+    return `latchkey auth set ${serviceName} -H "Authorization: Bearer <token>"`;
+  }
+
+  // The API access token is owned by the user who minted it but exposes no
+  // queryable "current user" endpoint; the tailnet it belongs to is the most
+  // meaningful account identifier available without an extra request.
+  override getAccount(apiCredentials: ApiCredentials): Promise<string | null> {
+    if (apiCredentials instanceof TailscaleCredentials) {
+      return Promise.resolve(apiCredentials.tailnet);
+    }
+    return Promise.resolve(null);
+  }
+
+  override getSession(appNamePrefix: string): TailscaleServiceSession {
+    return new TailscaleServiceSession(this, appNamePrefix);
+  }
+}
+
+export const TAILSCALE = new Tailscale();

--- a/src/services/tailscale.ts
+++ b/src/services/tailscale.ts
@@ -220,8 +220,8 @@ export class Tailscale extends Service {
 
   // The credential check needs the tailnet, which the static
   // credentialCheckCurlArguments cannot carry, so checkApiCredentials is
-  // overridden below. This value is unused but satisfies the abstract member.
-  readonly credentialCheckCurlArguments = [TAILSCALE_SETTINGS_URL_PREFIX] as const;
+  // overridden below and this value is unused (mirrors RegisteredService).
+  readonly credentialCheckCurlArguments = [] as const;
 
   override async checkApiCredentials(apiCredentials: ApiCredentials): Promise<ApiCredentialStatus> {
     // The tailnet is needed to validate a token and is only carried by the

--- a/tests/servicesAgainstRecordings.test.ts
+++ b/tests/servicesAgainstRecordings.test.ts
@@ -39,11 +39,20 @@ const DEFAULT_RECORDING_NAME = 'login_session.json';
 // Do not test services that require special followup steps: their credential is
 // minted by an interactive browser action (a BrowserFollowupServiceSession) and
 // is not present in the recorded login network traffic, so replaying a recording
-// cannot reconstruct it. ngrok, huggingface and openrouter are such services --
-// their token is created and read from a one-time reveal dialog, exactly like linear.
+// cannot reconstruct it. ngrok, huggingface, openrouter and tailscale are such
+// services -- their token is created and read from a one-time reveal dialog,
+// exactly like linear.
 // NOTE: todoist is also a BrowserFollowupServiceSession and arguably belongs here
 // too; it predates this list and is left as-is to keep this change scoped.
-const BLACKLIST = new Set(['dropbox', 'github', 'linear', 'ngrok', 'huggingface', 'openrouter']);
+const BLACKLIST = new Set([
+  'dropbox',
+  'github',
+  'linear',
+  'ngrok',
+  'huggingface',
+  'openrouter',
+  'tailscale',
+]);
 
 class InvalidRecordingError extends Error {
   constructor(message: string) {

--- a/tests/tailscale.test.ts
+++ b/tests/tailscale.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { TAILSCALE, TailscaleCredentials } from '../src/services/tailscale.js';
+import { ApiCredentialStatus } from '../src/apiCredentials/base.js';
+import {
+  serializeCredentials,
+  deserializeCredentials,
+  ApiCredentialsSchema,
+} from '../src/apiCredentials/serialization.js';
+import { SERVICE_REGISTRY } from '../src/serviceRegistry.js';
+import { resetAsyncSubprocessRunner, setAsyncSubprocessRunner } from '../src/curl.js';
+import type { Service } from '../src/services/core/base.js';
+
+afterEach(() => {
+  resetAsyncSubprocessRunner();
+});
+
+function mockCurlStdout(stdout: string): void {
+  setAsyncSubprocessRunner(() =>
+    Promise.resolve({ returncode: 0, stdout: Buffer.from(stdout), stderr: '' })
+  );
+}
+
+function primaryServiceForUrl(url: string): Service | null {
+  return SERVICE_REGISTRY.getByUrl(url);
+}
+
+describe('Tailscale URL matching', () => {
+  it('matches the admin API host and not lookalikes', () => {
+    expect(primaryServiceForUrl('https://api.tailscale.com/api/v2/tailnet/example.com/users')).toBe(
+      TAILSCALE
+    );
+    expect(primaryServiceForUrl('https://api.tailscale.com/api/v2/tailnet/example.com/keys')).toBe(
+      TAILSCALE
+    );
+  });
+
+  it('does not match the admin console or login host', () => {
+    expect(primaryServiceForUrl('https://console.tailscale.com/admin/users')).toBeNull();
+    expect(primaryServiceForUrl('https://login.tailscale.com/admin')).toBeNull();
+    expect(primaryServiceForUrl('https://api.tailscale.com.example.com/api/v2/')).toBeNull();
+  });
+});
+
+describe('Tailscale credentials', () => {
+  it('inject an Authorization: Bearer header', async () => {
+    const credentials = new TailscaleCredentials('tskey-api-kTest11CNTRL-secret', 'example.com');
+    const injected = await credentials.injectIntoCurlCall(['https://api.tailscale.com/api/v2/']);
+    expect(injected).toEqual([
+      '-H',
+      'Authorization: Bearer tskey-api-kTest11CNTRL-secret',
+      'https://api.tailscale.com/api/v2/',
+    ]);
+  });
+
+  it('reports the tailnet as the account and does not claim to know expiry', async () => {
+    const credentials = new TailscaleCredentials('tskey-api-kTest11CNTRL-secret', 'example.com');
+    expect(await TAILSCALE.getAccount(credentials)).toBe('example.com');
+    expect(credentials.isExpired()).toBeUndefined();
+  });
+
+  it('survives a serialization round-trip', () => {
+    const credentials = new TailscaleCredentials('tskey-api-kRound11CNTRL-secret', 'example.com');
+    const data = serializeCredentials(credentials);
+    // The discriminated union accepts the serialized form.
+    ApiCredentialsSchema.parse(data);
+    const restored = deserializeCredentials(data);
+    expect(restored).toBeInstanceOf(TailscaleCredentials);
+    expect((restored as TailscaleCredentials).token).toBe('tskey-api-kRound11CNTRL-secret');
+    expect((restored as TailscaleCredentials).tailnet).toBe('example.com');
+  });
+});
+
+describe('Tailscale credential check', () => {
+  // The check targets /tailnet/{tailnet}/settings; the response body is
+  // irrelevant, only the trailing HTTP status code (appended by `-w`) decides.
+  it('reports valid on a 200 from the tailnet settings endpoint', async () => {
+    mockCurlStdout('{"httpsEnabled":true}\n200');
+    const credentials = new TailscaleCredentials('tskey-api-kTest11CNTRL-secret', 'example.com');
+    expect(await TAILSCALE.checkApiCredentials(credentials)).toBe(ApiCredentialStatus.Valid);
+  });
+
+  it('reports invalid on a 401 (expired or revoked token)', async () => {
+    mockCurlStdout('\n401');
+    const credentials = new TailscaleCredentials('tskey-api-kTest11CNTRL-secret', 'example.com');
+    expect(await TAILSCALE.checkApiCredentials(credentials)).toBe(ApiCredentialStatus.Invalid);
+  });
+
+  it('reports invalid on a 404 (unknown tailnet)', async () => {
+    mockCurlStdout('\n404');
+    const credentials = new TailscaleCredentials('tskey-api-kTest11CNTRL-secret', 'example.com');
+    expect(await TAILSCALE.checkApiCredentials(credentials)).toBe(ApiCredentialStatus.Invalid);
+  });
+
+  it('reports unknown for a non-Tailscale credential (manual auth set)', async () => {
+    const raw = {
+      injectIntoCurlCall: () => Promise.resolve([] as readonly string[]),
+      isExpired: () => undefined,
+    } as never;
+    expect(await TAILSCALE.checkApiCredentials(raw)).toBe(ApiCredentialStatus.Unknown);
+  });
+});


### PR DESCRIPTION
Adds a Tailscale service connector for the admin API at `api.tailscale.com/api/v2`.

## Approach

A browser login (`latchkey auth browser tailscale`) signs the user into the admin console and mints an **API access token** (`tskey-api-...`) from the Keys page's one-time reveal dialog, capturing the tailnet name from the navigation. The token carries the full set of actions its owning user may perform — tailnet-wide user management (role changes, approval, suspension, deletion, restoration), device management, ACL/policy, DNS, and the minting of further keys including the auth keys the `tailscale` CLI consumes — and expires after at most 90 days, after which the user re-runs the login. Mirrors the OpenRouter/HuggingFace/Linear `BrowserFollowupServiceSession` mint-and-reveal pattern.

## Why the API access token (not an OAuth client)

Tailscale also offers OAuth clients (long-lived client_id/secret + a 1-hour client-credentials flow, no 90-day re-login), which are operationally cleaner for a long-running automation. They are a worse fit for the *autonomous* connector, though: their mint dialog requires choosing scopes and (for `auth_keys` write) org-specific tags, so a followup session cannot pick them without a mid-flow human decision. The API access token's mint is a simple description + expiry + one-time reveal, and a single token serves every admin action an Owner/Admin can take — including minting CLI auth keys with no tag constraint. An OAuth-client connector (`tailscale-oauth`) is a reasonable follow-up for a read-only, no-re-login workload.

## Credential shape

`TailscaleCredentials` (token + tailnet) injects an `Authorization: Bearer` header into every request to `api.tailscale.com`. The tailnet is part of nearly every useful API path and the API exposes no tailnet-independent way to validate a token, so it is captured at mint time and stored alongside the token. The credential check hits `GET /tailnet/{tailnet}/settings` (200 → valid, 401/404 → invalid); a manually-set credential (no tailnet) reports `unknown` while still injecting normally for `latchkey curl`. `getAccount` returns the tailnet.

## Contents

- `src/services/tailscale.ts` — the connector + `TailscaleCredentials`.
- Registered in `src/services/index.ts` and `src/serviceRegistry.ts`; `TailscaleCredentials` added to the credential serialization union in `src/apiCredentials/serialization.ts`.
- Listed in both `SKILL.md` service lists; blacklisted in `tests/servicesAgainstRecordings.test.ts` (a `BrowserFollowupServiceSession` whose token is minted by a one-time reveal dialog, like linear/ngrok/huggingface/openrouter).
- `tests/tailscale.test.ts` — URL matching, credential injection, account, serialization round-trip, and the credential check (valid / 401 / 404 / non-tailscale → unknown).

## Verified live

Against a real tailnet (imbue.com): a browser login minted a sealed `tskey-api` token; the connector's credential check reported it `valid`; `latchkey curl`-equivalent injection reached `GET /tailnet/{tailnet}/users`; a tampered tailnet and a revoked token both reported `invalid`. The token never left the gateway; all test credentials were revoked.

lint, typecheck, and `npm test` (766 tests) pass; the 6 CLI subprocess-suite flakes fail identically on clean `main` (sandbox gateway environment).

Pairs with a Detent scopes PR (`tailscale-api` + read/write) and an mngr-internal catalog entry, to follow.