### PR TITLE
Improvements to `latchkey auth re-encrypt`

### DIFF
--- a/src/apiCredentials/store.ts
+++ b/src/apiCredentials/store.ts
@@ -179,6 +179,14 @@ export class ApiCredentialStore {
   }
 
   /**
+   * List the services that have a preparation stored, in the order they appear
+   * in the store.
+   */
+  listPreparedServiceNames(): readonly string[] {
+    return Object.keys(this.loadStoreData().preparations);
+  }
+
+  /**
    * List the accounts that have credentials stored for a service, in the order
    * they appear in the store. Returns an empty array when the service has no
    * stored credentials.

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -1322,8 +1322,10 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
         const sourceStore = new ApiCredentialStore(deps.config.credentialStorePath, sourceStorage);
 
         let allCredentials: ReadonlyMap<string, ReadonlyMap<string, ApiCredentials>>;
+        let preparedServiceNames: readonly string[];
         try {
           allCredentials = sourceStore.getAll();
+          preparedServiceNames = sourceStore.listPreparedServiceNames();
         } catch (error) {
           if (error instanceof ApiCredentialStoreError || error instanceof EncryptedStorageError) {
             deps.errorLog(`Error: ${error.message}`);
@@ -1350,16 +1352,20 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           }
         }
 
+        // A service can have only a preparation and no credentials yet, so both
+        // sections of the store contribute to what can be re-encrypted.
+        const storedServiceNames = new Set([...allCredentials.keys(), ...preparedServiceNames]);
+
         let selectedServiceNames: string[];
         if (options.services !== undefined) {
-          const missing = options.services.filter((name) => !allCredentials.has(name));
+          const missing = options.services.filter((name) => !storedServiceNames.has(name));
           if (missing.length > 0) {
-            deps.errorLog(`Error: No stored credentials for: ${missing.join(', ')}`);
+            deps.errorLog(`Error: No stored credentials or preparation for: ${missing.join(', ')}`);
             deps.exit(1);
           }
           selectedServiceNames = options.services;
         } else {
-          selectedServiceNames = [...allCredentials.keys()];
+          selectedServiceNames = [...storedServiceNames];
         }
 
         if (selectedServiceNames.length === 0 && browserState === null) {

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -1262,6 +1262,9 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
     .description(
       'Re-encrypt stored credentials with a new key and write them into a ' +
         'destination directory, using the same filename Latchkey itself expects. ' +
+        'An existing credential store in the destination directory is kept and ' +
+        'the re-encrypted services are added into it, overwriting services with ' +
+        'the same name. ' +
         'The new key is read from stdin so that it does not appear in the process ' +
         'arguments or shell history. When stdin is empty, the existing encryption ' +
         'key is reused.'
@@ -1274,91 +1277,149 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
       '--services <services...>',
       'Only include these services in the new encrypted store (default: all stored services)'
     )
+    .option(
+      '--browser-state',
+      'Also re-encrypt the browser state file into the destination directory'
+    )
     .addHelpText(
       'after',
       `\nExamples:\n  $ openssl rand -base64 32 | latchkey auth re-encrypt ~/latchkey-export` +
-        `\n  $ echo "" | latchkey auth re-encrypt ~/latchkey-export --services gitlab slack`
+        `\n  $ echo "" | latchkey auth re-encrypt ~/latchkey-export --services gitlab slack` +
+        `\n  $ echo "" | latchkey auth re-encrypt ~/latchkey-export --browser-state`
     )
-    .action(async (destinationDirectory: string, options: { services?: string[] }) => {
-      refuseInGatewayMode(deps, 'auth re-encrypt');
+    .action(
+      async (
+        destinationDirectory: string,
+        options: { services?: string[]; browserState?: boolean }
+      ) => {
+        refuseInGatewayMode(deps, 'auth re-encrypt');
 
-      if (existsSync(destinationDirectory) && !statSync(destinationDirectory).isDirectory()) {
-        deps.errorLog(`Error: Destination is not a directory: ${destinationDirectory}`);
-        deps.exit(1);
-      }
-
-      const destination = join(destinationDirectory, basename(deps.config.credentialStorePath));
-      if (existsSync(destination)) {
-        deps.errorLog(`Error: Destination file already exists: ${destination}`);
-        deps.errorLog('Remove it first or choose a different destination directory.');
-        deps.exit(1);
-      }
-
-      const sourceKey = await resolveEncryptionKeyFromConfig(deps.config);
-
-      // An empty stdin means "reuse the existing encryption key".
-      const stdinKey = (await deps.readStdin()).trim();
-      const destinationKey = stdinKey === '' ? sourceKey : stdinKey;
-      // Validate the key up front using the encryption routine itself, rather
-      // than duplicating its key-format checks.
-      try {
-        encrypt('', destinationKey);
-      } catch (error) {
-        if (error instanceof EncryptionError) {
-          deps.errorLog(`Error: ${error.message}. Generate a key with: openssl rand -base64 32`);
+        if (existsSync(destinationDirectory) && !statSync(destinationDirectory).isDirectory()) {
+          deps.errorLog(`Error: Destination is not a directory: ${destinationDirectory}`);
           deps.exit(1);
         }
-        throw error;
-      }
 
-      const sourceStorage = new EncryptedStorage(sourceKey);
-      const sourceStore = new ApiCredentialStore(deps.config.credentialStorePath, sourceStorage);
+        const destination = join(destinationDirectory, basename(deps.config.credentialStorePath));
 
-      let allCredentials: ReadonlyMap<string, ReadonlyMap<string, ApiCredentials>>;
-      try {
-        allCredentials = sourceStore.getAll();
-      } catch (error) {
-        if (error instanceof ApiCredentialStoreError || error instanceof EncryptedStorageError) {
-          deps.errorLog(`Error: ${error.message}`);
-          deps.exit(1);
+        const sourceKey = await resolveEncryptionKeyFromConfig(deps.config);
+
+        // An empty stdin means "reuse the existing encryption key".
+        const stdinKey = (await deps.readStdin()).trim();
+        const destinationKey = stdinKey === '' ? sourceKey : stdinKey;
+        // Validate the key up front using the encryption routine itself, rather
+        // than duplicating its key-format checks.
+        try {
+          encrypt('', destinationKey);
+        } catch (error) {
+          if (error instanceof EncryptionError) {
+            deps.errorLog(`Error: ${error.message}. Generate a key with: openssl rand -base64 32`);
+            deps.exit(1);
+          }
+          throw error;
         }
-        throw error;
-      }
 
-      let selectedServiceNames: string[];
-      if (options.services !== undefined) {
-        const missing = options.services.filter((name) => !allCredentials.has(name));
-        if (missing.length > 0) {
-          deps.errorLog(`Error: No stored credentials for: ${missing.join(', ')}`);
-          deps.exit(1);
+        const sourceStorage = new EncryptedStorage(sourceKey);
+        const sourceStore = new ApiCredentialStore(deps.config.credentialStorePath, sourceStorage);
+
+        let allCredentials: ReadonlyMap<string, ReadonlyMap<string, ApiCredentials>>;
+        try {
+          allCredentials = sourceStore.getAll();
+        } catch (error) {
+          if (error instanceof ApiCredentialStoreError || error instanceof EncryptedStorageError) {
+            deps.errorLog(`Error: ${error.message}`);
+            deps.exit(1);
+          }
+          throw error;
         }
-        selectedServiceNames = options.services;
-      } else {
-        selectedServiceNames = [...allCredentials.keys()];
-      }
 
-      if (selectedServiceNames.length === 0) {
-        deps.errorLog('Error: No stored credentials found to re-encrypt.');
-        deps.exit(1);
-      }
-
-      const destinationStorage = new EncryptedStorage(destinationKey);
-      const destinationStore = new ApiCredentialStore(destination, destinationStorage);
-      for (const serviceName of selectedServiceNames) {
-        const accountMap = allCredentials.get(serviceName);
-        if (accountMap !== undefined) {
-          for (const [account, credentials] of accountMap) {
-            destinationStore.save(serviceName, credentials, account);
+        const sourceBrowserStatePath = deps.config.browserStatePath;
+        let browserState: string | null = null;
+        if (options.browserState === true) {
+          try {
+            browserState = sourceStorage.readFile(sourceBrowserStatePath);
+          } catch (error) {
+            if (error instanceof EncryptedStorageError) {
+              deps.errorLog(`Error: ${error.message}`);
+              deps.exit(1);
+            }
+            throw error;
+          }
+          if (browserState === null) {
+            deps.errorLog(`Error: No browser state found at ${sourceBrowserStatePath}.`);
+            deps.exit(1);
           }
         }
-        const preparation = sourceStore.getPreparation(serviceName);
-        if (preparation !== null) {
-          destinationStore.savePreparation(serviceName, preparation);
+
+        let selectedServiceNames: string[];
+        if (options.services !== undefined) {
+          const missing = options.services.filter((name) => !allCredentials.has(name));
+          if (missing.length > 0) {
+            deps.errorLog(`Error: No stored credentials for: ${missing.join(', ')}`);
+            deps.exit(1);
+          }
+          selectedServiceNames = options.services;
+        } else {
+          selectedServiceNames = [...allCredentials.keys()];
+        }
+
+        if (selectedServiceNames.length === 0 && browserState === null) {
+          deps.errorLog('Error: No stored credentials found to re-encrypt.');
+          deps.exit(1);
+        }
+
+        const destinationStorage = new EncryptedStorage(destinationKey);
+        const destinationStore = new ApiCredentialStore(destination, destinationStorage);
+        // Reading the destination store validates that it can be decrypted with
+        // the destination key before anything is written into it.
+        if (existsSync(destination)) {
+          try {
+            destinationStore.getAll();
+          } catch (error) {
+            if (
+              error instanceof ApiCredentialStoreError ||
+              error instanceof EncryptedStorageError
+            ) {
+              deps.errorLog(
+                `Error: Cannot read the existing credential store at ${destination}: ${error.message}`
+              );
+              deps.errorLog('It must be readable with the new key to be added to.');
+              deps.exit(1);
+            }
+            throw error;
+          }
+        }
+
+        for (const serviceName of selectedServiceNames) {
+          // Replace whatever the destination has for this service.
+          destinationStore.deleteAll(serviceName);
+          const accountMap = allCredentials.get(serviceName);
+          if (accountMap !== undefined) {
+            for (const [account, credentials] of accountMap) {
+              destinationStore.save(serviceName, credentials, account);
+            }
+          }
+          const preparation = sourceStore.getPreparation(serviceName);
+          if (preparation !== null) {
+            destinationStore.savePreparation(serviceName, preparation);
+          }
+        }
+
+        if (selectedServiceNames.length > 0) {
+          deps.log(
+            `Re-encrypted ${String(selectedServiceNames.length)} service(s) to ${destination}.`
+          );
+        }
+
+        if (browserState !== null) {
+          const browserStateDestination = join(
+            destinationDirectory,
+            basename(sourceBrowserStatePath)
+          );
+          destinationStorage.writeFile(browserStateDestination, browserState);
+          deps.log(`Re-encrypted browser state to ${browserStateDestination}.`);
         }
       }
-
-      deps.log(`Re-encrypted ${String(selectedServiceNames.length)} service(s) to ${destination}.`);
-    });
+    );
 
   program
     .command('skill-md')

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -77,6 +77,12 @@ import {
   type PermissionCheckMetadata,
 } from './permissions.js';
 import { ErrorMessages } from './errorMessages.js';
+import {
+  LATEST_VERSION,
+  MigrationError,
+  readDataFormatVersionOfDirectory,
+  writeDataFormatVersionOfDirectory,
+} from './migrations.js';
 import { getSkillMdContent } from './skillMd.js';
 import { startGateway } from './gateway/server.js';
 import {
@@ -1378,6 +1384,29 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
         // Reading the destination store validates that it can be decrypted with
         // the destination key before anything is written into it.
         if (existsSync(destination)) {
+          // An existing store in an older data format would be migrated (and
+          // thereby mangled) by the next Latchkey run, so refuse to add to it.
+          let destinationVersion: number;
+          try {
+            destinationVersion = readDataFormatVersionOfDirectory(destinationDirectory);
+          } catch (error) {
+            if (error instanceof MigrationError) {
+              deps.errorLog(`Error: ${error.message}`);
+              deps.exit(1);
+            }
+            throw error;
+          }
+          if (destinationVersion !== LATEST_VERSION) {
+            deps.errorLog(
+              `Error: The existing credential store at ${destination} is in data format ` +
+                `version ${String(destinationVersion)}, but ${String(LATEST_VERSION)} is required.`
+            );
+            deps.errorLog(
+              'Point Latchkey at that directory to migrate it first, or choose an empty destination.'
+            );
+            deps.exit(1);
+          }
+
           try {
             destinationStore.getAll();
           } catch (error) {
@@ -1424,6 +1453,10 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           destinationStorage.writeFile(browserStateDestination, browserState);
           deps.log(`Re-encrypted browser state to ${browserStateDestination}.`);
         }
+
+        // Stamp the data format version so that Latchkey does not mistake the
+        // exported directory for one in the oldest format and "migrate" it.
+        writeDataFormatVersionOfDirectory(destinationDirectory, LATEST_VERSION);
       }
     );
 

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -272,8 +272,12 @@ const MIGRATIONS: readonly MigrationFunction[] = [
 
 export const LATEST_VERSION = MIGRATIONS.length;
 
-export function readDataFormatVersion(config: Config): number {
-  const versionFilePath = join(config.directory, DATA_FORMAT_VERSION_FILENAME);
+/**
+ * Read the data format version of an arbitrary Latchkey directory. A directory
+ * without a version file is in the oldest format (version 0).
+ */
+export function readDataFormatVersionOfDirectory(directory: string): number {
+  const versionFilePath = join(directory, DATA_FORMAT_VERSION_FILENAME);
   if (!existsSync(versionFilePath)) {
     return 0;
   }
@@ -287,8 +291,12 @@ export function readDataFormatVersion(config: Config): number {
   return version;
 }
 
-function writeDataFormatVersion(config: Config, version: number): void {
-  const versionFilePath = join(config.directory, DATA_FORMAT_VERSION_FILENAME);
+export function readDataFormatVersion(config: Config): number {
+  return readDataFormatVersionOfDirectory(config.directory);
+}
+
+export function writeDataFormatVersionOfDirectory(directory: string, version: number): void {
+  const versionFilePath = join(directory, DATA_FORMAT_VERSION_FILENAME);
   writeFileAtomic(versionFilePath, String(version));
 }
 
@@ -307,7 +315,7 @@ export async function runMigrations(
     // created store for one in the oldest format and "migrate" (i.e. corrupt)
     // it.
     mkdirSync(config.directory, { recursive: true, mode: 0o700 });
-    writeDataFormatVersion(config, LATEST_VERSION);
+    writeDataFormatVersionOfDirectory(config.directory, LATEST_VERSION);
     return;
   }
 
@@ -329,6 +337,6 @@ export async function runMigrations(
   }
 
   if (currentVersion < LATEST_VERSION) {
-    writeDataFormatVersion(config, LATEST_VERSION);
+    writeDataFormatVersionOfDirectory(config.directory, LATEST_VERSION);
   }
 }

--- a/tests/apiCredentialStore.test.ts
+++ b/tests/apiCredentialStore.test.ts
@@ -162,6 +162,17 @@ describe('ApiCredentialStore', () => {
       expect((store.getPreparation('google-gmail') as OAuthCredentials).clientId).toBe('new-id');
     });
 
+    it('should list the services that have a preparation', () => {
+      const store = new ApiCredentialStore(storePath, encryptedStorage);
+      expect(store.listPreparedServiceNames()).toEqual([]);
+
+      store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));
+      store.savePreparation('gitlab', new OAuthCredentials('gitlab-id', 'gitlab-secret'));
+      store.save('slack', new AuthorizationBearer('token'));
+
+      expect([...store.listPreparedServiceNames()].sort()).toEqual(['gitlab', 'google-gmail']);
+    });
+
     it('should keep preparations separate from credentials', () => {
       const store = new ApiCredentialStore(storePath, encryptedStorage);
       store.savePreparation('google-gmail', new OAuthCredentials('client-id', 'client-secret'));

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1285,9 +1285,28 @@ describe('CLI commands with dependency injection', () => {
     const STORE_FILENAME = 'credentials.json';
     const BROWSER_STATE_FILENAME = 'browser_state.json';
 
-    function writeStore(contents: Record<string, unknown>): void {
-      writeSecureFile(join(tempDir, STORE_FILENAME), JSON.stringify(nestAccounts(contents)));
+    function writeStore(
+      contents: Record<string, unknown>,
+      preparations: Record<string, unknown> = {}
+    ): void {
+      writeSecureFile(
+        join(tempDir, STORE_FILENAME),
+        JSON.stringify({ ...nestAccounts(contents), preparations })
+      );
     }
+
+    function readPreparationsWithKey(path: string, key: string): Record<string, unknown> {
+      const raw = JSON.parse(new EncryptedStorage(key).readFile(path) ?? '{}') as {
+        preparations?: Record<string, unknown>;
+      };
+      return raw.preparations ?? {};
+    }
+
+    const GITLAB_PREPARATION = {
+      objectType: 'oauth',
+      clientId: 'gitlab-client-id',
+      clientSecret: 'gitlab-client-secret',
+    };
 
     it('re-encrypts all stored credentials with the new key', async () => {
       writeStore({
@@ -1348,7 +1367,7 @@ describe('CLI commands with dependency injection', () => {
       expect(Object.keys(reEncrypted)).toEqual(['slack']);
     });
 
-    it('errors when a requested service has no stored credentials', async () => {
+    it('errors when a requested service has neither credentials nor a preparation', async () => {
       writeStore({ slack: { objectType: 'slack', token: 'tok', dCookie: 'cookie' } });
       const destinationDirectory = join(tempDir, 'export');
 
@@ -1357,6 +1376,83 @@ describe('CLI commands with dependency injection', () => {
 
       expect(exitCode).toBe(1);
       expect(existsSync(join(destinationDirectory, STORE_FILENAME))).toBe(false);
+    });
+
+    it('carries the preparations of the re-encrypted services', async () => {
+      writeStore(
+        { gitlab: { objectType: 'authorizationBearer', token: 'gitlab-token' } },
+        { gitlab: GITLAB_PREPARATION }
+      );
+      const destinationDirectory = join(tempDir, 'export');
+
+      const deps = withStdinKey(NEW_ENCRYPTION_KEY);
+      await runCommand(['auth', 're-encrypt', destinationDirectory], deps);
+
+      expect(exitCode).toBeNull();
+      const destination = join(destinationDirectory, STORE_FILENAME);
+      expect(readPreparationsWithKey(destination, NEW_ENCRYPTION_KEY)).toEqual({
+        gitlab: GITLAB_PREPARATION,
+      });
+    });
+
+    it('includes services that only have a preparation', async () => {
+      writeStore(
+        { slack: { objectType: 'slack', token: 'tok', dCookie: 'cookie' } },
+        { gitlab: GITLAB_PREPARATION }
+      );
+      const destinationDirectory = join(tempDir, 'export');
+
+      const deps = withStdinKey(NEW_ENCRYPTION_KEY);
+      await runCommand(['auth', 're-encrypt', destinationDirectory], deps);
+
+      expect(exitCode).toBeNull();
+      const destination = join(destinationDirectory, STORE_FILENAME);
+      expect(Object.keys(readWithKey(destination, NEW_ENCRYPTION_KEY))).toEqual(['slack']);
+      expect(readPreparationsWithKey(destination, NEW_ENCRYPTION_KEY)).toEqual({
+        gitlab: GITLAB_PREPARATION,
+      });
+      expect(logs.join('\n')).toContain('2 service(s)');
+    });
+
+    it('selects a service that only has a preparation with --services', async () => {
+      writeStore(
+        { slack: { objectType: 'slack', token: 'tok', dCookie: 'cookie' } },
+        { gitlab: GITLAB_PREPARATION }
+      );
+      const destinationDirectory = join(tempDir, 'export');
+
+      const deps = withStdinKey(NEW_ENCRYPTION_KEY);
+      await runCommand(['auth', 're-encrypt', destinationDirectory, '--services', 'gitlab'], deps);
+
+      expect(exitCode).toBeNull();
+      const destination = join(destinationDirectory, STORE_FILENAME);
+      expect(readWithKey(destination, NEW_ENCRYPTION_KEY)).toEqual({});
+      expect(readPreparationsWithKey(destination, NEW_ENCRYPTION_KEY)).toEqual({
+        gitlab: GITLAB_PREPARATION,
+      });
+    });
+
+    it('replaces an existing preparation in the destination', async () => {
+      writeStore({}, { gitlab: GITLAB_PREPARATION });
+      const destinationDirectory = join(tempDir, 'export');
+      const destination = join(destinationDirectory, STORE_FILENAME);
+      new EncryptedStorage(NEW_ENCRYPTION_KEY).writeFile(
+        destination,
+        JSON.stringify({
+          credentials: {},
+          preparations: {
+            gitlab: { objectType: 'oauth', clientId: 'old-id', clientSecret: 'old-secret' },
+          },
+        })
+      );
+
+      const deps = withStdinKey(NEW_ENCRYPTION_KEY);
+      await runCommand(['auth', 're-encrypt', destinationDirectory], deps);
+
+      expect(exitCode).toBeNull();
+      expect(readPreparationsWithKey(destination, NEW_ENCRYPTION_KEY)).toEqual({
+        gitlab: GITLAB_PREPARATION,
+      });
     });
 
     it('errors for an invalid encryption key read from stdin', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1281,8 +1281,9 @@ describe('CLI commands with dependency injection', () => {
       return createMockDependencies({ readStdin: () => Promise.resolve(key), ...overrides });
     }
 
-    // The credential store filename used by the mock config.
+    // The filenames used by the mock config.
     const STORE_FILENAME = 'credentials.json';
+    const BROWSER_STATE_FILENAME = 'browser_state.json';
 
     function writeStore(contents: Record<string, unknown>): void {
       writeSecureFile(join(tempDir, STORE_FILENAME), JSON.stringify(nestAccounts(contents)));
@@ -1382,7 +1383,40 @@ describe('CLI commands with dependency injection', () => {
       ).toEqual(['slack']);
     });
 
-    it('refuses to overwrite an existing credential store in the destination', async () => {
+    it('adds the services into an existing credential store, overwriting by service', async () => {
+      writeStore({
+        slack: { objectType: 'slack', token: 'new-tok', dCookie: 'new-cookie' },
+      });
+      const destinationDirectory = join(tempDir, 'export');
+      const destination = join(destinationDirectory, STORE_FILENAME);
+      new EncryptedStorage(NEW_ENCRYPTION_KEY).writeFile(
+        destination,
+        JSON.stringify(
+          nestAccounts({
+            slack: { objectType: 'slack', token: 'old-tok', dCookie: 'old-cookie' },
+            discord: { objectType: 'authorizationBearer', token: 'discord-token' },
+          })
+        )
+      );
+
+      const deps = withStdinKey(NEW_ENCRYPTION_KEY);
+      await runCommand(['auth', 're-encrypt', destinationDirectory], deps);
+
+      expect(exitCode).toBeNull();
+      const reEncrypted = readWithKey(destination, NEW_ENCRYPTION_KEY);
+      expect(Object.keys(reEncrypted).sort()).toEqual(['discord', 'slack']);
+      expect(reEncrypted.slack).toEqual({
+        objectType: 'slack',
+        token: 'new-tok',
+        dCookie: 'new-cookie',
+      });
+      expect(reEncrypted.discord).toEqual({
+        objectType: 'authorizationBearer',
+        token: 'discord-token',
+      });
+    });
+
+    it('errors when the existing credential store cannot be read with the new key', async () => {
       writeStore({ slack: { objectType: 'slack', token: 'tok', dCookie: 'cookie' } });
       const destinationDirectory = join(tempDir, 'export');
       mkdirSync(destinationDirectory);
@@ -1394,6 +1428,57 @@ describe('CLI commands with dependency injection', () => {
 
       expect(exitCode).toBe(1);
       expect(readFileSync(destination, 'utf-8')).toBe('existing');
+    });
+
+    it('re-encrypts the browser state with --browser-state', async () => {
+      writeStore({ slack: { objectType: 'slack', token: 'tok', dCookie: 'cookie' } });
+      new EncryptedStorage(TEST_ENCRYPTION_KEY).writeFile(
+        join(tempDir, BROWSER_STATE_FILENAME),
+        '{"cookies":[]}'
+      );
+      const destinationDirectory = join(tempDir, 'export');
+
+      const deps = withStdinKey(NEW_ENCRYPTION_KEY);
+      await runCommand(['auth', 're-encrypt', destinationDirectory, '--browser-state'], deps);
+
+      expect(exitCode).toBeNull();
+      const browserStateDestination = join(destinationDirectory, BROWSER_STATE_FILENAME);
+      expect(new EncryptedStorage(NEW_ENCRYPTION_KEY).readFile(browserStateDestination)).toBe(
+        '{"cookies":[]}'
+      );
+      expect(
+        Object.keys(readWithKey(join(destinationDirectory, STORE_FILENAME), NEW_ENCRYPTION_KEY))
+      ).toEqual(['slack']);
+    });
+
+    it('errors with --browser-state when there is no browser state', async () => {
+      writeStore({ slack: { objectType: 'slack', token: 'tok', dCookie: 'cookie' } });
+      const destinationDirectory = join(tempDir, 'export');
+
+      const deps = withStdinKey(NEW_ENCRYPTION_KEY);
+      await runCommand(['auth', 're-encrypt', destinationDirectory, '--browser-state'], deps);
+
+      expect(exitCode).toBe(1);
+      expect(existsSync(join(destinationDirectory, STORE_FILENAME))).toBe(false);
+    });
+
+    it('overwrites an existing browser state in the destination', async () => {
+      writeStore({});
+      new EncryptedStorage(TEST_ENCRYPTION_KEY).writeFile(
+        join(tempDir, BROWSER_STATE_FILENAME),
+        '{"cookies":["new"]}'
+      );
+      const destinationDirectory = join(tempDir, 'export');
+      const browserStateDestination = join(destinationDirectory, BROWSER_STATE_FILENAME);
+      new EncryptedStorage(NEW_ENCRYPTION_KEY).writeFile(browserStateDestination, 'old');
+
+      const deps = withStdinKey(NEW_ENCRYPTION_KEY);
+      await runCommand(['auth', 're-encrypt', destinationDirectory, '--browser-state'], deps);
+
+      expect(exitCode).toBeNull();
+      expect(new EncryptedStorage(NEW_ENCRYPTION_KEY).readFile(browserStateDestination)).toBe(
+        '{"cookies":["new"]}'
+      );
     });
 
     it('errors when the destination is an existing file, not a directory', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -11,6 +11,7 @@ import { EncryptedStorage } from '../src/encryptedStorage.js';
 import { Config } from '../src/config.js';
 import { ServiceRegistry } from '../src/serviceRegistry.js';
 import { ApiCredentialStatus } from '../src/apiCredentials/base.js';
+import { LATEST_VERSION } from '../src/migrations.js';
 import { Service } from '../src/services/core/base.js';
 import { createMockService, MockService } from './mockService.js';
 import { RegisteredService } from '../src/services/core/registered.js';
@@ -1302,6 +1303,13 @@ describe('CLI commands with dependency injection', () => {
       return raw.preparations ?? {};
     }
 
+    // A destination that already holds a store must be in the current data
+    // format, which real Latchkey directories record in this file.
+    function stampDataFormatVersion(directory: string): void {
+      mkdirSync(directory, { recursive: true });
+      writeFileSync(join(directory, 'data-format-version'), String(LATEST_VERSION));
+    }
+
     const GITLAB_PREPARATION = {
       objectType: 'oauth',
       clientId: 'gitlab-client-id',
@@ -1436,6 +1444,7 @@ describe('CLI commands with dependency injection', () => {
       writeStore({}, { gitlab: GITLAB_PREPARATION });
       const destinationDirectory = join(tempDir, 'export');
       const destination = join(destinationDirectory, STORE_FILENAME);
+      stampDataFormatVersion(destinationDirectory);
       new EncryptedStorage(NEW_ENCRYPTION_KEY).writeFile(
         destination,
         JSON.stringify({
@@ -1485,6 +1494,7 @@ describe('CLI commands with dependency injection', () => {
       });
       const destinationDirectory = join(tempDir, 'export');
       const destination = join(destinationDirectory, STORE_FILENAME);
+      stampDataFormatVersion(destinationDirectory);
       new EncryptedStorage(NEW_ENCRYPTION_KEY).writeFile(
         destination,
         JSON.stringify(
@@ -1515,7 +1525,7 @@ describe('CLI commands with dependency injection', () => {
     it('errors when the existing credential store cannot be read with the new key', async () => {
       writeStore({ slack: { objectType: 'slack', token: 'tok', dCookie: 'cookie' } });
       const destinationDirectory = join(tempDir, 'export');
-      mkdirSync(destinationDirectory);
+      stampDataFormatVersion(destinationDirectory);
       const destination = join(destinationDirectory, STORE_FILENAME);
       writeFileSync(destination, 'existing');
 


### PR DESCRIPTION
- Make `auth re-encrypt` able to write to existing stores.