### PR TITLE
Classify unreadable stored credentials, and stop them failing unrelated exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ defaults:
 - `LATCHKEY_PERMISSIONS_CONFIG`: override the `permissions.json` location.
 - `LATCHKEY_PERMISSIONS_DO_NOT_USE_BUILTIN_SCHEMAS`: do not use the built-in permission definitions.
 - `LATCHKEY_PASSTHROUGH_UNKNOWN`: if set, Latchkey will forward requests (via `latchkey curl` or gateway) even if no credentials are injected.
+- `LATCHKEY_ERROR_JSON`: when set to `1`, a failure that Latchkey can classify is also printed on stderr as a JSON object (`{"latchkeyError": {"code": ..., "message": ..., "serviceName": ...}}`) after the human-readable message. Programs driving Latchkey as a subprocess can dispatch on `code` instead of matching on message text. Classified failures also use a dedicated exit code (currently: `3` for a stored credential no known schema accepts, which usually means a newer Latchkey wrote the store).
 - `LATCHKEY_HIDE_BUILTIN_SERVICES`: comma-separated list of built-in service names to disable/hide.
 - `LATCHKEY_GATEWAY`: when set to a base URL (e.g. `http://localhost:1989`), the CLI delegates commands to a remote Latchkey gateway instead of running them locally. Commands that change local state (`auth set`, `auth clear`, `auth re-encrypt`, `services register`, `ensure-browser`, `gateway`) cannot run in this mode.
 - `LATCHKEY_GATEWAY_LISTEN_HOST`, `LATCHKEY_GATEWAY_LISTEN_PORT`: default address and port the local `latchkey gateway` command binds to when `--host` / `--port` are not supplied (defaults: `localhost`, `1989`). Distinct from `LATCHKEY_GATEWAY`, which configures a *remote* gateway URL.

--- a/src/apiCredentials/store.ts
+++ b/src/apiCredentials/store.ts
@@ -36,6 +36,21 @@ export class ApiCredentialStoreError extends Error {
 }
 
 /**
+ * Thrown when a stored credential matches no known credential schema, which
+ * usually means the store was written by a newer Latchkey that knows a
+ * credential type this one does not.
+ */
+export class InvalidStoredCredentialError extends ApiCredentialStoreError {
+  readonly serviceName: string;
+
+  constructor(serviceName: string, detail: string) {
+    super(`Invalid credential data for service ${serviceName}: ${detail}`);
+    this.name = 'InvalidStoredCredentialError';
+    this.serviceName = serviceName;
+  }
+}
+
+/**
  * Thrown when a service has more than one account stored and no account was
  * specified to disambiguate between them.
  */
@@ -102,9 +117,7 @@ export class ApiCredentialStore {
   private parseCredentials(serviceName: string, credentialData: unknown): ApiCredentials {
     const parseResult = ApiCredentialsSchema.safeParse(credentialData);
     if (!parseResult.success) {
-      throw new ApiCredentialStoreError(
-        `Invalid credential data for service ${serviceName}: ${parseResult.error.message}`
-      );
+      throw new InvalidStoredCredentialError(serviceName, parseResult.error.message);
     }
     return deserializeCredentials(parseResult.data);
   }
@@ -198,13 +211,44 @@ export class ApiCredentialStore {
   }
 
   /**
+   * List the services that have credentials stored, in the order they appear in
+   * the store. Unlike {@link getAll} this does not parse the credentials, so it
+   * works even when the store holds a credential this Latchkey cannot read.
+   */
+  listServiceNames(): readonly string[] {
+    return Object.keys(this.loadStoreData().credentials);
+  }
+
+  /**
    * Return all stored credentials as a map of service name to a map of account
    * to credentials.
    */
   getAll(): ReadonlyMap<string, ReadonlyMap<string, ApiCredentials>> {
     const data = this.loadStoreData();
+    return this.parseServices(data, Object.keys(data.credentials));
+  }
+
+  /**
+   * Like {@link getAll}, but only for the named services: services that are not
+   * named are neither parsed nor returned. Names without stored credentials are
+   * skipped.
+   */
+  getAllForServices(
+    serviceNames: readonly string[]
+  ): ReadonlyMap<string, ReadonlyMap<string, ApiCredentials>> {
+    return this.parseServices(this.loadStoreData(), serviceNames);
+  }
+
+  private parseServices(
+    data: StoreData,
+    serviceNames: readonly string[]
+  ): ReadonlyMap<string, ReadonlyMap<string, ApiCredentials>> {
     const result = new Map<string, ReadonlyMap<string, ApiCredentials>>();
-    for (const [serviceName, serviceData] of Object.entries(data.credentials)) {
+    for (const serviceName of serviceNames) {
+      const serviceData = data.credentials[serviceName];
+      if (serviceData === undefined) {
+        continue;
+      }
       const accountMap = new Map<string, ApiCredentials>();
       for (const [account, credentialData] of Object.entries(serviceData)) {
         accountMap.set(account, this.parseCredentials(serviceName, credentialData));

--- a/src/cliCommands.ts
+++ b/src/cliCommands.ts
@@ -10,7 +10,9 @@ import {
   AmbiguousAccountError,
   ApiCredentialStore,
   ApiCredentialStoreError,
+  InvalidStoredCredentialError,
 } from './apiCredentials/store.js';
+import { failWithClassifiedError, INVALID_STORED_CREDENTIAL_EXIT_CODE } from './cliErrors.js';
 import {
   ApiCredentials,
   ApiCredentialsUsageError,
@@ -1327,11 +1329,15 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
         const sourceStorage = new EncryptedStorage(sourceKey);
         const sourceStore = new ApiCredentialStore(deps.config.credentialStorePath, sourceStorage);
 
-        let allCredentials: ReadonlyMap<string, ReadonlyMap<string, ApiCredentials>>;
-        let preparedServiceNames: readonly string[];
+        // Only the selected services are parsed, and only below, once the
+        // selection is known: a credential this Latchkey cannot read must not
+        // fail an export that never asked for it.
+        let storedServiceNames: ReadonlySet<string>;
         try {
-          allCredentials = sourceStore.getAll();
-          preparedServiceNames = sourceStore.listPreparedServiceNames();
+          storedServiceNames = new Set([
+            ...sourceStore.listServiceNames(),
+            ...sourceStore.listPreparedServiceNames(),
+          ]);
         } catch (error) {
           if (error instanceof ApiCredentialStoreError || error instanceof EncryptedStorageError) {
             deps.errorLog(`Error: ${error.message}`);
@@ -1358,10 +1364,6 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
           }
         }
 
-        // A service can have only a preparation and no credentials yet, so both
-        // sections of the store contribute to what can be re-encrypted.
-        const storedServiceNames = new Set([...allCredentials.keys(), ...preparedServiceNames]);
-
         let selectedServiceNames: string[];
         if (options.services !== undefined) {
           const missing = options.services.filter((name) => !storedServiceNames.has(name));
@@ -1377,6 +1379,33 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
         if (selectedServiceNames.length === 0 && browserState === null) {
           deps.errorLog('Error: No stored credentials found to re-encrypt.');
           deps.exit(1);
+        }
+
+        // Parse everything that will be written before writing any of it.
+        let allCredentials: ReadonlyMap<string, ReadonlyMap<string, ApiCredentials>>;
+        const preparations = new Map<string, ApiCredentials>();
+        try {
+          allCredentials = sourceStore.getAllForServices(selectedServiceNames);
+          for (const serviceName of selectedServiceNames) {
+            const preparation = sourceStore.getPreparation(serviceName);
+            if (preparation !== null) {
+              preparations.set(serviceName, preparation);
+            }
+          }
+        } catch (error) {
+          if (error instanceof InvalidStoredCredentialError) {
+            failWithClassifiedError(deps, {
+              code: 'invalid_stored_credential',
+              message: error.message,
+              serviceName: error.serviceName,
+              exitCode: INVALID_STORED_CREDENTIAL_EXIT_CODE,
+            });
+          }
+          if (error instanceof ApiCredentialStoreError || error instanceof EncryptedStorageError) {
+            deps.errorLog(`Error: ${error.message}`);
+            deps.exit(1);
+          }
+          throw error;
         }
 
         const destinationStorage = new EncryptedStorage(destinationKey);
@@ -1433,8 +1462,8 @@ export function registerCommands(program: Command, deps: CliDependencies): void 
               destinationStore.save(serviceName, credentials, account);
             }
           }
-          const preparation = sourceStore.getPreparation(serviceName);
-          if (preparation !== null) {
+          const preparation = preparations.get(serviceName);
+          if (preparation !== undefined) {
             destinationStore.savePreparation(serviceName, preparation);
           }
         }

--- a/src/cliErrors.ts
+++ b/src/cliErrors.ts
@@ -1,0 +1,52 @@
+/**
+ * Machine-readable failure reporting for the CLI.
+ *
+ * Programs that drive latchkey as a subprocess have to tell its failure modes
+ * apart. Matching on the human-readable message is brittle, so a classified
+ * failure carries a stable code in two ways: a dedicated exit code, and, when
+ * the LATCHKEY_ERROR_JSON environment variable is set to '1', a JSON object
+ * printed on stderr after the human-readable message.
+ */
+
+export const ERROR_JSON_ENVIRONMENT_VARIABLE = 'LATCHKEY_ERROR_JSON';
+
+/**
+ * Exit code for a stored credential that no known credential schema accepts,
+ * which usually means a newer latchkey wrote the store.
+ */
+export const INVALID_STORED_CREDENTIAL_EXIT_CODE = 3;
+
+export interface ClassifiedFailure {
+  /** Stable identifier for this failure mode; safe to dispatch on. */
+  readonly code: string;
+  readonly message: string;
+  readonly serviceName?: string;
+  readonly exitCode: number;
+}
+
+/**
+ * Report a classified failure and exit. The human-readable message is printed
+ * exactly as an unclassified failure would print it, so nothing changes for
+ * someone reading the output.
+ */
+export function failWithClassifiedError(
+  handlers: {
+    readonly errorLog: (message: string) => void;
+    readonly exit: (code: number) => never;
+  },
+  failure: ClassifiedFailure
+): never {
+  handlers.errorLog(`Error: ${failure.message}`);
+  if (process.env[ERROR_JSON_ENVIRONMENT_VARIABLE] === '1') {
+    handlers.errorLog(
+      JSON.stringify({
+        latchkeyError: {
+          code: failure.code,
+          message: failure.message,
+          ...(failure.serviceName === undefined ? {} : { serviceName: failure.serviceName }),
+        },
+      })
+    );
+  }
+  return handlers.exit(failure.exitCode);
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -16,6 +16,10 @@ import { Config } from '../src/config.js';
 import { ServiceRegistry } from '../src/serviceRegistry.js';
 import { ApiCredentialStatus } from '../src/apiCredentials/base.js';
 import { LATEST_VERSION } from '../src/migrations.js';
+import {
+  ERROR_JSON_ENVIRONMENT_VARIABLE,
+  INVALID_STORED_CREDENTIAL_EXIT_CODE,
+} from '../src/cliErrors.js';
 import { Service } from '../src/services/core/base.js';
 import { createMockService, MockService } from './mockService.js';
 import { RegisteredService } from '../src/services/core/registered.js';
@@ -1435,6 +1439,63 @@ describe('CLI commands with dependency injection', () => {
 
       expect(exitCode).toBe(1);
       expect(existsSync(join(destinationDirectory, STORE_FILENAME))).toBe(false);
+    });
+
+    // A credential type this Latchkey does not know (e.g. written by a newer
+    // one sharing the store) must not fail exports of other services.
+    const UNREADABLE_CREDENTIAL = { objectType: 'from-a-newer-latchkey', token: 'tok' };
+
+    it('exports the requested services when another stored credential is unreadable', async () => {
+      writeStore({
+        slack: { objectType: 'slack', token: 'tok', dCookie: 'cookie' },
+        mystery: UNREADABLE_CREDENTIAL,
+      });
+      const destinationDirectory = join(tempDir, 'export');
+
+      const deps = withStdinKey(NEW_ENCRYPTION_KEY);
+      await runCommand(['auth', 're-encrypt', destinationDirectory, '--services', 'slack'], deps);
+
+      expect(exitCode).toBeNull();
+      const reEncrypted = readWithKey(
+        join(destinationDirectory, STORE_FILENAME),
+        NEW_ENCRYPTION_KEY
+      );
+      expect(Object.keys(reEncrypted)).toEqual(['slack']);
+    });
+
+    it('exits with a dedicated code when a requested credential is unreadable', async () => {
+      writeStore({ mystery: UNREADABLE_CREDENTIAL });
+      const destinationDirectory = join(tempDir, 'export');
+
+      const deps = withStdinKey(NEW_ENCRYPTION_KEY);
+      await runCommand(['auth', 're-encrypt', destinationDirectory, '--services', 'mystery'], deps);
+
+      expect(exitCode).toBe(INVALID_STORED_CREDENTIAL_EXIT_CODE);
+      expect(errorLogs[0]).toContain('Invalid credential data for service mystery');
+    });
+
+    it('describes an unreadable credential as JSON when LATCHKEY_ERROR_JSON is set', async () => {
+      writeStore({ mystery: UNREADABLE_CREDENTIAL });
+      const destinationDirectory = join(tempDir, 'export');
+
+      const deps = withStdinKey(NEW_ENCRYPTION_KEY);
+      vi.stubEnv(ERROR_JSON_ENVIRONMENT_VARIABLE, '1');
+      try {
+        await runCommand(
+          ['auth', 're-encrypt', destinationDirectory, '--services', 'mystery'],
+          deps
+        );
+      } finally {
+        vi.unstubAllEnvs();
+      }
+
+      expect(exitCode).toBe(INVALID_STORED_CREDENTIAL_EXIT_CODE);
+      const reported = JSON.parse(errorLogs[errorLogs.length - 1]!) as {
+        latchkeyError: { code: string; serviceName: string; message: string };
+      };
+      expect(reported.latchkeyError.code).toBe('invalid_stored_credential');
+      expect(reported.latchkeyError.serviceName).toBe('mystery');
+      expect(reported.latchkeyError.message).toContain('Invalid credential data');
     });
 
     it('carries the preparations of the re-encrypted services', async () => {


### PR DESCRIPTION
## Why

In production, an app that bundles Latchkey 3.5.0 shares a credential store with newer standalone CLIs. One of those wrote a `tailscale`-typed credential, whose `objectType` the bundled binary's schema does not know. From then on **every** `latchkey auth re-encrypt` from that store failed -- including exports that only asked for `--services slack` -- because `re-encrypt` called `ApiCredentialStore.getAll()` (which schema-validates all stored credentials) *before* applying the `--services` filter.

The caller could only tell this failure from any other by matching the message text (`Invalid credential data for service <name>:`), since every `re-encrypt` failure path exits 1 through the same `deps.exit(1)` with no structured output.

## What changed

1. **`re-encrypt` parses only what it exports.** Stored service names now come from `ApiCredentialStore.listServiceNames()` (raw keys, no parsing) plus `listPreparedServiceNames()`; the credentials and preparations are parsed via the new `getAllForServices()` once the selection is known, before anything is written. A credential type this binary does not understand no longer breaks exports of other services.

2. **The remaining failure is classified.** `parseCredentials` now throws `InvalidStoredCredentialError` (an `ApiCredentialStoreError` subclass carrying `serviceName`). When a *requested* service is unreadable, `re-encrypt` reports it through the new `src/cliErrors.ts`:
   - exit code **3** (`INVALID_STORED_CREDENTIAL_EXIT_CODE`), alongside the existing `PERMISSION_DENIED_EXIT_CODE` precedent;
   - with `LATCHKEY_ERROR_JSON=1`, a JSON object on stderr after the human message: `{"latchkeyError": {"code": "invalid_stored_credential", "message": "...", "serviceName": "tailscale"}}`.

   Human-readable output is unchanged, and the JSON line only appears when the env var opts in, so nothing existing sees different output.

3. README documents `LATCHKEY_ERROR_JSON` and the dedicated exit code.

## Tests

`tests/cli.test.ts`, in the `auth re-encrypt` block: an unreadable credential no longer fails an export of another service; a requested unreadable credential exits 3; and with `LATCHKEY_ERROR_JSON=1` the JSON object carries the code and service name.

`npm run lint`, `npm run typecheck`, `npm test`: 859 passed, 7 skipped, 1 todo, 0 failed.

## Consumer

imbue-ai/mngr-internal#731 currently classifies this failure with a regex over stderr. Once this ships in a release, that PR drops the regex and dispatches on the exit code plus the JSON payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)