### PR TITLE
Add a generic token-capture browser login flow

### DIFF
--- a/src/services/core/loginFlows/registry.ts
+++ b/src/services/core/loginFlows/registry.ts
@@ -8,9 +8,13 @@
  */
 
 import { CookieCaptureLoginFlow } from './cookieCapture.js';
+import { TokenCaptureLoginFlow } from './tokenCapture.js';
 import type { LoginFlow, LoginFlowClass } from './base.js';
 
-export const LOGIN_FLOWS: readonly LoginFlowClass[] = [CookieCaptureLoginFlow];
+export const LOGIN_FLOWS: readonly LoginFlowClass[] = [
+  CookieCaptureLoginFlow,
+  TokenCaptureLoginFlow,
+];
 
 export class UnknownLoginFlowError extends Error {
   constructor(name: string) {

--- a/src/services/core/loginFlows/registry.ts
+++ b/src/services/core/loginFlows/registry.ts
@@ -62,10 +62,11 @@ export function formatLoginFlowsHelp(): string {
       indent(flowClass.details, '    ')
   );
   return [
-    'Login flows:',
-    '  Each login flow is configured by a JSON object supplied by',
-    '  --login-flow-params.',
-    '',
+    [
+      'Login flows:',
+      '  Each login flow is configured by a JSON object supplied by',
+      '  --login-flow-params.',
+    ].join('\n'),
     ...sections,
-  ].join('\n');
+  ].join('\n\n');
 }

--- a/src/services/core/loginFlows/tokenCapture.ts
+++ b/src/services/core/loginFlows/tokenCapture.ts
@@ -1,0 +1,239 @@
+/**
+ * A generic browser login for services whose credential is a token the web app
+ * mints for itself: open a URL, watch the responses that arrive while the user
+ * signs in, and lift a token out of the JSON body of a named endpoint.
+ *
+ * This is the counterpart to `cookie-capture`, for the other common shape. In a
+ * cookie-authenticated service the cookie *is* the API credential, so capturing
+ * it is enough. In a token-minting one the cookie authenticates the *page*,
+ * which then calls an endpoint of its own to obtain a short-lived token, and it
+ * is that token the API wants — capturing the cookie would store something the
+ * API refuses. Single-page apps built on NextAuth are the common case, where
+ * the mint endpoint is conventionally `/api/auth/session`.
+ *
+ * Nothing here is service-specific: which endpoint to watch, which field holds
+ * the token, and which header carries it all come from whoever registered the
+ * service, as the parameters of the `token-capture` login flow.
+ *
+ * Two consequences of capturing a minted token are worth knowing, and are the
+ * registrant's to accept rather than this flow's to solve:
+ *
+ * - **The token expires, and there is no refresh path.** The refresh material
+ *   is the browser session, which stays in the browser profile and never
+ *   reaches us. A credential going invalid is routine; signing in again mints
+ *   a fresh one.
+ * - **The token is only as scoped as the service says.** A minted token is
+ *   usually broader than an API key a user would issue deliberately.
+ */
+
+import type { Response } from 'playwright';
+import { z } from 'zod';
+import { type ApiCredentials, RawCurlCredentials } from '../../../apiCredentials/base.js';
+import { Service, SimpleServiceSession, type ServiceSession } from '../base.js';
+import { parseLoginFlowParams, type LoginFlow, type LoginFlowClass } from './base.js';
+
+/** The placeholder a header template puts the captured token in. */
+const TOKEN_PLACEHOLDER = '{token}';
+
+/**
+ * The header a captured token goes into when the registration does not say.
+ * Bearer is what the great majority of token-minting web APIs expect.
+ */
+const DEFAULT_HEADER_TEMPLATE = `Authorization: Bearer ${TOKEN_PLACEHOLDER}`;
+
+/**
+ * Identity of an endpoint for matching purposes: origin and path, with the
+ * query string and fragment dropped.
+ *
+ * Matching this way rather than on the URL verbatim is deliberate. A mint
+ * endpoint is commonly called with a cache-busting or callback parameter the
+ * registrant cannot predict — NextAuth appends one to `/api/auth/session` — and
+ * requiring the whole URL to match would silently never fire. The alternative,
+ * letting registrations carry a regular expression, puts an injection and
+ * catastrophic-backtracking surface into stored configuration to buy a
+ * generality nothing has asked for.
+ */
+function endpointIdentity(url: URL): string {
+  return `${url.origin}${url.pathname}`;
+}
+
+/**
+ * Read a dotted path out of parsed JSON — `accessToken`, or `data.token` when
+ * the endpoint nests it.
+ *
+ * Returns null for anything that is not a non-empty string, which is what makes
+ * the token's *presence* the completion signal: a signed-out visitor commonly
+ * gets the same endpoint answering `{}` or `{"accessToken": null}`, and the
+ * request having happened must not be mistaken for a finished login.
+ */
+function readTokenAtPath(body: unknown, path: readonly string[]): string | null {
+  let current: unknown = body;
+  for (const segment of path) {
+    if (typeof current !== 'object' || current === null || Array.isArray(current)) {
+      return null;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return typeof current === 'string' && current !== '' ? current : null;
+}
+
+const TokenCaptureParamsSchema = z
+  .object({
+    /**
+     * The endpoint whose response carries the token. Compared by origin and
+     * path, so a query string does not have to be predicted.
+     */
+    tokenUrl: z.string().url(),
+    /**
+     * Where the token sits in the JSON body. Dotted for a nested field; each
+     * segment is a literal key, so a key containing a dot cannot be addressed —
+     * no such endpoint has come up, and leaving it out keeps the syntax
+     * obvious.
+     */
+    tokenField: z.string().min(1),
+    /**
+     * The header the token is stored as. Must contain `{token}`, and must look
+     * like a header, so that a mistake here is caught at registration rather
+     * than as a puzzling 401 after a successful-looking login.
+     */
+    header: z
+      .string()
+      .min(1)
+      .refine((value) => value.includes(TOKEN_PLACEHOLDER), {
+        message: `must contain the ${TOKEN_PLACEHOLDER} placeholder`,
+      })
+      .refine((value) => /^[^:\s]+:/.test(value), {
+        message: "must be a header, as in 'Authorization: Bearer {token}'",
+      })
+      .optional(),
+  })
+  .strict();
+
+type TokenCaptureParams = z.infer<typeof TokenCaptureParamsSchema>;
+
+/** Store the captured token the way `latchkey auth set -H` would. */
+function buildTokenCredentials(headerTemplate: string, token: string): ApiCredentials {
+  return new RawCurlCredentials(['-H', headerTemplate.replaceAll(TOKEN_PLACEHOLDER, token)]);
+}
+
+/**
+ * One run of the flow: responses go by, and the first one from the mint
+ * endpoint that carries a token ends the login.
+ */
+class TokenCaptureSession extends SimpleServiceSession {
+  private readonly tokenEndpointIdentity: string;
+  private readonly tokenPath: readonly string[];
+  private readonly headerTemplate: string;
+
+  constructor(
+    service: Service,
+    appNamePrefix: string,
+    tokenUrl: URL,
+    tokenPath: readonly string[],
+    headerTemplate: string
+  ) {
+    super(service, appNamePrefix);
+    this.tokenEndpointIdentity = endpointIdentity(tokenUrl);
+    this.tokenPath = tokenPath;
+    this.headerTemplate = headerTemplate;
+  }
+
+  protected async getApiCredentialsFromResponse(
+    response: Response
+  ): Promise<ApiCredentials | null> {
+    let responseUrl: URL;
+    try {
+      responseUrl = new URL(response.url());
+    } catch {
+      // Not a URL we can compare — a data: or blob: response, say.
+      return null;
+    }
+    if (endpointIdentity(responseUrl) !== this.tokenEndpointIdentity) {
+      return null;
+    }
+
+    let token: string | null;
+    try {
+      token = readTokenAtPath(JSON.parse(await response.text()), this.tokenPath);
+    } catch {
+      // Unreadable or not JSON: the endpoint answered with something this
+      // registration does not describe. Keep waiting rather than fail the
+      // login — the response that carries the token may still be coming.
+      return null;
+    }
+
+    return token === null ? null : buildTokenCredentials(this.headerTemplate, token);
+  }
+}
+
+/**
+ * The flow. Its statics are the kind of automation — what `--login-flow`
+ * selects — and an instance is that kind configured with one service's
+ * parameters, ready to create a session per login.
+ */
+export class TokenCaptureLoginFlow implements LoginFlow {
+  /** Value of `--login-flow`. Not `name`, which every class already has. */
+  static readonly flowName = 'token-capture';
+
+  static readonly summary =
+    'Open the login URL and capture a token the web app mints for itself, from the JSON ' +
+    'body of a named endpoint.';
+
+  static readonly details = [
+    'Parameters:',
+    '  tokenUrl    Full URL, including the scheme, of the endpoint whose response',
+    '              carries the token. Required. Matched on origin and path, so a',
+    '              query string the app appends does not have to be predicted.',
+    '  tokenField  Where the token sits in the JSON body. Required. Dotted for a',
+    '              nested field, as in "data.accessToken".',
+    '  header      Header to store the token as. Optional; defaults to',
+    `              "${DEFAULT_HEADER_TEMPLATE}". Must contain ${TOKEN_PLACEHOLDER}.`,
+    '',
+    'For services where the cookie authenticates the page rather than the API,',
+    'and the page calls an endpoint of its own to mint a short-lived token. Use',
+    'cookie-capture instead when the cookie is itself the API credential.',
+    '',
+    'The login finishes when that endpoint answers with a non-empty token, not',
+    'when it is merely requested: a signed-out visitor commonly gets the same',
+    'endpoint answering `{}`. A token minted this way expires and cannot be',
+    'refreshed — the refresh material stays in the browser — so expect to sign',
+    'in again periodically.',
+    '',
+    'Example:',
+    '  $ latchkey services register my-app \\',
+    '      --base-api-url="https://app.example.com/backend-api/" \\',
+    '      --login-url="https://app.example.com/auth/login" \\',
+    '      --login-flow=token-capture \\',
+    '      --login-flow-params=\'{"tokenUrl": "https://app.example.com/api/auth/session",',
+    '                            "tokenField": "accessToken"}\'',
+  ].join('\n');
+
+  static readonly paramsSchema = TokenCaptureParamsSchema;
+
+  private readonly params: TokenCaptureParams;
+
+  constructor(rawParams: unknown) {
+    this.params = parseLoginFlowParams(TokenCaptureLoginFlow, rawParams);
+  }
+
+  describe(loginUrl: string): string {
+    return (
+      `\`latchkey auth browser\` opens ${loginUrl} and stores the '${this.params.tokenField}' ` +
+      `field of ${this.params.tokenUrl} as the credentials once it carries a token.`
+    );
+  }
+
+  createSession(service: Service, appNamePrefix: string): ServiceSession {
+    return new TokenCaptureSession(
+      service,
+      appNamePrefix,
+      new URL(this.params.tokenUrl),
+      this.params.tokenField.split('.'),
+      this.params.header ?? DEFAULT_HEADER_TEMPLATE
+    );
+  }
+}
+
+// TypeScript has no `static implements`, so this is where the class side of the
+// flow is checked. The registry checks it again, but the error lands here.
+TokenCaptureLoginFlow satisfies LoginFlowClass;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -32,6 +32,7 @@ export {
   type LoginFlowClass,
 } from './core/loginFlows/base.js';
 export { CookieCaptureLoginFlow } from './core/loginFlows/cookieCapture.js';
+export { TokenCaptureLoginFlow } from './core/loginFlows/tokenCapture.js';
 
 export { Slack, SLACK } from './slack.js';
 export { Discord, DISCORD } from './discord.js';

--- a/tests/tokenCapture.test.ts
+++ b/tests/tokenCapture.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for the generic token-capturing browser login used by registered
+ * services.
+ *
+ * Everything goes through the public path a real login takes — a flow, the
+ * service it is registered on, and the session that service hands out — with
+ * responses fed in by hand instead of by a browser.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Response } from 'playwright';
+import type { ApiCredentials } from '../src/apiCredentials/base.js';
+import { TokenCaptureLoginFlow } from '../src/services/core/loginFlows/tokenCapture.js';
+import { LOGIN_FLOWS, resolveLoginFlow } from '../src/services/core/loginFlows/registry.js';
+import { LoginFlowParamsInvalidError } from '../src/services/core/loginFlows/base.js';
+import { RegisteredService } from '../src/services/core/registered.js';
+import { SimpleServiceSession } from '../src/services/index.js';
+
+const LOGIN_URL = 'https://app.example.com/auth/login';
+const TOKEN_URL = 'https://app.example.com/api/auth/session';
+
+/** A response carrying the JSON body under test. */
+function responseWith(body: string, url: string): Response {
+  return {
+    url: () => url,
+    text: () => Promise.resolve(body),
+    headersArray: () => Promise.resolve([{ name: 'Content-Type', value: 'application/json' }]),
+  } as unknown as Response;
+}
+
+async function headerFrom(credentials: ApiCredentials | null): Promise<string | null> {
+  if (credentials === null) {
+    return null;
+  }
+  const curlArguments = await credentials.injectIntoCurlCall([]);
+  return curlArguments[1] ?? null;
+}
+
+/**
+ * A login in progress for a service registered with these parameters: responses
+ * go in, and out comes the header stored so far, or null.
+ */
+function startLogin(params: {
+  tokenUrl?: string;
+  tokenField?: string;
+  header?: string;
+}): (body: string, responseUrl?: string) => Promise<string | null> {
+  const service = new RegisteredService('my-service', 'https://app.example.com/backend-api/', {
+    loginUrl: LOGIN_URL,
+    loginFlow: new TokenCaptureLoginFlow({
+      tokenUrl: params.tokenUrl ?? TOKEN_URL,
+      tokenField: params.tokenField ?? 'accessToken',
+      ...(params.header === undefined ? {} : { header: params.header }),
+    }),
+  });
+  const session = service.getSession!('latchkey');
+  if (!(session instanceof SimpleServiceSession)) {
+    throw new TypeError('the token-capture flow should hand out a SimpleServiceSession');
+  }
+  return async (body, responseUrl = TOKEN_URL) => {
+    await session.onResponse(responseWith(body, responseUrl));
+    return headerFrom(session.capturedCredentials);
+  };
+}
+
+describe('token capture', () => {
+  it('captures a token from the named endpoint', async () => {
+    const respond = startLogin({});
+    expect(await respond('{"accessToken": "tok-123", "user": {"email": "a@example.com"}}')).toBe(
+      'Authorization: Bearer tok-123'
+    );
+  });
+
+  // The signal is the token, not the request: the same endpoint answers a
+  // signed-out visitor, and treating that as a finished login would store
+  // nothing and call it success.
+  it('is not complete while the endpoint answers without a token', async () => {
+    const respond = startLogin({});
+    expect(await respond('{}')).toBeNull();
+    expect(await respond('{"accessToken": null}')).toBeNull();
+    expect(await respond('{"accessToken": ""}')).toBeNull();
+    expect(await respond('{"accessToken": "tok-123"}')).toBe('Authorization: Bearer tok-123');
+  });
+
+  it('ignores responses from other endpoints', async () => {
+    const respond = startLogin({});
+    expect(
+      await respond('{"accessToken": "not-this-one"}', 'https://app.example.com/api/profile')
+    ).toBeNull();
+    expect(
+      await respond('{"accessToken": "nor-this"}', 'https://identity-provider.example.net/session')
+    ).toBeNull();
+  });
+
+  // A mint endpoint is commonly called with a parameter the registrant cannot
+  // predict — NextAuth appends one — so matching the URL verbatim would mean
+  // the flow silently never fires.
+  it('matches the endpoint regardless of query string', async () => {
+    const respond = startLogin({});
+    expect(await respond('{"accessToken": "tok"}', `${TOKEN_URL}?_rsc=1a2b3`)).toBe(
+      'Authorization: Bearer tok'
+    );
+  });
+
+  it('reads a nested field', async () => {
+    const respond = startLogin({ tokenField: 'data.session.token' });
+    expect(await respond('{"data": {"session": {"token": "deep"}}}')).toBe(
+      'Authorization: Bearer deep'
+    );
+  });
+
+  it('does not mistake a non-object on the path for a token', async () => {
+    const respond = startLogin({ tokenField: 'data.token' });
+    expect(await respond('{"data": null}')).toBeNull();
+    expect(await respond('{"data": ["token"]}')).toBeNull();
+    expect(await respond('{"data": {"token": 42}}')).toBeNull();
+  });
+
+  // Waiting rather than failing: the response that carries the token may still
+  // be coming, and a login that aborted on the first unparseable body would be
+  // at the mercy of anything else the page fetches from that path.
+  it('keeps waiting through a body that is not JSON', async () => {
+    const respond = startLogin({});
+    expect(await respond('<!doctype html><title>Just a moment...</title>')).toBeNull();
+    expect(await respond('{"accessToken": "tok"}')).toBe('Authorization: Bearer tok');
+  });
+
+  it('stores the token in a custom header when one is registered', async () => {
+    const respond = startLogin({ header: 'X-Auth-Token: {token}' });
+    expect(await respond('{"accessToken": "tok"}')).toBe('X-Auth-Token: tok');
+  });
+});
+
+describe('token capture parameters', () => {
+  it('is registered under its flow name', () => {
+    expect(LOGIN_FLOWS.map((flow) => flow.flowName)).toContain('token-capture');
+    expect(resolveLoginFlow('token-capture', { tokenUrl: TOKEN_URL, tokenField: 'accessToken' })).
+      toBeInstanceOf(TokenCaptureLoginFlow);
+  });
+
+  it('requires a URL and a field', () => {
+    expect(() => new TokenCaptureLoginFlow({})).toThrow(LoginFlowParamsInvalidError);
+    expect(() => new TokenCaptureLoginFlow({ tokenUrl: TOKEN_URL })).toThrow(
+      LoginFlowParamsInvalidError
+    );
+    expect(() => new TokenCaptureLoginFlow({ tokenUrl: 'not-a-url', tokenField: 'a' })).toThrow(
+      LoginFlowParamsInvalidError
+    );
+  });
+
+  // Caught at registration rather than as a puzzling 401 after a
+  // successful-looking login.
+  it('rejects a header that could not carry the token', () => {
+    const base = { tokenUrl: TOKEN_URL, tokenField: 'accessToken' };
+    expect(() => new TokenCaptureLoginFlow({ ...base, header: 'Authorization: Bearer' })).toThrow(
+      LoginFlowParamsInvalidError
+    );
+    expect(() => new TokenCaptureLoginFlow({ ...base, header: 'no colon {token}' })).toThrow(
+      LoginFlowParamsInvalidError
+    );
+  });
+
+  it('rejects unknown parameters', () => {
+    expect(
+      () =>
+        new TokenCaptureLoginFlow({
+          tokenUrl: TOKEN_URL,
+          tokenField: 'accessToken',
+          cookieKeys: ['sessionid'],
+        })
+    ).toThrow(LoginFlowParamsInvalidError);
+  });
+
+  it('describes itself for `services info`', () => {
+    const flow = new TokenCaptureLoginFlow({ tokenUrl: TOKEN_URL, tokenField: 'accessToken' });
+    const description = flow.describe(LOGIN_URL);
+    expect(description).toContain(LOGIN_URL);
+    expect(description).toContain(TOKEN_URL);
+    expect(description).toContain('accessToken');
+  });
+});

--- a/tests/tokenCapture.test.ts
+++ b/tests/tokenCapture.test.ts
@@ -134,8 +134,9 @@ describe('token capture', () => {
 describe('token capture parameters', () => {
   it('is registered under its flow name', () => {
     expect(LOGIN_FLOWS.map((flow) => flow.flowName)).toContain('token-capture');
-    expect(resolveLoginFlow('token-capture', { tokenUrl: TOKEN_URL, tokenField: 'accessToken' })).
-      toBeInstanceOf(TokenCaptureLoginFlow);
+    expect(
+      resolveLoginFlow('token-capture', { tokenUrl: TOKEN_URL, tokenField: 'accessToken' })
+    ).toBeInstanceOf(TokenCaptureLoginFlow);
   });
 
   it('requires a URL and a field', () => {


### PR DESCRIPTION
`cookie-capture` covers services whose cookie *is* the API credential. This adds the other common shape: **the cookie authenticates the page, which calls an endpoint of its own to mint a short-lived token, and it is that token the API wants.** Capturing the cookie there stores something the API refuses.

Single-page apps built on NextAuth are the usual case, where the mint endpoint is conventionally `/api/auth/session`.

## It is a capability, not a connector

Nothing in the flow is service-specific. Which endpoint to watch, which field holds the token, and which header carries it are all registered parameters — exactly as cookie names are for `cookie-capture`. A service latchkey has never heard of can be taught this login **as data**, with no connector in core:

```bash
latchkey services register my-app \
  --base-api-url="https://app.example.com/backend-api/" \
  --login-url="https://app.example.com/auth/login" \
  --login-flow=token-capture \
  --login-flow-params='{"tokenUrl": "https://app.example.com/api/auth/session",
                        "tokenField": "accessToken"}'
```

This is the generalisation of what #132 did in service-specific code, and it's offered as an alternative to that PR: the mechanism, without the two connectors that put it out of scope. Anyone wanting a private API can register it themselves, which is the outcome that discussion was aiming at.

## Three choices worth the review

- **Endpoints match on origin and path, not the whole URL.** A mint endpoint is commonly called with a parameter the registrant cannot predict — NextAuth appends one — so matching verbatim would mean the flow silently never fires. Letting registrations carry a regex instead would put an injection and catastrophic-backtracking surface into stored configuration to buy a generality nothing has asked for.
- **The token's presence is the completion signal, not the request.** A signed-out visitor commonly gets the same endpoint answering `{}`, so finishing on the request having happened would store nothing and call it success.
- **A body that is not JSON is waited through, not failed on.** The response carrying the token may still be coming, and aborting on the first unparseable body would put the login at the mercy of anything else the page fetches from that path.

## Compatibility and validation

The credential is stored as `RawCurlCredentials`, byte-identical to what `auth set -H` writes today, so a service can move onto this flow without invalidating credentials already stored for it.

The header is a parameter defaulting to `Authorization: Bearer {token}`, validated at registration — a template with no placeholder, or one that isn't a header, is rejected there rather than surfacing as a puzzling 401 after a successful-looking login.

## Documented rather than solved

Two properties of minted tokens are the registrant's to accept, and the flow's `--help` says so:

- they **expire with no refresh path**, because the refresh material is the browser session and never reaches us;
- they are usually **broader in scope** than an API key a user would issue deliberately.

## Testing

`npm run lint` clean. `npx vitest run` → 867 passed. The 6 failures in `cli.test.ts` and `devShim.test.ts` reproduce identically on an unmodified `origin/main` in this environment, so they are not from this change.

13 new tests in `tests/tokenCapture.test.ts`, driving the flow through the public login path — a flow, the service it is registered on, and the session it hands out — with responses fed in by hand, mirroring `cookieCapture.test.ts`.

`services register --help` picks the flow up from the registry with no CLI change, so it documents itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)