### PR TITLE
Reload the whole configuration on every gateway request

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,13 +365,22 @@ route your agent's `latchkey` calls to the host Latchkey
 agent won't be able to tamper with your Latchkey configuration
 while still being able to use Latchkey itself as intended.
 
-A running gateway reads the registered services from
-`config.json` on every request, so `latchkey services register`
-and `latchkey services deregister` take effect immediately, the
-same way stored credentials and `permissions.json` do. The
-`settings` section of `config.json` is still read once at
-startup, so changing a setting (including `hideBuiltinServices`)
-requires restarting the gateway.
+A running gateway reads the environment and `config.json` again on
+every request, so most changes take effect without a restart:
+services added or removed with `latchkey services register` and
+`latchkey services deregister`, and settings such as
+`passthroughUnknown`, `hideBuiltinServices`, `permissionsConfig`,
+`credentialsRefreshDisabled`, `browserDisabled` and `curlCommand`.
+Stored credentials and `permissions.json` were already read this
+way.
+
+The exceptions are the settings whose work is done before the
+first request arrives: `keyringServiceName` and
+`keyringAccountName` (the encryption key has already been
+resolved), `gatewayListenHost` and `gatewayListenPort` (the socket
+is already bound), and `countingDisabled` (the daily count has
+already run). The gateway logs a warning when it sees one of these
+change, and applying it needs a restart.
 
 #### Password
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -185,6 +185,13 @@ function resolveBoolean(envValue: string | undefined, fileValue: boolean | undef
  * LATCHKEY_DIRECTORY and LATCHKEY_ENCRYPTION_KEY are env-only.
  */
 export class Config {
+  /**
+   * Where this config was read from, kept so that {@link reload} can consult
+   * the same sources again.
+   */
+  readonly getEnv: (name: string) => string | undefined;
+  readonly loadSettingsFromFile: (configPath: string) => Settings;
+
   readonly directory: string;
   readonly curlCommand: string;
   /**
@@ -293,6 +300,9 @@ export class Config {
     getEnv: (name: string) => string | undefined = (name) => process.env[name],
     loadSettingsFromFile: (configPath: string) => Settings = loadSettings
   ) {
+    this.getEnv = getEnv;
+    this.loadSettingsFromFile = loadSettingsFromFile;
+
     // The directory and encryption key are configured exclusively via environment variables;
     // they cannot be set from config.json (the directory determines where config.json lives).
     const directoryEnv = getEnv(LATCHKEY_DIRECTORY_ENV_VAR);
@@ -382,6 +392,15 @@ export class Config {
       settings.appNamePrefix,
       DEFAULT_APP_NAME_PREFIX
     );
+  }
+
+  /**
+   * Read the same environment and config file again, returning what they say
+   * now. The receiver is left untouched, so a caller holding it keeps a stable
+   * view for as long as it needs one.
+   */
+  reload(): Config {
+    return new Config(this.getEnv, this.loadSettingsFromFile);
   }
 
   get credentialStorePath(): string {

--- a/src/curl.ts
+++ b/src/curl.ts
@@ -11,6 +11,26 @@ import { CONFIG } from './config.js';
 // have to depend on detent directly.
 export { CurlParseError, parseCurlArgs };
 
+/**
+ * The curl command to spawn, when something other than the startup config
+ * decides it. The gateway sets this per request so that a changed
+ * `curlCommand` reaches the call sites inside the services, which reach this
+ * module directly rather than through the CLI dependencies.
+ */
+let curlCommandOverride: string | null = null;
+
+export function setCurlCommand(command: string): void {
+  curlCommandOverride = command;
+}
+
+export function resetCurlCommand(): void {
+  curlCommandOverride = null;
+}
+
+function curlCommand(): string {
+  return curlCommandOverride ?? CONFIG.curlCommand;
+}
+
 export interface CurlResult {
   readonly returncode: number;
   readonly stdout: string;
@@ -28,7 +48,7 @@ export type SubprocessRunner = (args: readonly string[]) => CurlResult;
 export type DetachedSubprocessRunner = (args: readonly string[]) => void;
 
 function defaultSubprocessRunner(args: readonly string[]): CurlResult {
-  const result: SpawnSyncReturns<Buffer> = spawnSync(CONFIG.curlCommand, args as string[], {
+  const result: SpawnSyncReturns<Buffer> = spawnSync(curlCommand(), args as string[], {
     stdio: ['inherit', 'inherit', 'inherit'],
   });
   return {
@@ -39,7 +59,7 @@ function defaultSubprocessRunner(args: readonly string[]): CurlResult {
 }
 
 function defaultDetachedSubprocessRunner(args: readonly string[]): void {
-  const child = spawn(CONFIG.curlCommand, args as string[], {
+  const child = spawn(curlCommand(), args as string[], {
     stdio: 'ignore',
     detached: true,
   });
@@ -80,7 +100,7 @@ function defaultAsyncSubprocessRunner(
   options?: AsyncSubprocessOptions
 ): Promise<AsyncCurlResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(CONFIG.curlCommand, args as string[], {
+    const child = spawn(curlCommand(), args as string[], {
       stdio: ['pipe', 'pipe', 'pipe'],
       ...(options?.timeout !== undefined ? { timeout: options.timeout * 1000 } : {}),
     });

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -8,8 +8,10 @@
 import * as http from 'node:http';
 import type { ApiCredentialStore } from '../apiCredentials/store.js';
 import type { CliDependencies } from '../cliCommands.js';
+import type { Config } from '../config.js';
 import type { EncryptedStorage } from '../encryptedStorage.js';
 import { ErrorMessages } from '../errorMessages.js';
+import { setCurlCommand } from '../curl.js';
 import {
   extractTargetUrl,
   GATEWAY_PATH_PREFIX,
@@ -128,6 +130,72 @@ function runExtensions(
 }
 
 /**
+ * Settings a running gateway reads again but cannot act on, with the reason it
+ * cannot. Everything else in the config takes effect on the next request, so
+ * these are the ones worth telling the user about rather than leaving to be
+ * discovered.
+ */
+interface StartupOnlySetting {
+  readonly name: string;
+  readonly reason: string;
+  readonly read: (config: Config) => string | number | boolean;
+}
+
+const STARTUP_ONLY_SETTINGS: readonly StartupOnlySetting[] = [
+  {
+    name: 'keyringServiceName',
+    reason: 'the encryption key was resolved before the server started',
+    read: (config) => config.serviceName,
+  },
+  {
+    name: 'keyringAccountName',
+    reason: 'the encryption key was resolved before the server started',
+    read: (config) => config.accountName,
+  },
+  {
+    name: 'gatewayListenHost',
+    reason: 'the listening socket is already bound',
+    read: (config) => config.gatewayListenHost,
+  },
+  {
+    name: 'gatewayListenPort',
+    reason: 'the listening socket is already bound',
+    read: (config) => config.gatewayListenPort,
+  },
+  {
+    name: 'countingDisabled',
+    reason: 'daily counting runs once, at startup',
+    read: (config) => config.countingDisabled,
+  },
+];
+
+/**
+ * Report settings that changed since startup but cannot take effect until the
+ * gateway is restarted. Each is reported once, so that a config left in place
+ * does not repeat itself on every request.
+ */
+function reportSettingChangesNeedingRestart(
+  startupConfig: Config,
+  requestConfig: Config,
+  alreadyReported: Set<string>,
+  deps: CliDependencies
+): void {
+  for (const setting of STARTUP_ONLY_SETTINGS) {
+    if (alreadyReported.has(setting.name)) {
+      continue;
+    }
+    if (setting.read(startupConfig) === setting.read(requestConfig)) {
+      continue;
+    }
+    alreadyReported.add(setting.name);
+    deps.errorLog(
+      `Warning: '${setting.name}' has changed, but this gateway cannot apply it ` +
+        `because ${setting.reason}. Restart the gateway for it to take effect.`
+    );
+  }
+}
+
+/**
  * Start the gateway HTTP server.
  */
 export async function startGateway(
@@ -140,6 +208,8 @@ export async function startGateway(
 
   const extensions = await loadExtensions(deps.config.extensionsDirectoryPath);
   await startExtensions(extensions);
+
+  const settingChangesReported = new Set<string>();
 
   const server = http.createServer((request, response) => {
     const rawUrl = request.url ?? '';
@@ -156,20 +226,32 @@ export async function startGateway(
       return;
     }
 
-    // Build the registry from config.json as it reads now, rather than using
-    // the one in `deps`, so that registering or deregistering a service while
-    // the gateway runs takes effect without a restart — the way writes to the
-    // credential store and to permissions.json already do. Each request gets
-    // its own: a shared one would be rebuilt underneath requests already in
-    // flight.
+    // Read the environment and config.json again, so that everything the
+    // request path consults reflects what they say now rather than what they
+    // said at startup. Each request gets its own config and registry: shared
+    // ones would change underneath requests already in flight.
+    //
+    // Hiding is re-applied here from the config as it reads now, which works
+    // because the registry is rebuilt from the full set of built-in services: a
+    // name dropped from hideBuiltinServices brings its service back.
+    const requestConfig = deps.config.reload();
+    reportSettingChangesNeedingRestart(deps.config, requestConfig, settingChangesReported, deps);
     const requestDeps: CliDependencies = {
       ...deps,
+      config: requestConfig,
       registry: createServiceRegistry(
         deps.builtinServices,
-        deps.config.configPath,
-        deps.config.hideBuiltinServices
+        requestConfig.configPath,
+        requestConfig.hideBuiltinServices
       ),
     };
+
+    // curl is spawned from call sites deep inside the services, which reach the
+    // runner directly rather than through these dependencies, so the command to
+    // spawn is handed to that module instead of threaded down to them. Every
+    // request computes it from the same file, so concurrent requests write the
+    // same value except in the moment the file itself changes.
+    setCurlCommand(requestConfig.curlCommand);
 
     // Latchkey RPC endpoint
     if (rawUrl === '/latchkey/' || rawUrl === '/latchkey') {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -411,6 +411,11 @@ describe('CLI commands with dependency injection', () => {
       appNamePrefix: overrides.appNamePrefix ?? defaultConfig.appNamePrefix,
       checkSensitiveFilePermissions: () => undefined,
       checkSystemPrerequisites: () => undefined,
+      getEnv: () => undefined,
+      loadSettingsFromFile: () => ({}),
+      // A reloaded stand-in reads the same stubbed sources, so it says exactly
+      // what this one says.
+      reload: () => createMockConfig(overrides),
     };
   }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -256,4 +256,54 @@ describe('Config with config.json settings', () => {
 
     expect(config.curlCommand).toBe('curl');
   });
+
+  describe('reload', () => {
+    it('picks up a setting written after the config was constructed', () => {
+      const config = makeConfig();
+      expect(config.passthroughUnknown).toBe(false);
+
+      writeSettings({ passthroughUnknown: true });
+
+      expect(config.reload().passthroughUnknown).toBe(true);
+    });
+
+    it('picks up a setting removed after the config was constructed', () => {
+      writeSettings({ passthroughUnknown: true });
+      const config = makeConfig();
+      expect(config.passthroughUnknown).toBe(true);
+
+      writeSettings({});
+
+      expect(config.reload().passthroughUnknown).toBe(false);
+    });
+
+    it('leaves the config it was called on untouched', () => {
+      const config = makeConfig();
+
+      writeSettings({ passthroughUnknown: true, hideBuiltinServices: ['slack'] });
+      const reloaded = config.reload();
+
+      expect(config.passthroughUnknown).toBe(false);
+      expect(config.hideBuiltinServices).toEqual([]);
+      expect(reloaded.passthroughUnknown).toBe(true);
+      expect(reloaded.hideBuiltinServices).toEqual(['slack']);
+    });
+
+    it('reads the same environment the config was built from', () => {
+      const config = makeConfig({ LATCHKEY_CURL: '/usr/bin/env-curl' });
+
+      writeSettings({ curlCommand: '/usr/bin/file-curl' });
+
+      // The environment still wins over the file, as it does at construction.
+      expect(config.reload().curlCommand).toBe('/usr/bin/env-curl');
+      expect(config.reload().directory).toBe(directory);
+    });
+
+    it('can be called repeatedly', () => {
+      const config = makeConfig();
+
+      writeSettings({ passthroughUnknown: true });
+      expect(config.reload().reload().passthroughUnknown).toBe(true);
+    });
+  });
 });

--- a/tests/curl.test.ts
+++ b/tests/curl.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { CONFIG } from '../src/config.js';
+import { resetCurlCommand, runCapturedAsync, setCurlCommand } from '../src/curl.js';
+
+describe('curl command selection', () => {
+  afterEach(() => {
+    resetCurlCommand();
+  });
+
+  it('spawns the command set with setCurlCommand', async () => {
+    setCurlCommand('echo');
+
+    const result = await runCapturedAsync(['from-the-override']);
+
+    expect(result.returncode).toBe(0);
+    expect(result.stdout.trim()).toBe('from-the-override');
+  });
+
+  it('spawns the configured command again after a reset', () => {
+    setCurlCommand('echo');
+    resetCurlCommand();
+
+    // The startup config decides again, and this suite has no curl stand-in for
+    // it, so all that can be checked is which binary it names.
+    expect(CONFIG.curlCommand).toBe('curl');
+  });
+
+  it('takes the most recent command when set more than once', async () => {
+    setCurlCommand('true');
+    setCurlCommand('echo');
+
+    const result = await runCapturedAsync(['second-override']);
+
+    expect(result.stdout.trim()).toBe('second-override');
+  });
+});

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Command } from 'commander';
@@ -16,7 +16,12 @@ import {
   PERMISSIONS_OVERRIDE_HEADER,
 } from '../src/gateway/permissionsOverride.js';
 import { startGateway, type GatewayServer } from '../src/gateway/server.js';
-import type { AsyncCurlResult, CurlResult } from '../src/curl.js';
+import {
+  resetCurlCommand,
+  runCapturedAsync,
+  type AsyncCurlResult,
+  type CurlResult,
+} from '../src/curl.js';
 import { EncryptedStorage } from '../src/encryptedStorage.js';
 import { ApiCredentialStore } from '../src/apiCredentials/store.js';
 import { Config } from '../src/config.js';
@@ -25,6 +30,7 @@ import {
   ServiceRegistry,
 } from '../src/serviceRegistry.js';
 import { Service } from '../src/services/core/base.js';
+import { GITHUB } from '../src/services/index.js';
 import { createMockService } from './mockService.js';
 
 const TEST_ENCRYPTION_KEY = 'dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleXRlc3Q=';
@@ -204,20 +210,27 @@ describe('gateway server', () => {
     getSession: undefined,
   });
 
+  /**
+   * Merge into the config file the gateway reads, so that settings survive the
+   * per-request reload the way they do in a real deployment.
+   */
+  function updateConfigFile(update: Record<string, unknown>): void {
+    const path = join(tempDir, 'config.json');
+    const existing = existsSync(path)
+      ? (JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>)
+      : {};
+    writeFileSync(path, JSON.stringify({ ...existing, ...update }));
+  }
+
   function createMockConfig(configOverrides: Partial<Config> = {}): Config {
-    const base = new Config((name) => {
+    if (Object.keys(configOverrides).length > 0) {
+      updateConfigFile({ settings: configOverrides });
+    }
+    return new Config((name) => {
       if (name === 'LATCHKEY_DIRECTORY') return tempDir;
       if (name === 'LATCHKEY_ENCRYPTION_KEY') return TEST_ENCRYPTION_KEY;
       return undefined;
     });
-    if (Object.keys(configOverrides).length === 0) {
-      return base;
-    }
-    return Object.assign(
-      Object.create(Object.getPrototypeOf(base) as object) as Config,
-      base,
-      configOverrides
-    );
   }
 
   async function createTestGateway(
@@ -333,6 +346,7 @@ describe('gateway server', () => {
     if (gateway) {
       await gateway.close();
     }
+    resetCurlCommand();
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -989,7 +1003,7 @@ describe('gateway server', () => {
     };
 
     function writeRegisteredServices(registeredServices: Record<string, unknown>): void {
-      writeFileSync(join(tempDir, 'config.json'), JSON.stringify({ registeredServices }));
+      updateConfigFile({ registeredServices });
     }
 
     it('injects credentials for a service registered after startup', async () => {
@@ -1047,6 +1061,108 @@ describe('gateway server', () => {
       const response = await fetch('/gateway/https://slack.com/api/auth.test');
       expect(response.status).toBe(200);
       expect(capturedCurlArgs).toContain('Authorization: Bearer test-token');
+    });
+  });
+
+  describe('configuration changed while the gateway runs', () => {
+    function writeSettings(settings: Record<string, unknown>): void {
+      updateConfigFile({ settings });
+    }
+
+    it('applies passthroughUnknown enabled after startup', async () => {
+      gateway = await createTestGateway();
+
+      const beforeEnabling = await fetch('/gateway/https://unknown-api.example.com/thing');
+      expect(beforeEnabling.status).toBe(400);
+
+      writeSettings({ passthroughUnknown: true });
+
+      const afterEnabling = await fetch('/gateway/https://unknown-api.example.com/thing');
+      expect(afterEnabling.status).toBe(200);
+    });
+
+    it('applies passthroughUnknown disabled after startup', async () => {
+      writeSettings({ passthroughUnknown: true });
+      gateway = await createTestGateway();
+
+      const beforeDisabling = await fetch('/gateway/https://unknown-api.example.com/thing');
+      expect(beforeDisabling.status).toBe(200);
+
+      writeSettings({ passthroughUnknown: false });
+
+      const afterDisabling = await fetch('/gateway/https://unknown-api.example.com/thing');
+      expect(afterDisabling.status).toBe(400);
+    });
+
+    it('hides a service named in hideBuiltinServices after startup', async () => {
+      gateway = await createTestGateway();
+      expect((await fetch('/gateway/https://slack.com/api/auth.test')).status).toBe(200);
+
+      writeSettings({ hideBuiltinServices: ['slack'] });
+
+      expect((await fetch('/gateway/https://slack.com/api/auth.test')).status).toBe(400);
+    });
+
+    it('brings back a service dropped from hideBuiltinServices after startup', async () => {
+      // GitHub is among the built-in services but hidden at startup, so this
+      // only passes if hiding is re-applied per request from the config as it
+      // reads then, rather than baked into what the gateway starts from.
+      writeSettings({ hideBuiltinServices: ['github'] });
+      gateway = await createTestGateway(
+        {
+          github: {
+            objectType: 'rawCurl',
+            curlArguments: ['-H', 'Authorization: Bearer github-token'],
+          },
+        },
+        { builtinServices: [mockSlackService, GITHUB] }
+      );
+
+      const whileHidden = await fetch('/gateway/https://api.github.com/user');
+      expect(whileHidden.status).toBe(400);
+
+      writeSettings({ hideBuiltinServices: [] });
+
+      const afterUnhiding = await fetch('/gateway/https://api.github.com/user');
+      expect(afterUnhiding.status).toBe(200);
+      expect(capturedCurlArgs).toContain('Authorization: Bearer github-token');
+    });
+
+    it('warns once about a setting it cannot apply without a restart', async () => {
+      gateway = await createTestGateway();
+
+      writeSettings({ gatewayListenPort: 4242 });
+
+      await fetch('/gateway/https://slack.com/api/auth.test');
+      await fetch('/gateway/https://slack.com/api/auth.test');
+
+      const warnings = errorLogs.filter((message) => message.includes('gatewayListenPort'));
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('listening socket is already bound');
+      expect(warnings[0]).toContain('Restart the gateway');
+    });
+
+    it('applies a changed curlCommand to the curl the services spawn', async () => {
+      gateway = await createTestGateway();
+
+      writeSettings({ curlCommand: 'echo' });
+      await fetch('/gateway/https://slack.com/api/auth.test');
+
+      // The proxy itself runs curl through the injected runCurlAsync, so what
+      // this checks is the other path: the gateway handing the command to the
+      // curl module, which is where the call sites inside the services reach
+      // for it.
+      const result = await runCapturedAsync(['picked-up']);
+      expect(result.stdout.trim()).toBe('picked-up');
+    });
+
+    it('does not warn about settings it can apply', async () => {
+      gateway = await createTestGateway();
+
+      writeSettings({ passthroughUnknown: true });
+      await fetch('/gateway/https://unknown-api.example.com/thing');
+
+      expect(errorLogs.filter((message) => message.startsWith('Warning:'))).toEqual([]);
     });
   });
 

--- a/tests/latchkeyEndpoint.test.ts
+++ b/tests/latchkeyEndpoint.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { EncryptedStorage } from '../src/encryptedStorage.js';
@@ -127,20 +127,27 @@ describe('/latchkey/ endpoint', () => {
   let logs: string[];
   let errorLogs: string[];
 
+  /**
+   * Merge into the config file the gateway reads, so that settings survive the
+   * per-request reload the way they do in a real deployment.
+   */
+  function updateConfigFile(update: Record<string, unknown>): void {
+    const path = join(tempDir, 'config.json');
+    const existing = existsSync(path)
+      ? (JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>)
+      : {};
+    writeFileSync(path, JSON.stringify({ ...existing, ...update }));
+  }
+
   function createMockConfig(configOverrides: Partial<Config> = {}): Config {
-    const base = new Config((name) => {
+    if (Object.keys(configOverrides).length > 0) {
+      updateConfigFile({ settings: configOverrides });
+    }
+    return new Config((name) => {
       if (name === 'LATCHKEY_DIRECTORY') return tempDir;
       if (name === 'LATCHKEY_ENCRYPTION_KEY') return TEST_ENCRYPTION_KEY;
       return undefined;
     });
-    if (Object.keys(configOverrides).length === 0) {
-      return base;
-    }
-    return Object.assign(
-      Object.create(Object.getPrototypeOf(base) as object) as Config,
-      base,
-      configOverrides
-    );
   }
 
   async function createTestGateway(


### PR DESCRIPTION
Stacked on #133, so this diff is against that branch. #133 alone reloads only the registered services; this one reloads the whole configuration, which is the "if we'd rather not reload just part of it" option.

## What changes for users

A running `latchkey gateway` rereads the environment and `config.json` on every request, instead of holding whatever they said when it started. Editing a setting now takes effect on the next request, with no restart.

These become live:

| Setting | Effect while running |
|---|---|
| `passthroughUnknown` | requests to unknown services start or stop being forwarded |
| `hideBuiltinServices` | adding a name hides that service; removing it brings the service back |
| `permissionsConfig` | the gateway starts consulting a different `permissions.json` |
| `permissionsDoNotUseBuiltinSchemas` | built-in request schemas stop or start being applied |
| `credentialsRefreshDisabled` | expired credentials stop or start being refreshed |
| `curlCommand` | a different curl binary is spawned, for proxied requests and credential checks alike |
| `browserDisabled`, `browserEphemeral`, `appNamePrefix` | apply to `auth browser` issued through the gateway |

Stored credentials, `permissions.json` and (from #133) registered services already reloaded this way.

## What still needs a restart

These control work that finishes before the first request arrives, so a running server genuinely cannot apply them:

| Setting | Why |
|---|---|
| `keyringServiceName`, `keyringAccountName` | the encryption key was resolved at startup |
| `gatewayListenHost`, `gatewayListenPort` | the listening socket is already bound |
| `countingDisabled` | the daily count already ran |

Rather than let these change silently, the gateway writes a warning to stderr the first time it notices one differ, naming the reason and saying a restart is needed. It warns once per setting, not once per request.

## Internal changes worth knowing about

**`curl.ts` gained process-wide state.** `curlCommand` is read at 8 call sites deep inside the services — `src/services/core/base.ts:224` sits inside `Service.checkApiCredentials`, a public method many services override — so threading a config down to them would change that signature and every override. Instead the gateway hands the command to `src/curl.ts`, next to the swappable runners that module already keeps. This is the one piece I'd want a second opinion on; dropping it and leaving `curlCommand` restart-only removes about 30 lines.

**`Config.reload()`** returns a new `Config` from the same sources the receiver was built from, leaving the receiver alone so a request in flight keeps a stable view. `Config` gained two public readonly fields (`getEnv`, `loadSettingsFromFile`) to make that possible.

## Risk to be aware of

A malformed `config.json` no longer fails loudly at startup — it is now read on every request, and both `readConfigFile` and `loadSettings` fall back to defaults rather than throwing. A half-written file (an editor that truncates before writing) would therefore make the gateway briefly serve *default* settings, silently. Latchkey's own writes go through `writeFileAtomic`, so `latchkey services register` and friends are safe; hand-editing is the exposure.

## Manual testing

Run `latchkey gateway` in one terminal and watch its output while doing the following in another. None of these should need a restart.

1. **passthroughUnknown** — `curl` an unknown host through `/gateway/`; expect 400. Set `"passthroughUnknown": true` under `settings` in `config.json`, repeat; expect the request to be forwarded. Set it back to `false` and confirm it 400s again.
2. **hideBuiltinServices** — with credentials stored for a built-in service, make a request through the gateway and confirm it works. Add `"hideBuiltinServices": ["github"]`, repeat; expect 400. Remove the name and confirm the service comes back.
3. **permissionsConfig** — point it at a second `permissions.json` that denies something the first allows, and confirm the denial takes effect on the next request.
4. **curlCommand** — point it at a wrapper script that logs its arguments and then execs the real curl. Confirm the log records both a proxied `/gateway/` request **and** a `latchkey services info <service>` issued through the gateway (that second one is the deep call path, and is the reason for the `curl.ts` change).
5. **Restart-only warning** — change `gatewayListenPort` in `config.json`, then make two requests. Expect exactly one warning on the gateway's stderr naming `gatewayListenPort`, and the gateway still listening on the original port.
6. **No spurious warnings** — change only `passthroughUnknown` and confirm nothing is warned about.
7. **Registered services still work** (carried over from #133) — `latchkey services register` a self-hosted instance while the gateway runs, use it immediately, then `latchkey services deregister` it and confirm it stops being served.
8. **Malformed config** — write invalid JSON into `config.json` while the gateway is running. Expect it to keep serving on default settings rather than crash, and to recover once the file is valid again.
9. **Under load** — hammer the gateway (`for i in $(seq 200); do ... done` or similar) while editing `config.json`, and confirm no crashes, no torn behavior, and that requests keep succeeding.

## Automated tests

- `tests/config.test.ts` — 5 cases for `reload`: setting added, setting removed, receiver left untouched, environment still winning over the file, repeated reloads.
- `tests/gateway.test.ts` — 7 integration cases against a live gateway, covering items 1, 2, 4, 5 and 6 above.
- `tests/curl.test.ts` — new file, 3 cases for the curl-command seam.

Verified that 6 of the 7 gateway cases fail when the `reload()` call is reverted. Full suite: 836 passed, lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
