### PR TITLE
token-capture: ask the mint endpoint, don't only wait to overhear it

### DIFF
--- a/src/services/core/base.ts
+++ b/src/services/core/base.ts
@@ -350,11 +350,32 @@ export abstract class ServiceSession {
   ): Promise<ApiCredentials | null>;
 
   /**
+   * Work the session does itself while the login phase is still going, run
+   * between polls of {@link isLoginComplete}.
+   *
+   * The default does nothing, which is right for a session that only has to
+   * react to what the browser does. A session whose credential the page never
+   * hands over unprompted overrides this and goes and gets it.
+   *
+   * Implementations own their transient failures: anything thrown here aborts
+   * the login, so a step that can fail and be retried on the next poll has to
+   * swallow that itself.
+   *
+   * Public for the same reason {@link onResponse} is: it is one half of the
+   * pair of hooks a login phase drives, and the tests drive it directly rather
+   * than through a browser.
+   */
+  whileWaitingForLogin(_page: Page): Promise<void> {
+    return Promise.resolve();
+  }
+
+  /**
    * Wait until the browser login phase is complete.
    */
   private async waitForLoginComplete(page: Page): Promise<void> {
     while (!this.isLoginComplete()) {
       await page.waitForTimeout(100);
+      await this.whileWaitingForLogin(page);
     }
   }
 

--- a/src/services/core/loginFlows/tokenCapture.ts
+++ b/src/services/core/loginFlows/tokenCapture.ts
@@ -1,7 +1,14 @@
 /**
  * A generic browser login for services whose credential is a token the web app
- * mints for itself: open a URL, watch the responses that arrive while the user
- * signs in, and lift a token out of the JSON body of a named endpoint.
+ * mints for itself: open a URL, and lift a token out of the JSON body of a
+ * named endpoint, either as it goes by or by asking for it.
+ *
+ * Watching alone is not enough, because a web app calls its own mint endpoint
+ * when it needs a token and not otherwise. ChatGPT is the case that showed
+ * this: it signs in, renders the app, and never calls `/api/auth/session` —
+ * the endpoint is there and answers with a token, but a login that only
+ * listens waits for a request that is never made. So once the browser reaches
+ * the endpoint's origin, this flow also asks it directly.
  *
  * This is the counterpart to `cookie-capture`, for the other common shape. In a
  * cookie-authenticated service the cookie *is* the API credential, so capturing
@@ -26,7 +33,7 @@
  *   usually broader than an API key a user would issue deliberately.
  */
 
-import type { Response } from 'playwright';
+import type { Page, Response } from 'playwright';
 import { z } from 'zod';
 import { type ApiCredentials, RawCurlCredentials } from '../../../apiCredentials/base.js';
 import { Service, SimpleServiceSession, type ServiceSession } from '../base.js';
@@ -40,6 +47,13 @@ const TOKEN_PLACEHOLDER = '{token}';
  * Bearer is what the great majority of token-minting web APIs expect.
  */
 const DEFAULT_HEADER_TEMPLATE = `Authorization: Bearer ${TOKEN_PLACEHOLDER}`;
+
+/**
+ * How often the endpoint is asked, once the browser is somewhere it can be
+ * asked from. Slow enough not to hammer a service through a login that takes a
+ * while, quick enough that the login ends promptly once a token exists.
+ */
+const TOKEN_REQUEST_INTERVAL_MS = 2_000;
 
 /**
  * Identity of an endpoint for matching purposes: origin and path, with the
@@ -111,19 +125,33 @@ const TokenCaptureParamsSchema = z
 
 type TokenCaptureParams = z.infer<typeof TokenCaptureParamsSchema>;
 
+/**
+ * Ask the endpoint from inside the page, so the request is the browser's own:
+ * same cookies, same bot-detection clearance the app itself enjoys. Returns
+ * null when the endpoint refuses the request.
+ */
+function requestTokenBody(page: Page, tokenUrl: string): Promise<string | null> {
+  return page.evaluate(async (url) => {
+    const response = await fetch(url, { credentials: 'include' });
+    return response.ok ? await response.text() : null;
+  }, tokenUrl);
+}
+
 /** Store the captured token the way `latchkey auth set -H` would. */
 function buildTokenCredentials(headerTemplate: string, token: string): ApiCredentials {
   return new RawCurlCredentials(['-H', headerTemplate.replaceAll(TOKEN_PLACEHOLDER, token)]);
 }
 
 /**
- * One run of the flow: responses go by, and the first one from the mint
- * endpoint that carries a token ends the login.
+ * One run of the flow. The endpoint is both watched and asked, and whichever
+ * produces a token first ends the login.
  */
 class TokenCaptureSession extends SimpleServiceSession {
+  private readonly tokenUrl: URL;
   private readonly tokenEndpointIdentity: string;
   private readonly tokenPath: readonly string[];
   private readonly headerTemplate: string;
+  private lastRequestedAt = 0;
 
   constructor(
     service: Service,
@@ -133,9 +161,25 @@ class TokenCaptureSession extends SimpleServiceSession {
     headerTemplate: string
   ) {
     super(service, appNamePrefix);
+    this.tokenUrl = tokenUrl;
     this.tokenEndpointIdentity = endpointIdentity(tokenUrl);
     this.tokenPath = tokenPath;
     this.headerTemplate = headerTemplate;
+  }
+
+  /**
+   * Credentials from one body of the endpoint, or null when it carries no
+   * token — including when it is not JSON at all, which is how a bot-detection
+   * interstitial or an error page arrives.
+   */
+  private credentialsFromBody(rawBody: string): ApiCredentials | null {
+    let token: string | null;
+    try {
+      token = readTokenAtPath(JSON.parse(rawBody), this.tokenPath);
+    } catch {
+      return null;
+    }
+    return token === null ? null : buildTokenCredentials(this.headerTemplate, token);
   }
 
   protected async getApiCredentialsFromResponse(
@@ -152,17 +196,63 @@ class TokenCaptureSession extends SimpleServiceSession {
       return null;
     }
 
-    let token: string | null;
+    let rawBody: string;
     try {
-      token = readTokenAtPath(JSON.parse(await response.text()), this.tokenPath);
+      rawBody = await response.text();
     } catch {
-      // Unreadable or not JSON: the endpoint answered with something this
-      // registration does not describe. Keep waiting rather than fail the
-      // login — the response that carries the token may still be coming.
+      // The body is no longer retrievable — a redirect, or a response the page
+      // navigated away from. Keep waiting rather than fail the login; the next
+      // request to the endpoint, ours or the app's, gets another chance.
       return null;
     }
 
-    return token === null ? null : buildTokenCredentials(this.headerTemplate, token);
+    return this.credentialsFromBody(rawBody);
+  }
+
+  /**
+   * Ask the endpoint ourselves, because an app only calls it when it wants a
+   * token and may never want one while we are watching.
+   *
+   * This waits for the browser to arrive on the endpoint's own origin. The
+   * request is made from inside the page so that it carries the session, and a
+   * cross-origin read of the response would be refused — mid-login the browser
+   * is commonly parked on an identity provider, where there is nothing to ask.
+   */
+  override async whileWaitingForLogin(page: Page): Promise<void> {
+    if (Date.now() - this.lastRequestedAt < TOKEN_REQUEST_INTERVAL_MS) {
+      return;
+    }
+
+    let pageUrl: URL;
+    try {
+      pageUrl = new URL(page.url());
+    } catch {
+      return;
+    }
+    if (pageUrl.origin !== this.tokenUrl.origin) {
+      return;
+    }
+    this.lastRequestedAt = Date.now();
+
+    let rawBody: string | null;
+    try {
+      rawBody = await requestTokenBody(page, this.tokenUrl.href);
+    } catch {
+      // The page navigated out from under the request, or the endpoint could
+      // not be reached. The next poll asks again; a browser the user closed is
+      // caught by the wait loop itself.
+      return;
+    }
+    if (rawBody === null) {
+      return;
+    }
+
+    const credentials = this.credentialsFromBody(rawBody);
+    // A response may have produced credentials while this request was in
+    // flight, and the first token captured is the one the login keeps.
+    if (credentials !== null && this.apiCredentials === null) {
+      this.apiCredentials = credentials;
+    }
   }
 }
 
@@ -193,11 +283,13 @@ export class TokenCaptureLoginFlow implements LoginFlow {
     'and the page calls an endpoint of its own to mint a short-lived token. Use',
     'cookie-capture instead when the cookie is itself the API credential.',
     '',
-    'The login finishes when that endpoint answers with a non-empty token, not',
-    'when it is merely requested: a signed-out visitor commonly gets the same',
-    'endpoint answering `{}`. A token minted this way expires and cannot be',
-    'refreshed — the refresh material stays in the browser — so expect to sign',
-    'in again periodically.',
+    'The endpoint is both watched and asked: once the browser reaches its',
+    'origin, it is requested from inside the page every couple of seconds, so a',
+    'web app that never calls it unprompted still works. Either way the login',
+    'finishes when it answers with a non-empty token, not when it is merely',
+    'requested: a signed-out visitor commonly gets the same endpoint answering',
+    '`{}`. A token minted this way expires and cannot be refreshed — the refresh',
+    'material stays in the browser — so expect to sign in again periodically.',
     '',
     'Example:',
     '  $ latchkey services register my-app \\',

--- a/tests/tokenCapture.test.ts
+++ b/tests/tokenCapture.test.ts
@@ -7,8 +7,8 @@
  * responses fed in by hand instead of by a browser.
  */
 
-import { describe, it, expect } from 'vitest';
-import type { Response } from 'playwright';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Page, Response } from 'playwright';
 import type { ApiCredentials } from '../src/apiCredentials/base.js';
 import { TokenCaptureLoginFlow } from '../src/services/core/loginFlows/tokenCapture.js';
 import { LOGIN_FLOWS, resolveLoginFlow } from '../src/services/core/loginFlows/registry.js';
@@ -40,11 +40,11 @@ async function headerFrom(credentials: ApiCredentials | null): Promise<string | 
  * A login in progress for a service registered with these parameters: responses
  * go in, and out comes the header stored so far, or null.
  */
-function startLogin(params: {
+function registerSession(params: {
   tokenUrl?: string;
   tokenField?: string;
   header?: string;
-}): (body: string, responseUrl?: string) => Promise<string | null> {
+}): SimpleServiceSession {
   const service = new RegisteredService('my-service', 'https://app.example.com/backend-api/', {
     loginUrl: LOGIN_URL,
     loginFlow: new TokenCaptureLoginFlow({
@@ -57,6 +57,15 @@ function startLogin(params: {
   if (!(session instanceof SimpleServiceSession)) {
     throw new TypeError('the token-capture flow should hand out a SimpleServiceSession');
   }
+  return session;
+}
+
+function startLogin(params: {
+  tokenUrl?: string;
+  tokenField?: string;
+  header?: string;
+}): (body: string, responseUrl?: string) => Promise<string | null> {
+  const session = registerSession(params);
   return async (body, responseUrl = TOKEN_URL) => {
     await session.onResponse(responseWith(body, responseUrl));
     return headerFrom(session.capturedCredentials);
@@ -128,6 +137,121 @@ describe('token capture', () => {
   it('stores the token in a custom header when one is registered', async () => {
     const respond = startLogin({ header: 'X-Auth-Token: {token}' });
     expect(await respond('{"accessToken": "tok"}')).toBe('X-Auth-Token: tok');
+  });
+});
+
+/**
+ * A browser parked at `pageUrl`, answering each request for the endpoint with
+ * the next canned reply: a body, null for a request the endpoint refused, or an
+ * Error the request rejects with.
+ *
+ * The last reply repeats, so a test that only cares about the first request
+ * need not say what a second would get.
+ */
+function pageAt(
+  pageUrl: string,
+  replies: readonly (string | null | Error)[]
+): { readonly page: Page; requestCount: () => number } {
+  let requestCount = 0;
+  const page = {
+    url: () => pageUrl,
+    evaluate: () => {
+      const reply = replies[Math.min(requestCount, replies.length - 1)] ?? null;
+      requestCount += 1;
+      return reply instanceof Error ? Promise.reject(reply) : Promise.resolve(reply);
+    },
+  } as unknown as Page;
+  return { page, requestCount: () => requestCount };
+}
+
+async function headerAfterWaiting(
+  session: ReturnType<typeof registerSession>,
+  page: Page
+): Promise<string | null> {
+  await session.whileWaitingForLogin(page);
+  return headerFrom(session.capturedCredentials);
+}
+
+/**
+ * Asking, rather than waiting to overhear.
+ *
+ * A web app calls its own mint endpoint when it wants a token and not
+ * otherwise, so a login that only listens can wait forever on a service that is
+ * working perfectly — which is what chatgpt.com does.
+ */
+describe('token capture by request', () => {
+  const START_TIME = new Date('2026-01-01T00:00:00Z').getTime();
+  // Comfortably past the interval between requests, whatever it is set to.
+  const WELL_PAST_THE_INTERVAL_MS = 10_000;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_TIME);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('asks the endpoint when the app never calls it', async () => {
+    const session = registerSession({});
+    const { page } = pageAt('https://app.example.com/', ['{"accessToken": "tok-123"}']);
+    expect(await headerAfterWaiting(session, page)).toBe('Authorization: Bearer tok-123');
+  });
+
+  // Mid-login the browser is commonly on an identity provider, where there is
+  // nothing to ask and a cross-origin read would be refused anyway.
+  it('does not ask while the browser is on another origin', async () => {
+    const session = registerSession({});
+    const { page, requestCount } = pageAt('https://identity-provider.example.net/consent', [
+      '{"accessToken": "tok-123"}',
+    ]);
+    expect(await headerAfterWaiting(session, page)).toBeNull();
+    expect(requestCount()).toBe(0);
+  });
+
+  it('does not ask again before the interval has passed', async () => {
+    const session = registerSession({});
+    const { page, requestCount } = pageAt('https://app.example.com/', ['{}']);
+    await session.whileWaitingForLogin(page);
+    await session.whileWaitingForLogin(page);
+    expect(requestCount()).toBe(1);
+  });
+
+  // A signed-out visitor gets the same endpoint answering `{}`, so asking early
+  // and often has to stay harmless.
+  it('keeps asking until the endpoint has a token', async () => {
+    const session = registerSession({});
+    const { page } = pageAt('https://app.example.com/', ['{}', '{"accessToken": "tok-123"}']);
+    expect(await headerAfterWaiting(session, page)).toBeNull();
+    vi.setSystemTime(START_TIME + WELL_PAST_THE_INTERVAL_MS);
+    expect(await headerAfterWaiting(session, page)).toBe('Authorization: Bearer tok-123');
+  });
+
+  // The page navigates out from under a request all the time during a login.
+  it('keeps waiting when a request fails', async () => {
+    const session = registerSession({});
+    const { page } = pageAt('https://app.example.com/', [
+      new Error('Execution context was destroyed'),
+      '{"accessToken": "tok-123"}',
+    ]);
+    expect(await headerAfterWaiting(session, page)).toBeNull();
+    vi.setSystemTime(START_TIME + WELL_PAST_THE_INTERVAL_MS);
+    expect(await headerAfterWaiting(session, page)).toBe('Authorization: Bearer tok-123');
+  });
+
+  it('captures nothing from a request the endpoint refused', async () => {
+    const session = registerSession({});
+    const { page } = pageAt('https://app.example.com/', [null]);
+    expect(await headerAfterWaiting(session, page)).toBeNull();
+  });
+
+  // Both paths write the same field, and the login keeps the first token.
+  it('leaves a token already captured from a response alone', async () => {
+    const session = registerSession({});
+    await session.onResponse(responseWith('{"accessToken": "from-response"}', TOKEN_URL));
+    const { page } = pageAt('https://app.example.com/', ['{"accessToken": "from-request"}']);
+    expect(await headerAfterWaiting(session, page)).toBe('Authorization: Bearer from-response');
   });
 });
 


### PR DESCRIPTION
#140 shipped `token-capture` with a gap I should have caught, and I'm sorry: the flow only ever *watched* for the mint endpoint. That works for an app that calls its own endpoint while we happen to be looking, and it silently never completes for one that doesn't — which turns out to include the single most obvious service anyone would point this flow at. The PR was written and tested entirely against hand-fed responses, so nothing in it ever exercised the assumption it rested on. This adds the missing half.

## The failure

Registering chatgpt.com exactly as #140's own `--help` example suggests produces a login that hangs forever:

```bash
latchkey services register chatgpt-tc \
  --base-api-url="https://chatgpt.com/" \
  --login-url="https://chatgpt.com/auth/login" \
  --login-flow=token-capture \
  --login-flow-params='{"tokenUrl": "https://chatgpt.com/api/auth/session",
                        "tokenField": "accessToken"}'
```

Sign-in completes, the app loads, nothing happens. Instrumenting the browser showed why: a full bootstrap of the signed-in app makes **48 requests and not one of them is to `/api/auth/session`**. The endpoint is not gone — asking it directly returns a 1984-character `accessToken` — but a web app calls its mint endpoint when *it* wants a token, not when we want one. NextAuth conventions say where the endpoint is, not that the app will ever call it.

It also never fails. Every unmet condition returns null and the wait loop has no timeout, so "endpoint moved", "body unreadable", "field absent" and "never called" all present as one indistinguishable hang. That is a bad property on its own and it is what made this take a while to pin down.

## The fix

The flow now also asks. Once the browser reaches the endpoint's origin, it is requested from inside the page every couple of seconds. Watching stays — it costs nothing and is the whole story for an app that does call its endpoint — and whichever path produces a token first ends the login.

`ServiceSession` gains `whileWaitingForLogin`, the active counterpart to the existing `onResponse`: work a session does itself between polls of `isLoginComplete`. The default does nothing, so no other flow changes.

## Three choices worth the review

- **`page.evaluate(fetch)` rather than Playwright's `context.request`.** The latter shares the cookie jar but not the browser's TLS fingerprint, which is exactly what Cloudflare inspects — and this flow's whole audience is apps sitting behind that kind of wall. Making the page issue the request means it carries the same session *and* the same clearance the app itself has.
- **Waiting for the page to reach the endpoint's origin** is not just tidiness. The response read would be cross-origin otherwise and refused, and mid-login the browser is usually parked on an identity provider where there is nothing to ask.
- **`whileWaitingForLogin` implementations swallow their own transient failures.** Anything thrown there aborts the login, and a page navigating out from under a request is routine during a sign-in, not fatal. The contract is stated on the hook.

Also separated: `response.text()` throwing on a body the page had navigated past was being caught by the same `catch` as a JSON parse failure. Two different situations, now two branches.

## Testing

`npm run lint` and `npx prettier --check` clean.

7 new tests in `tests/tokenCapture.test.ts`, driving the hook through the public path with a page whose replies are canned, mirroring how the existing tests drive responses. **4 of them fail against the passive-only flow** — I neutered the override and watched them go red before believing them, because a test for a silent hang that cannot itself fail is worth nothing.

`npx vitest run` → 876 passed, 8 failed. The same 8 fail on an unmodified `origin/dev` in this environment (subprocess tests in `cli.test.ts`, `devShim.test.ts`, `lint.test.ts` and `typecheck.test.ts` hitting a 20s timeout), so they are not from this change. #140 reported 6 of these; `lint`/`typecheck` have since joined, same cause.

What the unit tests cannot cover is the body of the `page.evaluate` callback, which only runs in a browser. So this was verified live: `auth browser chatgpt-tc` against a local build now completes within about two seconds of the chat UI appearing, and the credential it stores works —

| endpoint | status |
|---|---|
| `/backend-api/me` | 200, real profile payload |
| `/backend-api/conversations?offset=0&limit=3` | 200, 3 items |

(through a JA3-impersonating curl, since plain curl gets a 403 from Cloudflare on chatgpt.com regardless of credentials.)

## Two things noticed, deliberately not fixed here

- `RegisteredService.getAccount()` returns null unconditionally, so every login for a registered service lands in the unnamed default account and overwrites the last one. Registering a service twice is currently the only way to hold two accounts for it.
- The login wait loop has no timeout, which is what turns any of this flow's failure modes into an indefinite hang with nothing on stderr.

Happy to take either as a follow-up if you'd like them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
