### PR TITLE
Reload registered services on every gateway request

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,14 +365,6 @@ route your agent's `latchkey` calls to the host Latchkey
 agent won't be able to tamper with your Latchkey configuration
 while still being able to use Latchkey itself as intended.
 
-A running gateway reads the registered services from
-`config.json` on every request, so `latchkey services register`
-and `latchkey services deregister` take effect immediately, the
-same way stored credentials and `permissions.json` do. The
-`settings` section of `config.json` is still read once at
-startup, so changing a setting (including `hideBuiltinServices`)
-requires restarting the gateway.
-
 #### Password
 
 You can additionally protect the gateway with a shared password.

--- a/README.md
+++ b/README.md
@@ -365,6 +365,14 @@ route your agent's `latchkey` calls to the host Latchkey
 agent won't be able to tamper with your Latchkey configuration
 while still being able to use Latchkey itself as intended.
 
+A running gateway reads the registered services from
+`config.json` on every request, so `latchkey services register`
+and `latchkey services deregister` take effect immediately, the
+same way stored credentials and `permissions.json` do. The
+`settings` section of `config.json` is still read once at
+startup, so changing a setting (including `hideBuiltinServices`)
+requires restarting the gateway.
+
 #### Password
 
 You can additionally protect the gateway with a shared password.

--- a/scripts/recordBrowserSession.ts
+++ b/scripts/recordBrowserSession.ts
@@ -23,7 +23,9 @@ import { CONFIG } from '../src/config.js';
 import { EncryptedStorage } from '../src/encryptedStorage.js';
 import { resolveEncryptionKey } from '../src/encryption.js';
 import { withTempBrowserContext } from '../src/playwrightUtils.js';
-import { SERVICE_REGISTRY } from '../src/serviceRegistry.js';
+import { BUILTIN_SERVICES, ServiceRegistry } from '../src/serviceRegistry.js';
+
+const BUILTIN_SERVICE_REGISTRY = new ServiceRegistry(BUILTIN_SERVICES);
 
 // Get the directory of this file
 const __filename = fileURLToPath(import.meta.url);
@@ -188,7 +190,7 @@ async function record(
   serviceName: string,
   recordingName: string = DEFAULT_RECORDING_NAME
 ): Promise<void> {
-  const service = SERVICE_REGISTRY.getByName(serviceName);
+  const service = BUILTIN_SERVICE_REGISTRY.getByName(serviceName);
   if (service === null) {
     throw new UnknownServiceError(serviceName);
   }
@@ -271,7 +273,7 @@ async function main(): Promise<void> {
     if (error instanceof UnknownServiceError) {
       console.error(`Error: ${error.message}`);
       console.error('Available services:');
-      for (const service of SERVICE_REGISTRY.services) {
+      for (const service of BUILTIN_SERVICE_REGISTRY.services) {
         console.error(`  - ${service.name}`);
       }
       process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,10 +16,6 @@ import {
 } from './encryption.js';
 import { KeychainTimeoutError } from './keychain.js';
 import { MigrationError, runMigrations } from './migrations.js';
-import {
-  hideServicesFromRegistry,
-  loadRegisteredServicesIntoServiceRegistry,
-} from './serviceRegistry.js';
 import { countDailyIfNeeded } from './dailyCounting.js';
 import { VERSION } from './version.js';
 
@@ -79,11 +75,7 @@ if (!gatewayMode) {
     }
     throw error;
   }
-
-  loadRegisteredServicesIntoServiceRegistry(deps.config.configPath, deps.registry);
 }
-
-hideServicesFromRegistry(deps.registry, deps.config.hideBuiltinServices);
 
 program
   .name('latchkey')

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -43,10 +43,11 @@ import type { CurlResult } from './curl.js';
 import { EncryptedStorage, EncryptedStorageError } from './encryptedStorage.js';
 import { encrypt, EncryptionError, resolveEncryptionKey } from './encryption.js';
 import {
+  BUILTIN_SERVICES,
+  createServiceRegistry,
   DuplicateServiceNameError,
   InvalidServiceNameError,
   ServiceRegistry,
-  SERVICE_REGISTRY,
   canonicalizeServiceName,
 } from './serviceRegistry.js';
 import { buildRegisteredServiceOptions, RegisteredService } from './services/core/registered.js';
@@ -117,6 +118,13 @@ export const PERMISSION_DENIED_EXIT_CODE = 126;
  */
 export interface CliDependencies {
   readonly registry: ServiceRegistry;
+  /**
+   * The services latchkey ships with, which is what a registry is built on top
+   * of before config.json is applied to it. The gateway rebuilds a registry
+   * from these on every request, so it needs them separately from `registry`,
+   * which has already had config.json applied and the hidden services removed.
+   */
+  readonly builtinServices: readonly Service[];
   readonly config: Config;
   readonly runCurl: (args: readonly string[]) => CurlResult;
   readonly runCurlAsync: typeof curlRunAsync;
@@ -139,7 +147,15 @@ export interface CliDependencies {
  */
 export function createDefaultDependencies(): CliDependencies {
   return {
-    registry: SERVICE_REGISTRY,
+    // Pointed at a remote gateway, the CLI forwards commands rather than
+    // resolving services itself, so it leaves the registered ones to the
+    // gateway.
+    registry: createServiceRegistry(
+      BUILTIN_SERVICES,
+      CONFIG.gatewayUrl === null ? CONFIG.configPath : null,
+      CONFIG.hideBuiltinServices
+    ),
+    builtinServices: BUILTIN_SERVICES,
     config: CONFIG,
     runCurl: curlRun,
     runCurlAsync: curlRunAsync,

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -18,6 +18,7 @@ import {
 } from './gatewayEndpoint.js';
 import { handleLatchkeyRequest } from './latchkeyEndpoint.js';
 import { GATEWAY_PASSWORD_HEADER, passwordsMatch } from './password.js';
+import { createServiceRegistry } from '../serviceRegistry.js';
 import {
   dispatchExtensionRequest,
   loadExtensions,
@@ -155,12 +156,27 @@ export async function startGateway(
       return;
     }
 
+    // Build the registry from config.json as it reads now, rather than using
+    // the one in `deps`, so that registering or deregistering a service while
+    // the gateway runs takes effect without a restart — the way writes to the
+    // credential store and to permissions.json already do. Each request gets
+    // its own: a shared one would be rebuilt underneath requests already in
+    // flight.
+    const requestDeps: CliDependencies = {
+      ...deps,
+      registry: createServiceRegistry(
+        deps.builtinServices,
+        deps.config.configPath,
+        deps.config.hideBuiltinServices
+      ),
+    };
+
     // Latchkey RPC endpoint
     if (rawUrl === '/latchkey/' || rawUrl === '/latchkey') {
       const requestPromise = handleLatchkeyRequest(
         request,
         response,
-        deps,
+        requestDeps,
         apiCredentialStore,
         encryptedStorage
       ).catch((error: unknown) => {
@@ -192,7 +208,7 @@ export async function startGateway(
         request,
         response,
         targetUrl,
-        deps,
+        requestDeps,
         apiCredentialStore,
         options
       ).catch((error: unknown) => {
@@ -212,7 +228,7 @@ export async function startGateway(
     }
 
     // Finally, try extensions (if any).
-    const requestPromise = runExtensions(request, response, extensions, deps, options)
+    const requestPromise = runExtensions(request, response, extensions, requestDeps, options)
       .then((handled) => {
         if (!handled && !response.headersSent) {
           response.writeHead(404);

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,4 +78,4 @@ export {
 } from './services/index.js';
 
 // ServiceRegistry
-export { ServiceRegistry, SERVICE_REGISTRY } from './serviceRegistry.js';
+export { ServiceRegistry } from './serviceRegistry.js';

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -11,7 +11,14 @@ import {
 import type { Config } from './config.js';
 import type { EncryptedStorage } from './encryptedStorage.js';
 import type { Service } from './services/core/base.js';
-import { SERVICE_REGISTRY } from './serviceRegistry.js';
+import { BUILTIN_SERVICES, ServiceRegistry } from './serviceRegistry.js';
+
+/**
+ * Migrations run before the CLI has built its own registry, and only ever need
+ * to recognize the services latchkey ships with: a credential stored under a
+ * name that is not one of them is left with an unknown status.
+ */
+const BUILTIN_SERVICE_REGISTRY = new ServiceRegistry(BUILTIN_SERVICES);
 
 export class MigrationError extends Error {
   constructor(message: string) {
@@ -85,7 +92,7 @@ async function resolveCredentialViaServiceRegistry(
   serviceName: string,
   credentialData: unknown
 ): Promise<ResolvedCredential> {
-  const service = SERVICE_REGISTRY.getByName(serviceName);
+  const service = BUILTIN_SERVICE_REGISTRY.getByName(serviceName);
   if (service === null) {
     return { status: ApiCredentialStatus.Unknown, account: null };
   }

--- a/src/serviceRegistry.ts
+++ b/src/serviceRegistry.ts
@@ -275,11 +275,3 @@ export const BUILTIN_SERVICES: readonly Service[] = [
   OPENROUTER,
   TAILSCALE,
 ];
-
-/**
- * The built-in services alone, with nothing from config.json and nothing
- * hidden. The CLI and the gateway both build their own registry with
- * {@link createServiceRegistry} instead; this is for callers that want the
- * services latchkey ships with.
- */
-export const SERVICE_REGISTRY = new ServiceRegistry(BUILTIN_SERVICES);

--- a/src/serviceRegistry.ts
+++ b/src/serviceRegistry.ts
@@ -212,7 +212,32 @@ export function loadRegisteredServicesIntoServiceRegistry(
   }
 }
 
-export const SERVICE_REGISTRY = new ServiceRegistry([
+/**
+ * Build a registry holding `builtinServices` plus the services registered in
+ * config.json, with the named services removed. This is how both the CLI and
+ * every gateway request get their registry.
+ *
+ * Hiding happens once the whole file has been loaded, so that a registered
+ * service naming a hidden built-in as its family still resolves that family.
+ *
+ * A null `configPath` skips config.json entirely, which is what the CLI does
+ * when it is pointed at a remote gateway: the gateway owns the registered
+ * services there, and the local CLI only forwards commands to it.
+ */
+export function createServiceRegistry(
+  builtinServices: readonly Service[],
+  configPath: string | null,
+  hiddenServiceNames: readonly string[]
+): ServiceRegistry {
+  const registry = new ServiceRegistry(builtinServices);
+  if (configPath !== null) {
+    loadRegisteredServicesIntoServiceRegistry(configPath, registry);
+  }
+  hideServicesFromRegistry(registry, hiddenServiceNames);
+  return registry;
+}
+
+export const BUILTIN_SERVICES: readonly Service[] = [
   SLACK,
   DISCORD,
   DROPBOX,
@@ -249,4 +274,12 @@ export const SERVICE_REGISTRY = new ServiceRegistry([
   HUGGINGFACE,
   OPENROUTER,
   TAILSCALE,
-]);
+];
+
+/**
+ * The built-in services alone, with nothing from config.json and nothing
+ * hidden. The CLI and the gateway both build their own registry with
+ * {@link createServiceRegistry} instead; this is for callers that want the
+ * services latchkey ships with.
+ */
+export const SERVICE_REGISTRY = new ServiceRegistry(BUILTIN_SERVICES);

--- a/tests/builtinServiceRegistry.ts
+++ b/tests/builtinServiceRegistry.ts
@@ -1,0 +1,11 @@
+/**
+ * A registry over the services latchkey ships with.
+ *
+ * The CLI and the gateway each build their own registry with
+ * `createServiceRegistry`, since theirs also carry whatever config.json holds.
+ * Tests that only care about the built-in services share this one.
+ */
+
+import { BUILTIN_SERVICES, ServiceRegistry } from '../src/serviceRegistry.js';
+
+export const BUILTIN_SERVICE_REGISTRY = new ServiceRegistry(BUILTIN_SERVICES);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -421,6 +421,7 @@ describe('CLI commands with dependency injection', () => {
 
     return {
       registry: mockRegistry,
+      builtinServices: [mockSlackService],
       config: createMockConfig(),
       runCurl: (args: readonly string[]): CurlResult => {
         capturedArgs.push(...args);

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -20,7 +20,10 @@ import type { AsyncCurlResult, CurlResult } from '../src/curl.js';
 import { EncryptedStorage } from '../src/encryptedStorage.js';
 import { ApiCredentialStore } from '../src/apiCredentials/store.js';
 import { Config } from '../src/config.js';
-import { ServiceRegistry } from '../src/serviceRegistry.js';
+import {
+  loadRegisteredServicesIntoServiceRegistry,
+  ServiceRegistry,
+} from '../src/serviceRegistry.js';
 import { Service } from '../src/services/core/base.js';
 import { createMockService } from './mockService.js';
 
@@ -237,8 +240,12 @@ describe('gateway server', () => {
     const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
     const apiCredentialStore = new ApiCredentialStore(storePath, encryptedStorage);
 
+    // One source for both, so that overriding the services a test runs against
+    // cannot leave the registry describing a different set.
+    const services: readonly Service[] = overrides.builtinServices ?? [mockSlackService];
     const deps: CliDependencies = {
-      registry: new ServiceRegistry([mockSlackService]),
+      builtinServices: services,
+      registry: new ServiceRegistry(services),
       config: createMockConfig(configOverrides),
       runCurl: (): CurlResult => ({ returncode: 0, stdout: '', stderr: '' }),
       runCurlAsync: async (
@@ -968,6 +975,81 @@ describe('gateway server', () => {
     });
   });
 
+  describe('services registered while the gateway runs', () => {
+    const REGISTERED_BASE_URL = 'https://selfhosted.example.com/api/';
+    const CREDENTIALS = {
+      slack: {
+        objectType: 'rawCurl',
+        curlArguments: ['-H', 'Authorization: Bearer test-token'],
+      },
+      'self-hosted': {
+        objectType: 'rawCurl',
+        curlArguments: ['-H', 'Authorization: Bearer self-hosted-token'],
+      },
+    };
+
+    function writeRegisteredServices(registeredServices: Record<string, unknown>): void {
+      writeFileSync(join(tempDir, 'config.json'), JSON.stringify({ registeredServices }));
+    }
+
+    it('injects credentials for a service registered after startup', async () => {
+      gateway = await createTestGateway(CREDENTIALS);
+
+      const beforeRegistering = await fetch(`/gateway/${REGISTERED_BASE_URL}thing`);
+      expect(beforeRegistering.status).toBe(400);
+
+      writeRegisteredServices({ 'self-hosted': { baseApiUrl: REGISTERED_BASE_URL } });
+
+      const afterRegistering = await fetch(`/gateway/${REGISTERED_BASE_URL}thing`);
+      expect(afterRegistering.status).toBe(200);
+      expect(capturedCurlArgs).toContain('Authorization: Bearer self-hosted-token');
+    });
+
+    it('stops serving a service deregistered after startup', async () => {
+      writeRegisteredServices({ 'self-hosted': { baseApiUrl: REGISTERED_BASE_URL } });
+      gateway = await createTestGateway(CREDENTIALS);
+
+      const beforeDeregistering = await fetch(`/gateway/${REGISTERED_BASE_URL}thing`);
+      expect(beforeDeregistering.status).toBe(200);
+
+      writeRegisteredServices({});
+
+      const afterDeregistering = await fetch(`/gateway/${REGISTERED_BASE_URL}thing`);
+      expect(afterDeregistering.status).toBe(400);
+    });
+
+    // The registry in the dependencies is the one cli.ts already loaded
+    // config.json into, so a deregistered service is still sitting in it. The
+    // gateway builds its own registry per request and must not fall back to
+    // that one.
+    it('drops a service deregistered after startup even when it was loaded at startup', async () => {
+      writeRegisteredServices({ 'self-hosted': { baseApiUrl: REGISTERED_BASE_URL } });
+      const startupRegistry = new ServiceRegistry([mockSlackService]);
+      loadRegisteredServicesIntoServiceRegistry(join(tempDir, 'config.json'), startupRegistry);
+      expect(startupRegistry.getByName('self-hosted')).not.toBeNull();
+
+      gateway = await createTestGateway(CREDENTIALS, { registry: startupRegistry });
+
+      const beforeDeregistering = await fetch(`/gateway/${REGISTERED_BASE_URL}thing`);
+      expect(beforeDeregistering.status).toBe(200);
+
+      writeRegisteredServices({});
+
+      const afterDeregistering = await fetch(`/gateway/${REGISTERED_BASE_URL}thing`);
+      expect(afterDeregistering.status).toBe(400);
+    });
+
+    it('keeps serving the built-in services it started with', async () => {
+      gateway = await createTestGateway(CREDENTIALS);
+
+      writeRegisteredServices({ 'self-hosted': { baseApiUrl: REGISTERED_BASE_URL } });
+
+      const response = await fetch('/gateway/https://slack.com/api/auth.test');
+      expect(response.status).toBe(200);
+      expect(capturedCurlArgs).toContain('Authorization: Bearer test-token');
+    });
+  });
+
   describe('shutdown', () => {
     it('should shut down cleanly', async () => {
       gateway = await createTestGateway();
@@ -998,6 +1080,7 @@ describe('gateway CLI command registration', () => {
 
     const mockDeps: CliDependencies = {
       registry: new ServiceRegistry([]),
+      builtinServices: [],
       config: new Config(() => undefined),
       runCurl: (): CurlResult => ({ returncode: 0, stdout: '', stderr: '' }),
       runCurlAsync: () => Promise.resolve({ returncode: 0, stdout: Buffer.from(''), stderr: '' }),

--- a/tests/gatewayExtensions.test.ts
+++ b/tests/gatewayExtensions.test.ts
@@ -182,6 +182,7 @@ describe('startExtensions / stopExtensions', () => {
   function makeFakeDeps(errorLogs: string[]): CliDependencies {
     return {
       registry: new ServiceRegistry([]),
+      builtinServices: [],
       config: new Config(() => undefined),
       runCurl: (): CurlResult => ({ returncode: 0, stdout: '', stderr: '' }),
       runCurlAsync: (): Promise<AsyncCurlResult> =>
@@ -352,6 +353,7 @@ describe('gateway extensions integration', () => {
     const config = createMockConfig();
     const deps: CliDependencies = {
       registry: new ServiceRegistry([]),
+      builtinServices: [],
       config,
       runCurl: (): CurlResult => ({ returncode: 0, stdout: '', stderr: '' }),
       runCurlAsync: (): Promise<AsyncCurlResult> =>

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -5,11 +5,11 @@ import {
   UnexpectedGithubCredentialsError,
 } from '../src/services/github.js';
 import { AuthorizationBearer, RawCurlCredentials } from '../src/apiCredentials/base.js';
-import { SERVICE_REGISTRY } from '../src/serviceRegistry.js';
+import { BUILTIN_SERVICE_REGISTRY } from './builtinServiceRegistry.js';
 import type { Service } from '../src/services/core/base.js';
 
 function primaryServiceForUrl(url: string): Service | null {
-  return SERVICE_REGISTRY.getByUrl(url);
+  return BUILTIN_SERVICE_REGISTRY.getByUrl(url);
 }
 
 describe('Github URL matching', () => {

--- a/tests/huggingface.test.ts
+++ b/tests/huggingface.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { HUGGINGFACE } from '../src/services/huggingface.js';
-import { SERVICE_REGISTRY } from '../src/serviceRegistry.js';
+import { BUILTIN_SERVICE_REGISTRY } from './builtinServiceRegistry.js';
 import type { Service } from '../src/services/core/base.js';
 
 function primaryServiceForUrl(url: string): Service | null {
-  return SERVICE_REGISTRY.getByUrl(url);
+  return BUILTIN_SERVICE_REGISTRY.getByUrl(url);
 }
 
 describe('Hugging Face URL matching', () => {

--- a/tests/latchkeyEndpoint.test.ts
+++ b/tests/latchkeyEndpoint.test.ts
@@ -158,8 +158,12 @@ describe('/latchkey/ endpoint', () => {
     const encryptedStorage = new EncryptedStorage(TEST_ENCRYPTION_KEY);
     const apiCredentialStore = new ApiCredentialStore(storePath, encryptedStorage);
 
+    // One source for both, so that overriding the services a test runs against
+    // cannot leave the registry describing a different set.
+    const services: readonly Service[] = overrides.builtinServices ?? [mockSlackService];
     const deps: CliDependencies = {
-      registry: new ServiceRegistry([mockSlackService]),
+      builtinServices: services,
+      registry: new ServiceRegistry(services),
       config: createMockConfig(configOverrides),
       runCurl: (): CurlResult => ({ returncode: 0, stdout: '', stderr: '' }),
       runCurlAsync: () => Promise.resolve({ returncode: 0, stdout: Buffer.from(''), stderr: '' }),
@@ -340,7 +344,7 @@ describe('/latchkey/ endpoint', () => {
 
   describe('prepare', () => {
     it('stores OAuth client credentials for a Google service', async () => {
-      gateway = await createTestGateway({}, { registry: new ServiceRegistry([GOOGLE_GMAIL]) });
+      gateway = await createTestGateway({}, { builtinServices: [GOOGLE_GMAIL] });
       const response = await postLatchkey({
         command: 'auth prepare',
         params: {
@@ -369,7 +373,7 @@ describe('/latchkey/ endpoint', () => {
     });
 
     it('returns 400 for malformed prepare JSON', async () => {
-      gateway = await createTestGateway({}, { registry: new ServiceRegistry([GOOGLE_GMAIL]) });
+      gateway = await createTestGateway({}, { builtinServices: [GOOGLE_GMAIL] });
       const response = await postLatchkey({
         command: 'auth prepare',
         params: { serviceName: 'google-gmail', json: '{not valid' },
@@ -435,7 +439,7 @@ describe('/latchkey/ endpoint', () => {
       });
       gateway = await createTestGateway(
         {},
-        { registry: new ServiceRegistry([browserSlack]) },
+        { builtinServices: [browserSlack] },
         { browserDisabled: true }
       );
       const response = await postLatchkey({
@@ -462,7 +466,7 @@ describe('/latchkey/ endpoint', () => {
         getSession: undefined,
       });
 
-      gateway = await createTestGateway({}, { registry: new ServiceRegistry([noLoginService]) });
+      gateway = await createTestGateway({}, { builtinServices: [noLoginService] });
       const response = await postLatchkey({
         command: 'auth browser',
         params: { serviceName: 'nologin' },

--- a/tests/manualCredentialForms.test.ts
+++ b/tests/manualCredentialForms.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { SERVICE_REGISTRY } from '../src/serviceRegistry.js';
+import { BUILTIN_SERVICE_REGISTRY } from './builtinServiceRegistry.js';
 import {
   BrowserFollowupServiceSession,
   type ManualCredentialForm,
@@ -37,7 +37,7 @@ interface NamedSession {
   readonly session: BrowserFollowupServiceSession;
 }
 
-const BROWSER_FOLLOWUP_SESSIONS: readonly NamedSession[] = SERVICE_REGISTRY.services
+const BROWSER_FOLLOWUP_SESSIONS: readonly NamedSession[] = BUILTIN_SERVICE_REGISTRY.services
   .map((service) => ({ service, session: service.getSession?.('latchkey') }))
   .filter(
     (candidate): candidate is NamedSession =>

--- a/tests/serviceRegistry.test.ts
+++ b/tests/serviceRegistry.test.ts
@@ -7,11 +7,11 @@ import {
   DuplicateServiceNameError,
   InvalidServiceNameError,
   ServiceRegistry,
-  SERVICE_REGISTRY,
   canonicalizeServiceName,
   hideServicesFromRegistry,
 } from '../src/serviceRegistry.js';
 import { RegisteredService } from '../src/services/core/registered.js';
+import { BUILTIN_SERVICE_REGISTRY } from './builtinServiceRegistry.js';
 import {
   SLACK,
   DISCORD,
@@ -72,16 +72,16 @@ describe('ServiceRegistry', () => {
 
     for (const [name, service] of namedServices) {
       it(`should find ${name} by name`, () => {
-        expect(SERVICE_REGISTRY.getByName(name)).toBe(service);
+        expect(BUILTIN_SERVICE_REGISTRY.getByName(name)).toBe(service);
       });
     }
 
     it('should return null for unknown service', () => {
-      expect(SERVICE_REGISTRY.getByName('unknown')).toBeNull();
+      expect(BUILTIN_SERVICE_REGISTRY.getByName('unknown')).toBeNull();
     });
 
     it('should be case-sensitive', () => {
-      expect(SERVICE_REGISTRY.getByName('Slack')).toBeNull();
+      expect(BUILTIN_SERVICE_REGISTRY.getByName('Slack')).toBeNull();
     });
   });
 
@@ -119,7 +119,7 @@ describe('ServiceRegistry', () => {
 
     for (const [url, service] of urlMappings) {
       it(`should find ${service.name} by URL ${url}`, () => {
-        expect(primaryServiceForUrl(SERVICE_REGISTRY, url)).toBe(service);
+        expect(primaryServiceForUrl(BUILTIN_SERVICE_REGISTRY, url)).toBe(service);
       });
     }
 
@@ -139,7 +139,7 @@ describe('ServiceRegistry', () => {
         'https://carddav.fastmail.com/dav/principals/',
       ];
       for (const url of urls) {
-        const claimants = SERVICE_REGISTRY.getCandidatesByUrl(url).filter(
+        const claimants = BUILTIN_SERVICE_REGISTRY.getCandidatesByUrl(url).filter(
           (service) => service === FASTMAIL || service === FASTMAIL_DAV
         );
         expect(claimants).toHaveLength(1);
@@ -147,36 +147,41 @@ describe('ServiceRegistry', () => {
     });
 
     it('should return null for unknown URL', () => {
-      expect(primaryServiceForUrl(SERVICE_REGISTRY, 'https://example.com/api')).toBeNull();
+      expect(primaryServiceForUrl(BUILTIN_SERVICE_REGISTRY, 'https://example.com/api')).toBeNull();
     });
 
     it('should not match partial URLs', () => {
-      expect(primaryServiceForUrl(SERVICE_REGISTRY, 'https://slack.com/')).toBeNull();
+      expect(primaryServiceForUrl(BUILTIN_SERVICE_REGISTRY, 'https://slack.com/')).toBeNull();
     });
 
     it('should match GitHub git smart-HTTP operation URLs', () => {
       expect(
         primaryServiceForUrl(
-          SERVICE_REGISTRY,
+          BUILTIN_SERVICE_REGISTRY,
           'https://github.com/owner/repo.git/info/refs?service=git-upload-pack'
         )
       ).toBe(GITHUB);
       expect(
-        primaryServiceForUrl(SERVICE_REGISTRY, 'https://github.com/owner/repo/git-upload-pack')
+        primaryServiceForUrl(
+          BUILTIN_SERVICE_REGISTRY,
+          'https://github.com/owner/repo/git-upload-pack'
+        )
       ).toBe(GITHUB);
     });
 
     it('should not match GitHub web pages as git operations', () => {
-      expect(primaryServiceForUrl(SERVICE_REGISTRY, 'https://github.com/owner/repo')).toBeNull();
       expect(
-        primaryServiceForUrl(SERVICE_REGISTRY, 'https://github.com/settings/tokens')
+        primaryServiceForUrl(BUILTIN_SERVICE_REGISTRY, 'https://github.com/owner/repo')
+      ).toBeNull();
+      expect(
+        primaryServiceForUrl(BUILTIN_SERVICE_REGISTRY, 'https://github.com/settings/tokens')
       ).toBeNull();
     });
   });
 
   describe('getCandidatesByUrl', () => {
     it('should return every service matching a shared Drive files URL', () => {
-      const candidates = SERVICE_REGISTRY.getCandidatesByUrl(
+      const candidates = BUILTIN_SERVICE_REGISTRY.getCandidatesByUrl(
         'https://www.googleapis.com/drive/v3/files?pageSize=1'
       );
       expect(candidates).toContain(GOOGLE_DRIVE);
@@ -188,23 +193,23 @@ describe('ServiceRegistry', () => {
     });
 
     it('should only match Drive itself for non-files Drive URLs', () => {
-      const candidates = SERVICE_REGISTRY.getCandidatesByUrl(
+      const candidates = BUILTIN_SERVICE_REGISTRY.getCandidatesByUrl(
         'https://www.googleapis.com/drive/v3/about?fields=user'
       );
       expect(candidates).toEqual([GOOGLE_DRIVE]);
     });
 
     it('should return an empty list for unknown URLs', () => {
-      expect(SERVICE_REGISTRY.getCandidatesByUrl('https://example.com/api')).toEqual([]);
+      expect(BUILTIN_SERVICE_REGISTRY.getCandidatesByUrl('https://example.com/api')).toEqual([]);
     });
   });
 
   describe('services', () => {
     it('should contain all registered services', () => {
-      expect(SERVICE_REGISTRY.services.length).toBeGreaterThan(0);
-      expect(SERVICE_REGISTRY.services).toContain(SLACK);
-      expect(SERVICE_REGISTRY.services).toContain(GITHUB);
-      expect(SERVICE_REGISTRY.services).toContain(AWS);
+      expect(BUILTIN_SERVICE_REGISTRY.services.length).toBeGreaterThan(0);
+      expect(BUILTIN_SERVICE_REGISTRY.services).toContain(SLACK);
+      expect(BUILTIN_SERVICE_REGISTRY.services).toContain(GITHUB);
+      expect(BUILTIN_SERVICE_REGISTRY.services).toContain(AWS);
     });
   });
 

--- a/tests/serviceRegistry.test.ts
+++ b/tests/serviceRegistry.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
+  createServiceRegistry,
   DuplicateServiceNameError,
   InvalidServiceNameError,
   ServiceRegistry,
@@ -399,6 +403,113 @@ describe('ServiceRegistry', () => {
       hideServicesFromRegistry(registry, ['nope', 'slack']);
       expect(registry.getByName('slack')).toBeNull();
       expect(registry.services).toHaveLength(0);
+    });
+  });
+
+  describe('createServiceRegistry', () => {
+    let temporaryDirectory: string;
+    let configPath: string;
+
+    beforeEach(() => {
+      temporaryDirectory = mkdtempSync(join(tmpdir(), 'latchkey-registry-'));
+      configPath = join(temporaryDirectory, 'config.json');
+    });
+
+    afterEach(() => {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    });
+
+    function writeRegisteredServices(registeredServices: Record<string, unknown>): void {
+      writeFileSync(configPath, JSON.stringify({ registeredServices }));
+    }
+
+    it('combines the base services with the ones registered in config.json', () => {
+      writeRegisteredServices({
+        'self-hosted-gitlab': {
+          baseApiUrl: 'https://gitlab.example.com/api/',
+          serviceFamily: 'gitlab',
+        },
+      });
+
+      const registry = createServiceRegistry([SLACK, GITLAB], configPath, []);
+
+      expect(registry.getByName('slack')).toBe(SLACK);
+      expect(registry.getByName('gitlab')).toBe(GITLAB);
+      expect(registry.getByName('self-hosted-gitlab')).toBeInstanceOf(RegisteredService);
+    });
+
+    it('works when config.json does not exist', () => {
+      const registry = createServiceRegistry([SLACK], configPath, []);
+
+      expect(registry.services).toHaveLength(1);
+      expect(registry.getByName('slack')).toBe(SLACK);
+    });
+
+    it('picks up a service registered between two calls', () => {
+      writeRegisteredServices({});
+      expect(createServiceRegistry([SLACK], configPath, []).getByName('added-later')).toBeNull();
+
+      writeRegisteredServices({ 'added-later': { baseApiUrl: 'https://api.example.com/' } });
+
+      const refreshed = createServiceRegistry([SLACK], configPath, []);
+      expect(refreshed.getByName('added-later')).toBeInstanceOf(RegisteredService);
+      expect(refreshed.getByUrl('https://api.example.com/things')?.name).toBe('added-later');
+    });
+
+    it('drops a service deregistered between two calls', () => {
+      writeRegisteredServices({ 'going-away': { baseApiUrl: 'https://api.example.com/' } });
+      expect(createServiceRegistry([SLACK], configPath, []).getByName('going-away')).not.toBeNull();
+
+      writeRegisteredServices({});
+
+      const refreshed = createServiceRegistry([SLACK], configPath, []);
+      expect(refreshed.getByName('going-away')).toBeNull();
+      expect(refreshed.getByUrl('https://api.example.com/things')).toBeNull();
+    });
+
+    it('returns an independent registry on every call', () => {
+      writeRegisteredServices({});
+      const first = createServiceRegistry([SLACK], configPath, []);
+      const second = createServiceRegistry([SLACK], configPath, []);
+
+      first.removeService('slack');
+
+      expect(first.getByName('slack')).toBeNull();
+      expect(second.getByName('slack')).toBe(SLACK);
+    });
+
+    it('skips config.json entirely when given no path', () => {
+      writeRegisteredServices({ 'from-the-file': { baseApiUrl: 'https://api.example.com/' } });
+
+      const registry = createServiceRegistry([SLACK, GITHUB], null, ['github']);
+
+      expect(registry.getByName('from-the-file')).toBeNull();
+      expect(registry.getByName('slack')).toBe(SLACK);
+      // Hiding still applies, as it does for a CLI pointed at a gateway.
+      expect(registry.getByName('github')).toBeNull();
+    });
+
+    it('hides the named services', () => {
+      writeRegisteredServices({});
+
+      const registry = createServiceRegistry([SLACK, GITHUB], configPath, ['slack']);
+
+      expect(registry.getByName('slack')).toBeNull();
+      expect(registry.getByName('github')).toBe(GITHUB);
+    });
+
+    it('lets a registered service use a hidden built-in as its family', () => {
+      writeRegisteredServices({
+        'self-hosted-gitlab': {
+          baseApiUrl: 'https://gitlab.example.com/api/',
+          serviceFamily: 'gitlab',
+        },
+      });
+
+      const registry = createServiceRegistry([GITLAB], configPath, ['gitlab']);
+
+      expect(registry.getByName('gitlab')).toBeNull();
+      expect(registry.getByName('self-hosted-gitlab')).toBeInstanceOf(RegisteredService);
     });
   });
 });

--- a/tests/servicesAgainstRecordings.test.ts
+++ b/tests/servicesAgainstRecordings.test.ts
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import type { Response, Request } from 'playwright';
 import { ApiCredentials } from '../src/apiCredentials/base.js';
-import { SERVICE_REGISTRY } from '../src/serviceRegistry.js';
+import { BUILTIN_SERVICE_REGISTRY } from './builtinServiceRegistry.js';
 import { Service, SimpleServiceSession } from '../src/services/core/base.js';
 
 // Get the directory of this file
@@ -225,7 +225,7 @@ describe('Services Against Recordings', () => {
 
   for (const { serviceName, recordingPath } of discoveredRecordings) {
     it(`should extract credentials from ${serviceName} recording`, async () => {
-      const service = SERVICE_REGISTRY.getByName(serviceName);
+      const service = BUILTIN_SERVICE_REGISTRY.getByName(serviceName);
 
       if (service === null) {
         // Skip if service not found in registry

--- a/tests/tailscale.test.ts
+++ b/tests/tailscale.test.ts
@@ -6,7 +6,7 @@ import {
   deserializeCredentials,
   ApiCredentialsSchema,
 } from '../src/apiCredentials/serialization.js';
-import { SERVICE_REGISTRY } from '../src/serviceRegistry.js';
+import { BUILTIN_SERVICE_REGISTRY } from './builtinServiceRegistry.js';
 import { resetAsyncSubprocessRunner, setAsyncSubprocessRunner } from '../src/curl.js';
 import type { Service } from '../src/services/core/base.js';
 
@@ -21,7 +21,7 @@ function mockCurlStdout(stdout: string): void {
 }
 
 function primaryServiceForUrl(url: string): Service | null {
-  return SERVICE_REGISTRY.getByUrl(url);
+  return BUILTIN_SERVICE_REGISTRY.getByUrl(url);
 }
 
 describe('Tailscale URL matching', () => {


### PR DESCRIPTION
## What changes for users

A running `latchkey gateway` built its service registry once, at startup, and never looked at `config.json` again. So `latchkey services register` on the gateway host wrote the entry to disk, but the gateway kept rejecting that service until someone restarted it.

After this, registering and deregistering a service take effect on the next request, with no restart. That matches how the gateway already treats the rest of its on-disk state:

| State | Reloaded per request before this PR? |
|---|---|
| Stored credentials (`auth set`, refreshed tokens) | yes |
| `permissions.json` | yes |
| Which permissions file a request uses | yes |
| Registered custom services | **no** — this PR |

Nothing else changes. The `settings` section of `config.json`, `hideBuiltinServices` included, is still read once at startup and still needs a restart. #134 is the follow-up that reloads the whole configuration, if we'd rather not reload only part of it.

## Cost

Measured end to end, not just the file read: a real gateway via `startGateway` with a stubbed curl runner, 2000 requests after a 300-request warmup, three runs of this branch against three of a variant that builds the registry once. Median of the p50s, on an M-series Mac:

| registered services in config.json | registry built once | rebuilt per request | added |
|---|---|---|---|
| 0 | 337 µs | 361 µs | **+24 µs** |
| 10 | 322 µs | 358 µs | **+36 µs** |
| 100 | 325 µs | 455 µs | **+130 µs** |

About 25 µs fixed, plus ~1.3 µs per registered service. Total gateway overhead per request is ~330 µs here, and that excludes the `curl` spawn a real proxied request pays (~9.7 ms before any network) — so this is well under 1% of a real request's wall time.

Each request gets its own registry rather than sharing a rebuilt one, since a shared one would change underneath requests already in flight.

## Internal changes worth knowing about

**`SERVICE_REGISTRY` is gone from the package exports.** Building a registry is one function, `createServiceRegistry`, used by both the CLI at startup and the gateway per request, rather than the same load-then-hide pair written out in each place. The CLI therefore builds its own registry instead of mutating the `SERVICE_REGISTRY` singleton, which left that singleton with a single consumer — so it now lives in `src/migrations.ts` as an unexported constant and is no longer re-exported from `src/index.ts`.

That breaks the programmatic API for anyone importing it; per review, only CLI compatibility is maintained. Migrations are unaffected in substance: they ran before the old registry load, so they already only ever saw built-in services.

This also let `src/cli.ts` drop its registry setup entirely.

## Manual testing

Run `latchkey gateway` in one terminal and work in another. None of items 1–4 should need a restart.

1. **Register while running** — `latchkey services register my-thing --base-api-url https://…/`, give it credentials with `latchkey auth set`, then make a request through `/gateway/` and confirm the credentials are injected. Previously this returned 400 until the gateway was restarted.
2. **Deregister while running** — `latchkey services deregister my-thing`, then repeat the request and confirm it is no longer served.
3. **Self-hosted instance** — register one with `--service-family` (e.g. a self-hosted GitLab) and confirm the family's credential handling applies to it through the gateway.
4. **Built-ins unaffected** — with a registered service present, confirm a built-in service still resolves and injects normally.
5. **Settings still need a restart** — add `"hideBuiltinServices": ["github"]` to `config.json` while the gateway runs and confirm it does *not* take effect until restart. This is the deliberate scope boundary, and the behavior #134 changes.

The rest exercise the startup restructure, which touches every CLI invocation and not just the gateway:

6. **Plain CLI, no gateway** — `latchkey services list` shows registered services, `latchkey curl` against one injects credentials, and `latchkey services list --builtin` excludes them. Confirm `hideBuiltinServices` in `config.json` still hides a service at startup.
7. **CLI pointed at a remote gateway** — with `LATCHKEY_GATEWAY` set, confirm `latchkey services list` still reports the services the *gateway* knows about, and that `latchkey services register` is still refused locally. This is the path where the CLI deliberately skips `config.json`, since the gateway owns registered services there.
8. **Migrations on an old data directory** — the registry is now built before migrations run rather than after. Migrations read the untouched `SERVICE_REGISTRY` in both cases, so this should be unchanged, but it is worth confirming against a pre-migration `~/.latchkey`.
9. **Under load** — hammer the gateway while registering and deregistering a service, and confirm no crashes and no torn behavior.

## Automated tests

- `tests/serviceRegistry.test.ts` — 8 cases for `createServiceRegistry`: built-ins plus config, missing config file, a service added between calls, one removed between calls, registries independent of each other, a null config path skipping the file while still hiding, hiding, and a registered service whose family is hidden.
- `tests/gateway.test.ts` — 4 integration cases against a live gateway, covering items 1, 2 and 4 above, plus the case where the deregistered service is still sitting in the registry the gateway was handed.

Verified the three behavioral tests fail against the unmodified request path. Full suite: 821 passed, lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

