### PR TITLE
tailscale: fix mint dialog selector — input has no placeholder attribute

### DIFF
--- a/src/services/tailscale.ts
+++ b/src/services/tailscale.ts
@@ -30,7 +30,7 @@ import {
   LoginCancelledError,
 } from './core/base.js';
 
-const DEFAULT_TIMEOUT_MS = 12000;
+const DEFAULT_TIMEOUT_MS = 30000;
 
 // The Tailscale admin REST API.
 const TAILSCALE_API_BASE_URL = 'https://api.tailscale.com/';
@@ -168,10 +168,10 @@ class TailscaleServiceSession extends BrowserFollowupServiceSession {
       await mintDialog.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
 
       // Give the token a recognizable description so the user can find and
-      // revoke it from the Keys page.
-      const descriptionInput = mintDialog.getByPlaceholder(
-        'Add an optional description for the key.'
-      );
+      // revoke it from the Keys page. The description input is the first
+      // input inside the dialog (it has no placeholder — the "Add an optional
+      // description for the key." text is a label, not a placeholder).
+      const descriptionInput = mintDialog.locator('input').first();
       await descriptionInput.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
       await typeLikeHuman(page, descriptionInput, this.generateAppName());
 

--- a/src/services/tailscale.ts
+++ b/src/services/tailscale.ts
@@ -167,10 +167,8 @@ class TailscaleServiceSession extends BrowserFollowupServiceSession {
       const mintDialog = page.getByRole('dialog', { name: 'Generate API access token' });
       await mintDialog.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
 
-      // Give the token a recognizable description so the user can find and
-      // revoke it from the Keys page. The description input is the first
-      // input inside the dialog (it has no placeholder — the "Add an optional
-      // description for the key." text is a label, not a placeholder).
+      // The description input is the first input in the dialog (the "Add an
+      // optional description" text above it is a label, not a placeholder).
       const descriptionInput = mintDialog.locator('input').first();
       await descriptionInput.waitFor({ timeout: DEFAULT_TIMEOUT_MS });
       await typeLikeHuman(page, descriptionInput, this.generateAppName());


### PR DESCRIPTION
Fixes the mint dialog selector that prevented `auth browser tailscale` from completing.

## The bug

The connector used `getByPlaceholder('Add an optional description for the key.')` to find the description input in the "Generate API access token" dialog. But that input **has no placeholder attribute** — the "Add an optional description for the key." text is a `<label>` above the input, not a placeholder. The selector always timed out (12s, then 30s with the earlier fallback attempt).

Discovered during the live gateway e2e test: the browser login (`manage_credential.sh browser tailscale`) failed with `locator.waitFor: Timeout exceeded. waiting for getByPlaceholder('Add an optional description for the key.')`. Verified against the live Tailscale dashboard (fleet browser `state` showed `<input id=:rm: />` with no placeholder).

## The fix

Use `mintDialog.locator('input').first()` — the description input is the first input inside the dialog. Simple and reliable.

## Verified live

After the fix, `latchkey auth browser tailscale` on the real Minds gateway:
- Chrome opened → user completed Google SSO → connector navigated to the Keys page → opened the mint dialog → filled the description → submitted → scraped the `tskey-api-...` token from the reveal dialog → stored `TailscaleCredentials` (tailnet: imbue.com).
- `latchkey curl https://api.tailscale.com/api/v2/tailnet/imbue.com/users` through the gateway → **HTTP 200, 43 users returned**.

This is the only commit on top of the merged #123; the base is `dev` (where #123 landed).